### PR TITLE
`OP_CHECKMULTISIG` implemented, tested and documented  #27

### DIFF
--- a/src/bitcoin/script/ScriptOperation.swift
+++ b/src/bitcoin/script/ScriptOperation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A script operation.
 public enum ScriptOperation: Equatable {
-    case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, reserved(UInt8), constant(UInt8), noOp, ver, `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, noOp1, noOp2, noOp3, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
+    case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, reserved(UInt8), constant(UInt8), noOp, ver, `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, checkMultiSig, checkMultiSigVerify, noOp1, noOp2, noOp3, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
 
     private func operationPreconditions() {
         switch(self) {
@@ -130,6 +130,8 @@ public enum ScriptOperation: Equatable {
         case .codeSeparator: 0xab
         case .checkSig: 0xac
         case .checkSigVerify: 0xad
+        case .checkMultiSig: 0xae
+        case .checkMultiSigVerify: 0xaf
         case .noOp1: 0xb0
         case .noOp2: 0xb1
         case .noOp3: 0xb2
@@ -233,6 +235,8 @@ public enum ScriptOperation: Equatable {
         case .codeSeparator: "OP_CODESEPARATOR"
         case .checkSig: "OP_CHECKSIG"
         case .checkSigVerify: "OP_CHECKSIGVERIFY"
+        case .checkMultiSig: "OP_CHECKMULTISIG"
+        case .checkMultiSigVerify: "OP_CHECKMULTISIGVERIFY"
         case .noOp1: "OP_NOP1"
         case .noOp2: "OP_NOP2"
         case .noOp3: "OP_NOP3"
@@ -342,6 +346,8 @@ public enum ScriptOperation: Equatable {
         case .codeSeparator: break
         case .checkSig: try opCheckSig(&stack, context: context)
         case .checkSigVerify: try opCheckSigVerify(&stack, context: context)
+        case .checkMultiSig: try opCheckMultiSig(&stack, context: context)
+        case .checkMultiSigVerify: try opCheckMultiSigVerify(&stack, context: context)
         case .noOp1, .noOp2, .noOp3, .noOp4, .noOp5, .noOp6, .noOp7, .noOp8, .noOp9, .noOp10: break
         case .unknown(_): throw ScriptError.invalidScript
         case .pubKeyHash: throw ScriptError.disabledOperation
@@ -524,6 +530,8 @@ public enum ScriptOperation: Equatable {
         case Self.codeSeparator.opCode: self = .codeSeparator
         case Self.checkSig.opCode: self = .checkSig
         case Self.checkSigVerify.opCode: self = .checkSigVerify
+        case Self.checkMultiSig.opCode: self = .checkMultiSig
+        case Self.checkMultiSigVerify.opCode: self = .checkMultiSigVerify
         case Self.noOp1.opCode: self = .noOp1
         case Self.noOp2.opCode: self = .noOp2
         case Self.noOp3.opCode: self = .noOp3

--- a/src/bitcoin/scriptOperations/opCheckMultiSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckMultiSig.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Compares the first signature against each public key until it finds an ECDSA match. Starting with the subsequent public key, it compares the second signature against each remaining public key until it finds an ECDSA match. The process is repeated until all signatures have been checked or not enough public keys remain to produce a successful result. All signatures need to match a public key. Because public keys are not checked again if they fail any signature comparison, signatures must be placed in the `scriptSig` using the same order as their corresponding public keys were placed in the `scriptPubKey` or `redeemScript`. If all signatures are valid, `1` is returned, `0` otherwise. Due to a bug, one extra unused value is removed from the stack.
+func opCheckMultiSig(_ stack: inout [Data], context: ScriptContext) throws {
+    let (n, publicKeys, m, sigs) = try getCheckMultiSigParams(&stack)
+    precondition(m <= n)
+    precondition(publicKeys.count == n)
+    precondition(sigs.count == m)
+    var leftPubKeys = publicKeys
+    var leftSigs = sigs
+    while leftPubKeys.count > 0 && leftSigs.count > 0 {
+        let publicKey = leftPubKeys.removeFirst()
+        var result = false
+        var i = 0
+        while i < leftSigs.count {
+            switch context.script.version {
+                case .legacy:
+                guard let scriptCode = context.getScriptCode(signature: leftSigs[i]) else {
+                    throw ScriptError.invalidScript
+                }
+                result = context.transaction.checkSignature(extendedSignature: leftSigs[i], publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode)
+                default: preconditionFailure()
+            }
+            if result {
+                break
+            }
+            i += 1
+        }
+        if result {
+            leftSigs.remove(at: i)
+        }
+    }
+    stack.append(ScriptBoolean(leftSigs.count == 0).data)
+}

--- a/src/bitcoin/scriptOperations/opCheckMultiSigVerify.swift
+++ b/src/bitcoin/scriptOperations/opCheckMultiSigVerify.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Same as `OP_CHECKMULTISIG`' but `OP_VERIFY` is executed afterward.
+func opCheckMultiSigVerify(_ stack: inout [Data], context: ScriptContext) throws {
+    try opCheckMultiSig(&stack, context: context)
+    try opVerify(&stack)
+}

--- a/src/bitcoin/scriptOperations/opCheckSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckSig.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// The entire transaction's outputs, inputs, and script (from the most recently-executed `OP_CODESEPARATOR` to the end) are hashed. The signature used by `OP_CHECKSIG` must be a valid signature for this hash and public key. If it is, `1` is returned, `0` otherwise.
 func opCheckSig(_ stack: inout [Data], context: ScriptContext) throws {
     let (sig, publicKey) = try getBinaryParams(&stack)
 

--- a/src/bitcoin/scriptOperations/opCheckSigVerify.swift
+++ b/src/bitcoin/scriptOperations/opCheckSigVerify.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Same as `OP_CHECKSIG`, but `OP_VERIFY` is executed afterward.
 func opCheckSigVerify(_ stack: inout [Data], context: ScriptContext) throws {
     try opCheckSig(&stack, context: context)
     try opVerify(&stack)

--- a/src/ecc-helper/ecdsa.c
+++ b/src/ecc-helper/ecdsa.c
@@ -23,6 +23,158 @@ void WriteLE32(u_char* ptr, uint32_t x)
     memcpy(ptr, (char*)&v, 4);
 }
 
+/** This function is taken from the libsecp256k1 distribution and implements
+ *  DER parsing for ECDSA signatures, while supporting an arbitrary subset of
+ *  format violations.
+ *
+ *  Supported violations include negative integers, excessive padding, garbage
+ *  at the end, and overly long length descriptors. This is safe to use in
+ *  Bitcoin because since the activation of BIP66, signatures are verified to be
+ *  strict DER before being passed to this module, and we know it supports all
+ *  violations present in the blockchain before that point.
+ */
+int ecdsa_signature_parse_der_lax(secp256k1_ecdsa_signature* sig, const unsigned char *input, size_t inputlen) {
+    size_t rpos, rlen, spos, slen;
+    size_t pos = 0;
+    size_t lenbyte;
+    unsigned char tmpsig[64] = {0};
+    int overflow = 0;
+
+    /* Hack to initialize sig with a correctly-parsed but invalid signature. */
+    secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+
+    /* Sequence tag byte */
+    if (pos == inputlen || input[pos] != 0x30) {
+        return 0;
+    }
+    pos++;
+
+    /* Sequence length bytes */
+    if (pos == inputlen) {
+        return 0;
+    }
+    lenbyte = input[pos++];
+    if (lenbyte & 0x80) {
+        lenbyte -= 0x80;
+        if (lenbyte > inputlen - pos) {
+            return 0;
+        }
+        pos += lenbyte;
+    }
+
+    /* Integer tag byte for R */
+    if (pos == inputlen || input[pos] != 0x02) {
+        return 0;
+    }
+    pos++;
+
+    /* Integer length for R */
+    if (pos == inputlen) {
+        return 0;
+    }
+    lenbyte = input[pos++];
+    if (lenbyte & 0x80) {
+        lenbyte -= 0x80;
+        if (lenbyte > inputlen - pos) {
+            return 0;
+        }
+        while (lenbyte > 0 && input[pos] == 0) {
+            pos++;
+            lenbyte--;
+        }
+        static_assert(sizeof(size_t) >= 4, "size_t too small");
+        if (lenbyte >= 4) {
+            return 0;
+        }
+        rlen = 0;
+        while (lenbyte > 0) {
+            rlen = (rlen << 8) + input[pos];
+            pos++;
+            lenbyte--;
+        }
+    } else {
+        rlen = lenbyte;
+    }
+    if (rlen > inputlen - pos) {
+        return 0;
+    }
+    rpos = pos;
+    pos += rlen;
+
+    /* Integer tag byte for S */
+    if (pos == inputlen || input[pos] != 0x02) {
+        return 0;
+    }
+    pos++;
+
+    /* Integer length for S */
+    if (pos == inputlen) {
+        return 0;
+    }
+    lenbyte = input[pos++];
+    if (lenbyte & 0x80) {
+        lenbyte -= 0x80;
+        if (lenbyte > inputlen - pos) {
+            return 0;
+        }
+        while (lenbyte > 0 && input[pos] == 0) {
+            pos++;
+            lenbyte--;
+        }
+        static_assert(sizeof(size_t) >= 4, "size_t too small");
+        if (lenbyte >= 4) {
+            return 0;
+        }
+        slen = 0;
+        while (lenbyte > 0) {
+            slen = (slen << 8) + input[pos];
+            pos++;
+            lenbyte--;
+        }
+    } else {
+        slen = lenbyte;
+    }
+    if (slen > inputlen - pos) {
+        return 0;
+    }
+    spos = pos;
+
+    /* Ignore leading zeroes in R */
+    while (rlen > 0 && input[rpos] == 0) {
+        rlen--;
+        rpos++;
+    }
+    /* Copy R value */
+    if (rlen > 32) {
+        overflow = 1;
+    } else {
+        memcpy(tmpsig + 32 - rlen, input + rpos, rlen);
+    }
+
+    /* Ignore leading zeroes in S */
+    while (slen > 0 && input[spos] == 0) {
+        slen--;
+        spos++;
+    }
+    /* Copy S value */
+    if (slen > 32) {
+        overflow = 1;
+    } else {
+        memcpy(tmpsig + 64 - slen, input + spos, slen);
+    }
+
+    if (!overflow) {
+        overflow = !secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+    }
+    if (overflow) {
+        /* Overwrite the result again with a correctly-parsed but invalid
+           signature if parsing failed. */
+        memset(tmpsig, 0, 64);
+        secp256k1_ecdsa_signature_parse_compact(secp256k1_context_static, sig, tmpsig);
+    }
+    return 1;
+}
+
 // Check that the sig has a low R value and will be less than 71 bytes
 char SigHasLowR(const secp256k1_ecdsa_signature* sig)
 {
@@ -69,18 +221,21 @@ const int signECDSA(u_char* sigOut, size_t* sigLenOut, const u_char* msg32, cons
 
 const int verifyECDSA(const u_char *sigBytes, const size_t sigLen, const u_char* msg32, const u_char* pubKey, const size_t pubKeyLen) {
     secp256k1_context *secp256k1_context_verify = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    
+
     secp256k1_ecdsa_signature sig;
-    int ret = secp256k1_ecdsa_signature_parse_der(secp256k1_context_static, &sig, sigBytes, sigLen);
-    assert(ret);
+    if (!ecdsa_signature_parse_der_lax(&sig, sigBytes, sigLen)) {
+        return 0;
+    }
+
     secp256k1_ecdsa_signature sigNorm;
     int wasNormalized = secp256k1_ecdsa_signature_normalize(secp256k1_context_static, &sigNorm, &sig);
-    //assert(ret);
+
     secp256k1_pubkey pk;
-    ret = secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pk, pubKey, pubKeyLen);
-    assert(ret);
-    ret = secp256k1_ecdsa_verify(secp256k1_context_verify, &sigNorm, msg32, &pk);
-    return ret;
+    if (!secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pk, pubKey, pubKeyLen)) {
+        return 0;
+    }
+    int isValid = secp256k1_ecdsa_verify(secp256k1_context_verify, &sigNorm, msg32, &pk);
+    return isValid;
 }
 
 const int verifyECDSASecretKey(const u_char *sigBytes, const size_t sigLen, const u_char* msg32, const u_char* secretKey32) {

--- a/test/bitcoin/ValidTransactionTests.swift
+++ b/test/bitcoin/ValidTransactionTests.swift
@@ -17,6 +17,29 @@ fileprivate struct TestVector {
 
 fileprivate let testVectors: [TestVector] = [
 
+    // The following is 23b397edccd3740a74adb603c9756370fafcde9bcc4483eb271ecad09a94dd63
+    // It is of particular interest because it contains an invalidly-encoded signature which OpenSSL accepts
+    // See http://r6.ca/blog/20111119T211504Z.html
+    // It is also the first OP_CHECKMULTISIG transaction in standard form
+    .init(
+        previousOutputs: [
+            .init(
+                transactionIdentifier: "60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1",
+                outputIndex: 0,
+                amount: 0,
+                scriptOperations: [
+                    .constant(1),
+                    .pushBytes(.init(hex: "04cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaff7d8a473e7e2e6d317b87bafe8bde97e3cf8f065dec022b51d11fcdd0d348ac4")!),
+                    .pushBytes(.init(hex: "0461cbdcc5409fb4b4d42b51d33381354d80e550078cb532a34bfa2fcfdeb7d76519aecc62770f5b0e4ef8551946d8a540911abe3e7854a26f39f58b25c15342af")!),
+                    .constant(2),
+                    .checkMultiSig
+                ]
+            )
+        ],
+        serializedTransaction: "0100000001b14bdcbc3e01bdaad36cc08e81e69c82e1060bc14e518db2b49aa43ad90ba26000000000490047304402203f16c6f40162ab686621ef3000b04e75418a0c0cb2d8aebeac894ae360ac1e780220ddc15ecdfc3507ac48e1681a33eb60996631bf6bf5bc0a0682c4db743ce7ca2b01ffffffff0140420f00000000001976a914660d4ef3a743e3e696ad990364e555c271ad504b88ac00000000",
+        excludedVerifyFlags: "DERSIG,LOW_S,STRICTENC"
+    ),
+
     // A nearly-standard transaction with CHECKSIGVERIFY 1 instead of CHECKSIG
     .init(
         previousOutputs: [
@@ -142,6 +165,24 @@ fileprivate let testVectors: [TestVector] = [
         excludedVerifyFlags: "LOW_S"
     ),
 
+    .init(
+        previousOutputs: [
+            .init(
+                transactionIdentifier: "444e00ed7840d41f20ecd9c11d3f91982326c731a02f3c05748414a4fa9e59be",
+                outputIndex: 0,
+                amount: 0,
+                scriptOperations: [
+                    .constant(1),
+                    .zero,
+                    .pushBytes(.init(hex: "02136b04758b0b6e363e7a6fbe83aaf527a153db2b060d36cc29f7f8309ba6e458")!),
+                    .constant(2),
+                    .checkMultiSig
+                ]
+            )
+        ],
+        serializedTransaction: "0100000001be599efaa4148474053c2fa031c7262398913f1dc1d9ec201fd44078ed004e44000000004900473044022022b29706cb2ed9ef0cb3c97b72677ca2dfd7b4160f7b4beb3ba806aa856c401502202d1e52582412eba2ed474f1f437a427640306fd3838725fab173ade7fe4eae4a01ffffffff010100000000000000232103ac4bba7e7ca3e873eea49e08132ad30c7f03640b6539e9b59903cf14fd016bbbac00000000",
+        excludedVerifyFlags: "NONE"
+    ),
 
     // Test that SignatureHash() removes OP_CODESEPARATOR with FindAndDelete()
     .init(


### PR DESCRIPTION
Relaxed signature parsing rules to match bitcoin core. Ported `ecdsa_signature_parse_der_lax()` over.