### PR TITLE
Implementation of parsed scripts #11

### DIFF
--- a/src/bitcoin/script/ParsedScript.swift
+++ b/src/bitcoin/script/ParsedScript.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A valid script that does not need decoding as it's backed by a list of operations instead of raw data. For a representation of a ``Script`` that is backed by a byte array see ``SerializedScript``.
+public struct ParsedScript: Script {
+
+    public static let empty = Self([])
+    private(set) public var operations: [ScriptOperation]
+    public let version: ScriptVersion
+
+    public init(_ operations: [ScriptOperation], version: ScriptVersion = .legacy) {
+        self.operations = operations
+        self.version = version
+    }
+
+    init?(_ data: Data, version: ScriptVersion = .legacy) {
+        var data = data
+        self.operations = []
+        while data.count > 0 {
+            guard let operation = ScriptOperation(data, version: version) else {
+                return nil
+            }
+            operations.append(operation)
+            data = data.dropFirst(operation.size)
+        }
+        self.version = version
+    }
+
+    public var data: Data {
+        operations.reduce(Data()) { $0 + $1.data }
+    }
+
+    public var asm: String {
+        operations.reduce("") {
+            ($0.isEmpty ? "" : "\($0) ") + $1.asm
+        }
+    }
+
+    public var size: Int {
+        operations.reduce(0) { $0 + $1.size }
+    }
+
+    public var prefixedSize: Int {
+        UInt64(size).varIntSize + size
+    }
+
+    public var isEmpty: Bool {
+        operations.isEmpty
+    }
+
+    public var parsed: ParsedScript? { self }
+
+    public var serialized: SerializedScript {
+        SerializedScript(data, version: version)
+    }
+
+    public func run(_ stack: inout [Data], transaction: Transaction, inputIndex: Int, previousOutputs: [Output]) throws {
+        var context = ScriptContext(transaction: transaction, inputIndex: inputIndex, previousOutputs: previousOutputs, script: self)
+        
+        for operation in operations {
+            context.decodedOperations.append(operation)
+            context.programCounter += operation.size
+            try operation.execute(stack: &stack, context: &context)
+        }
+        if let last = stack.last, !ScriptBoolean(last).value {
+            throw ScriptError.invalidScript
+        }
+    }
+}

--- a/src/bitcoin/script/Script.swift
+++ b/src/bitcoin/script/Script.swift
@@ -2,18 +2,19 @@ import Foundation
 
 // A generic bitcoin script which can be in its serialized form or parsed.
 public protocol Script: Equatable {
-
     var version: ScriptVersion { get }
     var data: Data { get }
     var size: Int { get }
     var prefixedData: Data { get }
     var prefixedSize: Int { get }
-
     var asm: String { get }
+    var parsed: ParsedScript? { get }
+    var serialized: SerializedScript { get }
+    var isEmpty: Bool { get }
+
+    func run(_ stack: inout [Data], transaction: Transaction, inputIndex: Int, previousOutputs: [Output]) throws
 
     static var empty: Self { get }
-    var isEmpty: Bool { get }
-    func run(_ stack: inout [Data], transaction: Transaction, inputIndex: Int, previousOutputs: [Output]) throws
 }
 
 extension Script {

--- a/src/bitcoin/script/ScriptOperation.swift
+++ b/src/bitcoin/script/ScriptOperation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A script operation.
-enum ScriptOperation: Equatable {
+public enum ScriptOperation: Equatable {
     case zero, constant(UInt8)
 
     private func operationPreconditions() {

--- a/src/bitcoin/script/SerializedScript.swift
+++ b/src/bitcoin/script/SerializedScript.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A bitcoin script that hasn't been decoded yet. It may contain invalid operation codes and data.
+/// A bitcoin script that hasn't been decoded yet. It may contain invalid operation codes and data as it's backed by a byte array.  For a representation of a ``Script`` that is backed by a list of valid operations  see ``ParsedScript``.
 public struct SerializedScript: Script {
 
     public static let empty = Self(.init())
@@ -19,17 +19,25 @@ public struct SerializedScript: Script {
         self.init(data, version: version)
     }
 
-    public var size: Int {
-       data.count
+    /// Attempts to parse the script and return its assembly representation. Otherwise returns an empty string.
+    public var asm: String {
+        // TODO: When error attempt to return partial decoding. Check how core does this.
+        parsed?.asm ?? ""
     }
 
-    public var asm: String {
-        "" // TODO: convert to decoded script and call its asm method
+    public var size: Int {
+       data.count
     }
 
     public var isEmpty: Bool {
         data.isEmpty
     }
+
+    public var parsed: ParsedScript? {
+        ParsedScript(data, version: version)
+    }
+
+    public var serialized: SerializedScript { self }
 
     public func run(_ stack: inout [Data], transaction: Transaction, inputIndex: Int, previousOutputs: [Output]) throws {
         var context = ScriptContext(transaction: transaction, inputIndex: inputIndex, previousOutputs: previousOutputs, script: self)

--- a/src/bitcoin/transaction/Input.swift
+++ b/src/bitcoin/transaction/Input.swift
@@ -18,6 +18,10 @@ public struct Input: Equatable {
         self.witness = witness
     }
 
+    public init(outpoint: Outpoint, sequence: Sequence, script: ParsedScript, witness: Witness? = .none) {
+        self.init(outpoint: outpoint, sequence: sequence, script: script.serialized, witness: witness)
+    }
+
     init?(_ data: Data) {
         var offset = data.startIndex
         guard let outpoint = Outpoint(data) else {

--- a/src/bitcoin/transaction/Output.swift
+++ b/src/bitcoin/transaction/Output.swift
@@ -8,6 +8,10 @@ public struct Output: Equatable {
         self.script = script
     }
 
+    public init(value: Amount, script: ParsedScript) {
+        self.init(value: value, script: script.serialized)
+    }
+
     init?(_ data: Data) {
         guard data.count > MemoryLayout<Amount>.size else {
             return nil

--- a/test/bitcoin/APITests.swift
+++ b/test/bitcoin/APITests.swift
@@ -40,9 +40,7 @@ fileprivate let coinbaseTx2 = Transaction(
     outputs: [
         .init(
             value: 5_000_000_000, // 50 BTC
-            script: .init(Data([
-                0x51 // OP_1
-            ]))
+            script: .init([.constant(1)])
         )
     ])
 final class APITests: XCTestCase {
@@ -67,9 +65,7 @@ final class APITests: XCTestCase {
                 .init(
                     outpoint: outpoint,
                     sequence: .init(0),
-                    script: .init(Data([
-                        0x51 // OP_1
-                    ]))
+                    script: .init([.constant(1)])
                 )
             ],
             outputs: [


### PR DESCRIPTION
Extended script protocol with conversions between parsed and serialized. Convenience initializers for input/output from parsed scripts. Updated tests to use parsed scripts for clarity.
Documentation around parsed vs serialized.