### PR TITLE
BIP16 Pay-to-Script-Hash (P2SH) implemented #29

### DIFF
--- a/src/bitcoin/script/Script.swift
+++ b/src/bitcoin/script/Script.swift
@@ -26,4 +26,27 @@ extension Script {
     public var prefixedSize: Int {
         data.varLenSize
     }
+
+    // BIP16
+    var isPayToScriptHash: Bool {
+        if size == 23,
+           let operations = parsed?.operations,
+           operations.count == 3,
+           operations[0] == .hash160,
+           case .pushBytes(_) = operations[1],
+           operations[2] == .equal { true } else { false }
+    }
+
+    // BIP62
+    func checkPushOnly() throws {
+        guard let parsed else {
+            throw ScriptError.unparsableScript
+        }
+        for op in parsed.operations {
+            switch op {
+            case .oneNegate, .zero, .constant(_), .pushBytes(_), .pushData1(_), .pushData2(_), .pushData4(_): break
+            default: throw ScriptError.nonPushOnlyScript
+            }
+        }
+    }
 }

--- a/src/bitcoin/script/ScriptConfigurarion.swift
+++ b/src/bitcoin/script/ScriptConfigurarion.swift
@@ -3,22 +3,55 @@ import Foundation
 /// Script verification flags represented by configuration options. All flags are intended to be soft forks: the set of acceptable scripts under flags (A | B) is a subset of the acceptable scripts under flag (A).
 public struct ScriptConfigurarion {
 
-    /// BIP62 rule 7
-    /// Verify dummy stack item consumed by `CHECKMULTISIG` is of zero-length.
-    public var checkNullDummy = true
-
-    /// BIP62 rule 5
-    /// Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure.
-    public var checkLowS = true
+    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true) {
+        self.strictDER = strictDER || lowS || strictEncoding
+        self.pushOnly = pushOnly
+        self.lowS = lowS
+        self.cleanStack = cleanStack
+        self.nullDummy = nullDummy
+        self.strictEncoding = strictEncoding
+        self.payToScriptHash = payToScriptHash || cleanStack
+    }
 
     /// BIP62 rule 1
     /// Passing a non-strict-DER signature to a checksig operation causes script failure.
-    public var checkStrictDER = true
+    public var strictDER = true
+
+    /// BIP62 rule 2
+    /// Using a non-push operator in the scriptSig causes script failure.
+    public var pushOnly = true
+
+    /// BIP62 rule 5
+    /// Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure.
+    public var lowS = true {
+        didSet {
+            strictDER = strictDER || lowS || strictEncoding
+        }
+    }
+
+    /// BIP62 rule 6
+    /// Require that only a single stack element remains after evaluation.
+    public var cleanStack = true {
+        didSet {
+            payToScriptHash = payToScriptHash || cleanStack
+        }
+    }
+
+    /// BIP62 rule 7
+    /// Verify dummy stack item consumed by `CHECKMULTISIG` is of zero-length.
+    public var nullDummy = true
 
     /// Passing a non-strict-DER signature or one with undefined hashtype to a checksig operation causes script failure.
     /// Evaluating a pubkey that is not (0x04 + 64 bytes) or (0x02 or 0x03 + 32 bytes) by checksig causes script failure.
     /// Not used or intended as a consensus rule.
-    public var checkStrictEncoding = true
+    public var strictEncoding = true {
+        didSet {
+            strictDER = strictDER || lowS || strictEncoding
+        }
+    }
+
+    /// BIP16
+    public var payToScriptHash = true
 
     /// Standard script verification flags that standard transactions will comply with. However we do not ban/disconnect nodes that forward txs violating the additional (non-mandatory) rules here, to improve forwards and backwards compatability.
     public static let standard = ScriptConfigurarion()
@@ -26,9 +59,11 @@ public struct ScriptConfigurarion {
     /// Mandatory script verification flags that all new transactions must comply with for them to be valid. Failing one of these tests may trigger a DoS ban. See `CheckInputScripts()` on Bitcoin Core  for details.
     /// Note that this does not affect consensus validity. See `GetBlockScriptFlags()` for that.
     public static let mandatory = ScriptConfigurarion(
-        checkNullDummy: false,
-        checkLowS: false,
-        checkStrictDER: false,
-        checkStrictEncoding: false
+        strictDER: false,
+        pushOnly: false,
+        lowS: false,
+        cleanStack: false,
+        nullDummy: false,
+        strictEncoding: false
     )
 }

