### PR TITLE
Implemented txid and wtxid #5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "b51f1d6845b353a2121de1c6a670738ec33561a6",
+        "version" : "3.1.0"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",

--- a/Package.swift
+++ b/Package.swift
@@ -3,17 +3,22 @@ import PackageDescription
 
 let package = Package(
     name: "swift-bitcoin",
+    platforms: [.macOS(.v14), .iOS(.v17)],
     products: [
         .library(
             name: "Bitcoin",
             targets: ["Bitcoin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "Bitcoin",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux]))
+            ],
             path: "src/bitcoin"),
         .testTarget(
             name: "BitcoinTests",

--- a/src/bitcoin/util/hash256.swift
+++ b/src/bitcoin/util/hash256.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+#if canImport(Crypto)
+import Crypto
+#endif
+
+func hash256(_ data: Data) -> Data {
+    let digest = SHA256.hash(data: sha256(data))
+    return Data(digest)
+}

--- a/src/bitcoin/util/sha256.swift
+++ b/src/bitcoin/util/sha256.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+#if canImport(Crypto)
+import Crypto
+#endif
+
+func sha256(_ data: Data) -> Data {
+    Data(SHA256.hash(data: data))
+}

--- a/test/bitcoin/TransactionTests.swift
+++ b/test/bitcoin/TransactionTests.swift
@@ -10,15 +10,17 @@ final class TransactionTests: XCTestCase {
         }
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
-        decoder.allowsJSON5 = true
+
+        // Linux Foundation does not support JSON5
+        // decoder.allowsJSON5 = true
+
         let TxInfoItems = try decoder.decode([TxInfo].self, from: data)
         for txInfo in TxInfoItems {
             guard
                 let expectedTransactionData = Data(hex: txInfo.hex),
                 let tx = Transaction(expectedTransactionData)
             else {
-                XCTFail()
-                return
+                XCTFail(); return
             }
 
             XCTAssertEqual(tx.data, expectedTransactionData)
@@ -28,6 +30,15 @@ final class TransactionTests: XCTestCase {
 
             let expectedLocktime = txInfo.locktime
             XCTAssertEqual(tx.locktime.rawValue, expectedLocktime)
+
+            guard let expectedID = Data(hex: txInfo.txid), let expectedWitnessID = Data(hex: txInfo.hash) else {
+                XCTFail(); return
+            }
+            XCTAssertEqual(tx.id, expectedID)
+            XCTAssertEqual(tx.witnessID, expectedWitnessID)
+
+            let expectedSize = txInfo.size
+            XCTAssertEqual(tx.size, expectedSize)
 
             let expectedInputCount = txInfo.vin.count
             let expectedOutputCount = txInfo.vout.count

--- a/test/bitcoin/data/transactions/mainnet-transactions.json
+++ b/test/bitcoin/data/transactions/mainnet-transactions.json
@@ -1,6 +1,6 @@
 [
-// Block 2 coinbase
 {
+  "_comment": "Block 2 coinbase",
   "txid": "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
   "hash": "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
   "version": 1,
@@ -32,9 +32,8 @@
   "time": 1231469665,
   "blocktime": 1231469665
 },
-
-// Hal Finney transaction (first bitcoin transaction)
 {
+  "_comment": "Block 2 coinbase",
   "txid": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
   "hash": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
   "version": 1,
@@ -93,9 +92,8 @@
   "time": 1231731025,
   "blocktime": 1231731025
 },
-
-// First segwit transaction
 {
+  "_comment": "First segwit transaction",
   "txid": "dfcec48bb8491856c353306ab5febeb7e99e4d783eedf3de98f3ee0812b92bad",
   "hash": "48a387570eeffb07e8e84642efe36bc4088285fc04db91743a9850bfd1611af2",
   "version": 1,
@@ -150,9 +148,8 @@
   "time": 1503539857,
   "blocktime": 1503539857
 },
-
-// First taproot transaction
 {
+  "_comment": "First taproot transaction",
   "txid": "b10c007c60e14f9d087e0291d4d0c7869697c6681d979c6639dbd960792b4d41",
   "hash": "b10c007c60e14f9d087e0291d4d0c7869697c6681d979c6639dbd960792b4d41",
   "version": 1,
@@ -276,9 +273,8 @@
   "time": 1627028660,
   "blocktime": 1627028660
 },
-
-// Random recent transaction (October 2023)
 {
+  "_comment": "Random recent transaction (October 2023)",
   "txid": "a9bb4ec1e626d568be25717eba7ae8d1d9a0530616e9e0087e88685d2fd562f0",
   "hash": "8bd59d3ba5a9ab5f1a278995af8b6707c7cce7f41748355bdc3730cda5c018d1",
   "version": 1,


### PR DESCRIPTION
Wrote sha-256 and hash-256 wrappers.
Support for linux with Apple's SwiftCrypto dependency. Fix linux unit test by disabling JSON5 test data.
Made tx size public and included it in unit tests. Added method to extract an outpoint from a transaction.