### PR TITLE
Check inputs function for sanity checks. Fixes #34

### DIFF
--- a/src/bitcoin/transaction/Coin.swift
+++ b/src/bitcoin/transaction/Coin.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// A reference to an unspent transation output (aka _UTXO_).
+public struct Coin: Equatable {
+    let output: Output
+    let height: Int
+    let isCoinbase: Bool
+}

--- a/src/bitcoin/transaction/TransactionError.swift
+++ b/src/bitcoin/transaction/TransactionError.swift
@@ -10,5 +10,10 @@ enum TransactionError: Error {
          totalOutputsTooLarge,
          duplicateInput,
          coinbaseLengthOutOfRange,
-         missingOutpoint
+         missingOutpoint,
+         inputMissingOrSpent,
+         prematureCoinbaseSpend,
+         inputValuesOutOfRange,
+         inputsValueBelowOutput,
+         feeOutOfRange
 }


### PR DESCRIPTION
New coin structure for a view of the unspent transaction output state.