--- a/src/bitcoin/script/ScriptContext.swift
+++ b/src/bitcoin/script/ScriptContext.swift
@@ -34,7 +34,7 @@ struct ScriptContext {
     }
 
     /// Support for `OP_CHECKSIG` and `OP_CHECKSIGVERIFY`.
-    func getScriptCode(signature: Data) -> Data? {
+    func getScriptCode(signatures: [Data]) -> Data? {
         var scriptData = script.data
         if let codesepOffset = lastCodeSeparatorOffset {
             scriptData.removeFirst(codesepOffset + 1)
@@ -47,9 +47,16 @@ struct ScriptContext {
                 return .none
             }
 
+            var operationContainsSignature = false
+            for sig in signatures {
+                if !sig.isEmpty, operation == .pushBytes(sig) {
+                    operationContainsSignature = true
+                    break
+                }
+            }
+
             if
-                operation != .codeSeparator &&
-                (signature.isEmpty || operation != .pushBytes(signature)) // Equivalent to FindAndDelete
+                operation != .codeSeparator && !operationContainsSignature // Equivalent to FindAndDelete
             {
                 scriptCode.append(operation.data)
             }

--- a/src/bitcoin/script/ScriptError.swift
+++ b/src/bitcoin/script/ScriptError.swift
@@ -3,6 +3,8 @@ import Foundation
 /// An error while executing a bitcoin script.
 enum ScriptError: Error {
     case invalidScript,
+         unparsableScript,
+         nonPushOnlyScript,
          invalidStackOperation,
          invalidInstruction,
          disabledOperation,

--- a/src/bitcoin/script/ScriptOperation.swift
+++ b/src/bitcoin/script/ScriptOperation.swift
@@ -6,14 +6,19 @@ public enum ScriptOperation: Equatable {
 
     private func operationPreconditions() {
         switch(self) {
-        case .pushBytes(let d):
-            precondition(d.count > 0 && d.count <= 75)
-        case .pushData1(let d):
-            precondition(d.count > 75 && d.count <= UInt8.max)
-        case .pushData2(let d):
-            precondition(d.count > UInt8.max && d.count <= UInt16.max)
-        case .pushData4(let d):
-            precondition(d.count > UInt16.max && d.count <= UInt32.max)
+        case .pushBytes(_):
+            // TODO: Make precondition a script error when minimal data is enabled
+            // precondition(d.count > 0 && d.count <= 75)
+            break
+        case .pushData1(_):
+            // precondition(d.count > 75 && d.count <= UInt8.max)
+            break
+        case .pushData2(_):
+            // precondition(d.count > UInt8.max && d.count <= UInt16.max)
+            break
+        case .pushData4(_):
+            // precondition(d.count > UInt16.max && d.count <= UInt32.max)
+            break
         case .reserved(let k):
             precondition(k == 80 || (k >= 137 && k <= 138))
         case .constant(let k):

--- a/src/bitcoin/script/opUtils.swift
+++ b/src/bitcoin/script/opUtils.swift
@@ -56,7 +56,7 @@ func getCheckMultiSigParams(_ stack: inout [Data], configuration: ScriptConfigur
     let sigs = Array(stack[(stack.endIndex - m)...].reversed())
     stack.removeLast(m)
     let dummyValue = stack.removeLast()
-    if configuration.checkNullDummy, dummyValue.count > 0 {
+    if configuration.nullDummy, dummyValue.count > 0 {
         throw ScriptError.dummyValueNotNull
     }
     return (n, publicKeys, m, sigs)
@@ -66,13 +66,13 @@ func checkSignature(_ extendedSignature: Data, scriptConfiguration: ScriptConfig
     // Empty signature. Not strictly DER encoded, but allowed to provide a
     // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
     if extendedSignature.isEmpty { return }
-    if scriptConfiguration.checkStrictDER || scriptConfiguration.checkLowS || scriptConfiguration.checkStrictEncoding {
+    if scriptConfiguration.strictDER || scriptConfiguration.lowS || scriptConfiguration.strictEncoding {
         try checkSignatureEncoding(extendedSignature)
     }
-    if scriptConfiguration.checkLowS  {
+    if scriptConfiguration.lowS  {
         try checkSignatureLowS(extendedSignature)
     }
-    if scriptConfiguration.checkStrictEncoding  {
+    if scriptConfiguration.strictEncoding  {
         let sighashTypeData = extendedSignature.dropFirst(extendedSignature.count - 1)
         guard let sighashType = SighashType(sighashTypeData), sighashType.isDefined else {
             throw ScriptError.undefinedSighashType
@@ -81,7 +81,7 @@ func checkSignature(_ extendedSignature: Data, scriptConfiguration: ScriptConfig
 }
 
 func checkPublicKey(_ publicKey: Data, scriptConfiguration: ScriptConfigurarion) throws {
-    if scriptConfiguration.checkStrictEncoding  {
+    if scriptConfiguration.strictEncoding  {
         try checkPublicKeyEncoding(publicKey)
     }
 }

--- a/src/bitcoin/scriptOperations/opCheckMultiSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckMultiSig.swift
@@ -16,14 +16,15 @@ func opCheckMultiSig(_ stack: inout [Data], context: ScriptContext) throws {
             default: preconditionFailure() // TODO: SegWit will require compressed public keys
         }
 
+        guard let scriptCode = context.getScriptCode(signatures: sigs) else {
+            throw ScriptError.invalidScript
+        }
+
         var result = false
         var i = 0
         while i < leftSigs.count {
             switch context.script.version {
                 case .legacy:
-                guard let scriptCode = context.getScriptCode(signature: leftSigs[i]) else {
-                    throw ScriptError.invalidScript
-                }
                 try checkSignature(leftSigs[i], scriptConfiguration: context.configuration)
                 result = context.transaction.verifySignature(extendedSignature: leftSigs[i], publicKey: publicKey, inputIndex: context.inputIndex, previousOutput: context.previousOutput, scriptCode: scriptCode)
                 default: preconditionFailure()

--- a/src/bitcoin/scriptOperations/opCheckSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckSig.swift
@@ -8,7 +8,7 @@ func opCheckSig(_ stack: inout [Data], context: ScriptContext) throws {
     switch context.script.version {
         case .legacy:
         // Legacy semantics
-        guard let scriptCode = context.getScriptCode(signature: sig) else {
+        guard let scriptCode = context.getScriptCode(signatures: [sig]) else {
             throw ScriptError.invalidScript
         }
 

--- a/test/bitcoin/APITests.swift
+++ b/test/bitcoin/APITests.swift
@@ -78,6 +78,6 @@ final class APITests: XCTestCase {
                 )
             ])
         let previousOutputs = [coinbaseTx2.outputs[0]]
-        XCTAssert(tx.verify(previousOutputs: previousOutputs))
+        XCTAssert(tx.verify(previousOutputs: previousOutputs, configuration: .init(cleanStack: false)))
     }
 }

--- a/test/bitcoin/ValidTransactionTests.swift
+++ b/test/bitcoin/ValidTransactionTests.swift
@@ -26,23 +26,32 @@ final class ValidTransactionTests: XCTestCase {
             var excludeFlags = Set(vector.verifyFlags.split(separator: ","))
             excludeFlags.remove("NONE")
             var config = ScriptConfigurarion.standard
-            if excludeFlags.contains("NULLDUMMY") {
-                config.checkNullDummy = false
+            if excludeFlags.contains("STRICTENC") {
+                config.strictEncoding = false
             }
             if excludeFlags.contains("LOW_S") {
-                config.checkLowS = false
+                config.lowS = false
             }
             if excludeFlags.contains("DERSIG") {
-                config.checkStrictDER = false
+                config.strictDER = false
             }
-            if excludeFlags.contains("STRICTENC") {
-                config.checkStrictEncoding = false
+            if excludeFlags.contains("NULLDUMMY") {
+                config.nullDummy = false
+            }
+            if excludeFlags.contains("CLEANSTACK") {
+                config.cleanStack = false
+            }
+            if excludeFlags.contains("P2SH") {
+                config.payToScriptHash = false
+            }
+            if excludeFlags.contains("SIGPUSHONLY") {
+                config.pushOnly = false
             }
             let result = tx.verify(previousOutputs: previousOutputs, configuration: config)
             XCTAssert(result)
-            if !excludeFlags.isEmpty && !excludeFlags.contains("CLEANSTACK") && !excludeFlags.contains("CONST_SCRIPTCODE") && !excludeFlags.contains("NULLFAIL") && !excludeFlags.contains("SIGPUSHONLY") {
-                let failure = tx.verify(previousOutputs: previousOutputs, configuration: .standard)
-                XCTAssertFalse(failure)
+            if !excludeFlags.isEmpty && !excludeFlags.contains("CONST_SCRIPTCODE") && !excludeFlags.contains("NULLFAIL") {
+                 let failure = tx.verify(previousOutputs: previousOutputs, configuration: .standard)
+                 XCTAssertFalse(failure)
             }
         }
     }
@@ -356,7 +365,7 @@ fileprivate let testVectors: [TestVector] = [
             )
         ],
         serializedTransaction: "01000000010001000000000000000000000000000000000000000000000000000000000000000000006e493046022100c66c9cdf4c43609586d15424c54707156e316d88b0a1534c9e6b0d4f311406310221009c0fe51dbc9c4ab7cc25d3fdbeccf6679fe6827f08edf2b4a9f16ee3eb0e438a0123210338e8034509af564c62644c07691942e0c056752008a173c89f60ab2a88ac2ebfacffffffff010000000000000000015100000000",
-        verifyFlags: "NONE" // // TODO: Change to LOW_S once BIP16 is implemented.
+        verifyFlags: "LOW_S"
     ),
 
     // Tests for CheckTransaction()
@@ -375,7 +384,7 @@ fileprivate let testVectors: [TestVector] = [
             )
         ],
         serializedTransaction: "01000000010001000000000000000000000000000000000000000000000000000000000000000000006e493046022100e1eadba00d9296c743cb6ecc703fd9ddc9b3cd12906176a226ae4c18d6b00796022100a71aef7d2874deff681ba6080f1b278bac7bb99c61b08a85f4311970ffe7f63f012321030c0588dc44d92bdcbf8e72093466766fdc265ead8db64517b0c542275b70fffbacffffffff010040075af0750700015100000000",
-        verifyFlags: "NONE" // TODO: Change to LOW_S once BIP16 is implemented.
+        verifyFlags: "LOW_S"
     ),
 
     // MAX_MONEY output + 0 output
@@ -393,7 +402,7 @@ fileprivate let testVectors: [TestVector] = [
             )
         ],
         serializedTransaction: "01000000010001000000000000000000000000000000000000000000000000000000000000000000006d483045022027deccc14aa6668e78a8c9da3484fbcd4f9dcc9bb7d1b85146314b21b9ae4d86022100d0b43dece8cfb07348de0ca8bc5b86276fa88f7f2138381128b7c36ab2e42264012321029bb13463ddd5d2cc05da6e84e37536cb9525703cfd8f43afdb414988987a92f6acffffffff020040075af075070001510000000000000000015100000000",
-        verifyFlags: "NONE" // TODO: Change to LOW_S once BIP16 is implemented.
+        verifyFlags: "LOW_S"
     ),
 
     // Coinbase of size 2
@@ -564,7 +573,7 @@ fileprivate let testVectors: [TestVector] = [
             )
         ],
         serializedTransaction: "01000000012312503f2491a2a97fcd775f11e108a540a5528b5d4dee7a3c68ae4add01dab300000000fdfe0000483045022100f6649b0eddfdfd4ad55426663385090d51ee86c3481bdc6b0c18ea6c0ece2c0b0220561c315b07cffa6f7dd9df96dbae9200c2dee09bf93cc35ca05e6cdf613340aa0148304502207aacee820e08b0b174e248abd8d7a34ed63b5da3abedb99934df9fddd65c05c4022100dfe87896ab5ee3df476c2655f9fbe5bd089dccbef3e4ea05b5d121169fe7f5f4014c695221031d11db38972b712a9fe1fc023577c7ae3ddb4a3004187d41c45121eecfdbb5b7210207ec36911b6ad2382860d32989c7b8728e9489d7bbc94a6b5509ef0029be128821024ea9fac06f666a4adc3fc1357b7bec1fd0bdece2b9d08579226a8ebde53058e453aeffffffff0180380100000000001976a914c9b99cddf847d10685a4fabaa0baf505f7c3dfab88ac00000000",
-        verifyFlags: "NONE" // TODO: Change to LOW_S once BIP16 is implemented.
+        verifyFlags: "LOW_S"
     ),
 
     // cc60b1f899ec0a69b7c3f25ddf32c4524096a9c5b01cbd84c6d0312a0c478984, which is a fairly strange transaction which relies on OP_CHECKSIG returning 0 when checking a completely invalid sig of length 0
@@ -921,7 +930,7 @@ fileprivate let testVectors: [TestVector] = [
                 scriptOperations: [
                     .hash160,
                     .pushBytes(Data(hex: "d8dacdadb7462ae15cd906f1878706d0da8660e6")!),
-                    .equalVerify
+                    .equal
                 ]
             ),
         ],


### PR DESCRIPTION
Implemented BIP62 rule 2: scriptSig push only
Implemented BIP62 rule 6: clean stack
Fixed issue with findAndDelete not being applied properly in checkMultisig (detected by valid transaction test vector). Restored excluded flags for some of the valid transaction test vectors. Additional invalid transaction test vector.