### PR TITLE
Now validating non-standard signature hash types #48

### DIFF
--- a/src/bitcoin/script/SighashType.swift
+++ b/src/bitcoin/script/SighashType.swift
@@ -1,33 +1,44 @@
 import Foundation
 
-public enum SighashType: UInt8 {
-    case all = 0x01, none = 0x02, single = 0x03, allAnyCanPay = 0x81, noneAnyCanPay = 0x82, singleAnyCanPay = 0x83
+public struct SighashType {
 
-    init?(_ uInt32: UInt32) {
-        self.init(rawValue: UInt8(uInt32))
+    init?(_ data: Data) {
+        guard let value8 = data.first else {
+            return nil
+        }
+        value = Int(value8)
     }
 
-    var isNone: Bool {
-        self == .none || self == .noneAnyCanPay
-    }
+    let value: Int
 
-    var isAll: Bool {
-        self == .all || self == .allAnyCanPay
-    }
-
-    var isSingle: Bool {
-        self == .single || self == .singleAnyCanPay
-    }
-
-    var isAnyCanPay: Bool {
-        self == .allAnyCanPay || self == .noneAnyCanPay || self == .singleAnyCanPay
-    }
+    var value8: UInt8 { .init(value) }
 
     var data: Data {
-        withUnsafeBytes(of: rawValue) { Data($0) }
+        withUnsafeBytes(of: value8) { Data($0) }
     }
 
     var data32: Data {
-        withUnsafeBytes(of: UInt32(rawValue)) { Data($0) }
+        withUnsafeBytes(of: UInt32(value)) { Data($0) }
     }
+
+    var isAll: Bool {
+        value8 & 0x1f == Self.sighashAll
+    }
+
+    var isNone: Bool {
+        value8 & 0x1f == Self.sighashNone
+    }
+
+    var isSingle: Bool {
+        value8 & 0x1f == Self.sighashSingle
+    }
+
+    var isAnyCanPay: Bool {
+        value8 & 0x80 == Self.sighashAnyCanPay
+    }
+
+    static let sighashAll = UInt8(0x01)
+    static let sighashNone = UInt8(0x02)
+    static let sighashSingle = UInt8(0x03)
+    static let sighashAnyCanPay = UInt8(0x80)
 }

--- a/src/bitcoin/script/opUtils.swift
+++ b/src/bitcoin/script/opUtils.swift
@@ -62,7 +62,7 @@ func getCheckMultiSigParams(_ stack: inout [Data], configuration: ScriptConfigur
     return (n, publicKeys, m, sigs)
 }
 
-func checkSignatureEncoding(_ extendedSignature: Data, scriptConfiguration: ScriptConfigurarion) throws {
+func checkSignature(_ extendedSignature: Data, scriptConfiguration: ScriptConfigurarion) throws {
     // Empty signature. Not strictly DER encoded, but allowed to provide a
     // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
     if extendedSignature.isEmpty { return }

--- a/src/bitcoin/scriptOperations/opCheckMultiSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckMultiSig.swift
@@ -18,7 +18,8 @@ func opCheckMultiSig(_ stack: inout [Data], context: ScriptContext) throws {
                 guard let scriptCode = context.getScriptCode(signature: leftSigs[i]) else {
                     throw ScriptError.invalidScript
                 }
-                result = try context.transaction.verifySignature(extendedSignature: leftSigs[i], publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode, scriptConfiguration: context.configuration)
+                try checkSignature(leftSigs[i], scriptConfiguration: context.configuration)
+                result = context.transaction.verifySignature(extendedSignature: leftSigs[i], publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode)
                 default: preconditionFailure()
             }
             if result {

--- a/src/bitcoin/scriptOperations/opCheckSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckSig.swift
@@ -11,7 +11,8 @@ func opCheckSig(_ stack: inout [Data], context: ScriptContext) throws {
         guard let scriptCode = context.getScriptCode(signature: sig) else {
             throw ScriptError.invalidScript
         }
-        result = try context.transaction.verifySignature(extendedSignature: sig, publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode, scriptConfiguration: context.configuration)
+        try checkSignature(sig, scriptConfiguration: context.configuration)
+        result = context.transaction.verifySignature(extendedSignature: sig, publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode)
         default:
             preconditionFailure()
     }


### PR DESCRIPTION
Fixed problem with checkSignatureEncoding.
Tweaked valid tx test cases designed for checkTransaction by removing flag requirement.