### PR TITLE
BIP65 `CHECKLOCKTIMEVERIFY` fully implemented, documented and tested

### DIFF
--- a/src/bitcoin/script/ScriptConfigurarion.swift
+++ b/src/bitcoin/script/ScriptConfigurarion.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Script verification flags represented by configuration options. All flags are intended to be soft forks: the set of acceptable scripts under flags (A | B) is a subset of the acceptable scripts under flag (A).
 public struct ScriptConfigurarion {
 
-    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true) {
+    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true, checkLockTimeVerify: Bool = true) {
         self.strictDER = strictDER || lowS || strictEncoding
         self.pushOnly = pushOnly
         self.lowS = lowS
@@ -11,6 +11,7 @@ public struct ScriptConfigurarion {
         self.nullDummy = nullDummy
         self.strictEncoding = strictEncoding
         self.payToScriptHash = payToScriptHash || cleanStack
+        self.checkLockTimeVerify = checkLockTimeVerify
     }
 
     /// BIP66 (consensus) and BIP62 rule 1 (policy)
@@ -52,6 +53,9 @@ public struct ScriptConfigurarion {
 
     /// BIP16
     public var payToScriptHash = true
+
+    /// BIP65: Evaluate `OP_CHECKLOCKTIMEVERIFY`.
+    public var checkLockTimeVerify = true
 
     /// Standard script verification flags that standard transactions will comply with. However we do not ban/disconnect nodes that forward txs violating the additional (non-mandatory) rules here, to improve forwards and backwards compatability.
     public static let standard = ScriptConfigurarion()

--- a/src/bitcoin/script/ScriptError.swift
+++ b/src/bitcoin/script/ScriptError.swift
@@ -14,5 +14,11 @@ enum ScriptError: Error {
          invalidPublicKeyEncoding,
          invalidSignatureEncoding,
          undefinedSighashType,
-         dummyValueNotNull
+         missingDummyValue,
+         dummyValueNotNull,
+         invalidLockTimeArgument,
+         lockTimeHeightEarly,
+         lockTimeSecondsEarly,
+         inputSequenceFinal,
+         missingStackArgument
 }

--- a/src/bitcoin/script/ScriptOperation.swift
+++ b/src/bitcoin/script/ScriptOperation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A script operation.
 public enum ScriptOperation: Equatable {
-    case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, reserved(UInt8), constant(UInt8), noOp, ver, `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, checkMultiSig, checkMultiSigVerify, noOp1, noOp2, noOp3, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
+    case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, reserved(UInt8), constant(UInt8), noOp, ver, `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, checkMultiSig, checkMultiSigVerify, noOp1, checkLockTimeVerify, noOp3, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
 
     private func operationPreconditions() {
         switch(self) {
@@ -138,7 +138,7 @@ public enum ScriptOperation: Equatable {
         case .checkMultiSig: 0xae
         case .checkMultiSigVerify: 0xaf
         case .noOp1: 0xb0
-        case .noOp2: 0xb1
+        case .checkLockTimeVerify: 0xb1
         case .noOp3: 0xb2
         case .noOp4: 0xb3
         case .noOp5: 0xb4
@@ -243,7 +243,7 @@ public enum ScriptOperation: Equatable {
         case .checkMultiSig: "OP_CHECKMULTISIG"
         case .checkMultiSigVerify: "OP_CHECKMULTISIGVERIFY"
         case .noOp1: "OP_NOP1"
-        case .noOp2: "OP_NOP2"
+        case .checkLockTimeVerify: "OP_CHECKLOCKTIMEVERIFY"
         case .noOp3: "OP_NOP3"
         case .noOp4: "OP_NOP4"
         case .noOp5: "OP_NOP5"
@@ -353,7 +353,11 @@ public enum ScriptOperation: Equatable {
         case .checkSigVerify: try opCheckSigVerify(&stack, context: context)
         case .checkMultiSig: try opCheckMultiSig(&stack, context: context)
         case .checkMultiSigVerify: try opCheckMultiSigVerify(&stack, context: context)
-        case .noOp1, .noOp2, .noOp3, .noOp4, .noOp5, .noOp6, .noOp7, .noOp8, .noOp9, .noOp10: break
+        case .noOp1: break
+        case .checkLockTimeVerify:
+            guard context.configuration.checkLockTimeVerify else { break }
+            try opCheckLockTimeVerify(&stack, context: context)
+        case .noOp3, .noOp4, .noOp5, .noOp6, .noOp7, .noOp8, .noOp9, .noOp10: break
         case .unknown(_): throw ScriptError.invalidScript
         case .pubKeyHash: throw ScriptError.disabledOperation
         case .pubKey:  throw ScriptError.disabledOperation
@@ -539,7 +543,7 @@ public enum ScriptOperation: Equatable {
         case Self.checkMultiSig.opCode: self = .checkMultiSig
         case Self.checkMultiSigVerify.opCode: self = .checkMultiSigVerify
         case Self.noOp1.opCode: self = .noOp1
-        case Self.noOp2.opCode: self = .noOp2
+        case Self.checkLockTimeVerify.opCode: self = .checkLockTimeVerify
         case Self.noOp3.opCode: self = .noOp3
         case Self.noOp4.opCode: self = .noOp4
         case Self.noOp5.opCode: self = .noOp5

--- a/src/bitcoin/script/opUtils.swift
+++ b/src/bitcoin/script/opUtils.swift
@@ -47,7 +47,7 @@ func getSenaryParams(_ stack: inout [Data]) throws -> (Data, Data, Data, Data, D
 
 func getCheckMultiSigParams(_ stack: inout [Data], configuration: ScriptConfigurarion) throws -> (Int, [Data], Int, [Data]) {
     guard stack.count > 4 else {
-        throw ScriptError.invalidScript
+        throw ScriptError.missingStackArgument
     }
     let n = try ScriptNumber(stack.removeLast()).value
     let publicKeys = Array(stack[(stack.endIndex - n)...].reversed())
@@ -55,6 +55,9 @@ func getCheckMultiSigParams(_ stack: inout [Data], configuration: ScriptConfigur
     let m = try ScriptNumber(stack.removeLast()).value
     let sigs = Array(stack[(stack.endIndex - m)...].reversed())
     stack.removeLast(m)
+    guard stack.count > 0 else {
+        throw ScriptError.missingDummyValue
+    }
     let dummyValue = stack.removeLast()
     if configuration.nullDummy, dummyValue.count > 0 {
         throw ScriptError.dummyValueNotNull

--- a/src/bitcoin/scriptOperations/opCheckLockTimeVerify.swift
+++ b/src/bitcoin/scriptOperations/opCheckLockTimeVerify.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// [BIP65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
+func opCheckLockTimeVerify(_ stack: inout [Data], context: ScriptContext) throws {
+    let first = try getUnaryParam(&stack, keep: true)
+    let locktime64 = try ScriptNumber(first, extendedLength: true).value
+
+    guard
+        first.count < 6,
+        locktime64 >= 0,
+        locktime64 <= UInt32.max
+    else { throw ScriptError.invalidLockTimeArgument }
+
+    let locktime = Locktime(UInt32(locktime64))
+
+    if let blockHeight = locktime.blockHeight, let txBlockHeight = context.transaction.locktime.blockHeight {
+        if blockHeight > txBlockHeight {
+            throw ScriptError.lockTimeHeightEarly
+        }
+    } else if let seconds = locktime.secondsSince1970, let txSeconds = context.transaction.locktime.secondsSince1970 {
+        if seconds > txSeconds {
+            throw ScriptError.lockTimeSecondsEarly
+        }
+    } else {
+        throw ScriptError.invalidScript
+    }
+    
+    if context.transaction.inputs[context.inputIndex].sequence == .final { throw ScriptError.inputSequenceFinal }
+}

--- a/src/bitcoin/scriptOperations/opCheckMultiSig.swift
+++ b/src/bitcoin/scriptOperations/opCheckMultiSig.swift
@@ -8,6 +8,8 @@ func opCheckMultiSig(_ stack: inout [Data], context: ScriptContext) throws {
     precondition(sigs.count == m)
     var leftPubKeys = publicKeys
     var leftSigs = sigs
+
+    // TODO: Fix bug #60
     while leftPubKeys.count > 0 && leftSigs.count > 0 {
         let publicKey = leftPubKeys.removeFirst()
 

--- a/src/bitcoin/transaction/Input.swift
+++ b/src/bitcoin/transaction/Input.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A single input of a ``Transaction``.
 public struct Input: Equatable {
 
-    //- MARK: Initializers
+    // MARK: - Initializers
 
     /// Constructs a transaction input.
     /// - Parameters:
@@ -42,7 +42,7 @@ public struct Input: Equatable {
         self.init(outpoint: outpoint, sequence: sequence, script: script)
     }
 
-    //- MARK: Instance Properties
+    // MARK: - Instance Properties
 
     /// A reference to a previously unspent output of a prior transaction.
     public var outpoint: Outpoint

--- a/src/bitcoin/transaction/Locktime.swift
+++ b/src/bitcoin/transaction/Locktime.swift
@@ -15,12 +15,26 @@ public struct Locktime: Equatable {
         self.init(value32)
     }
 
-    private init(_ rawValue: UInt32) {
+    init(_ rawValue: UInt32) {
         self.init(Int(rawValue))
     }
 
     /// The numeric lock time value.
     public let locktimeValue: Int
+
+    var blockHeight: Int? {
+        guard locktimeValue <= Self.maxBlock.locktimeValue else {
+            return nil
+        }
+        return locktimeValue
+    }
+    
+    var secondsSince1970: Int? {
+        guard locktimeValue >= Self.minClock.locktimeValue else {
+            return nil
+        }
+        return locktimeValue
+    }
 
     var data: Data {
         withUnsafeBytes(of: rawValue) { Data($0) }
@@ -28,5 +42,7 @@ public struct Locktime: Equatable {
 
     var rawValue: UInt32 { UInt32(locktimeValue) }
 
+    public static let maxBlock = Self(minClock.locktimeValue - 1)
+    public static let minClock = Self(500_000_000)
     static let size = MemoryLayout<UInt32>.size
 }

--- a/src/bitcoin/transaction/Sequence.swift
+++ b/src/bitcoin/transaction/Sequence.swift
@@ -29,6 +29,7 @@ public struct Sequence: Equatable {
     var rawValue: UInt32 { UInt32(sequenceValue) }
 
     public static let initial = Self(0)
+    public static let final = Self(0xffffffff)
 
     static let size = MemoryLayout<UInt32>.size
 }

--- a/src/bitcoin/transaction/Transaction.swift
+++ b/src/bitcoin/transaction/Transaction.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A bitcoin transaction.
 public struct Transaction: Equatable {
 
-    //- MARK: Initializers
+    // MARK: - Initializers
 
     public init(version: Version, locktime: Locktime, inputs: [Input], outputs: [Output]) {
         self.version = version
@@ -75,7 +75,7 @@ public struct Transaction: Equatable {
         self.init(version: version, locktime: locktime, inputs: inputs, outputs: outputs)
     }
 
-    //- MARK: Instance Properties
+    // MARK: - Instance Properties
 
     /// The transaction's version.
     public let version: Version
@@ -153,7 +153,7 @@ public struct Transaction: Equatable {
         outputs.reduce(0) { $0 + $1.value }
     }
 
-    //- MARK: Instance Methods
+    // MARK: - Instance Methods
 
     /// Initial simplified version of transaction verification that allows for script execution.
     public func verify(previousOutputs: [Output], configuration: ScriptConfigurarion = .standard) -> Bool {
@@ -409,7 +409,7 @@ public struct Transaction: Equatable {
         return txCopy.data + sighashType.data32
     }
 
-    //- MARK: Type Properties
+    // MARK: - Type Properties
 
     /// The total amount of bitcoin supply is actually less than this number. But `maxMoney` as a limit for any amount is a  consensus-critical constant.
     static let maxMoney = 2_100_000_000_000_000
@@ -426,7 +426,7 @@ public struct Transaction: Equatable {
     /// BIP144
     private static let segwitFlag = UInt8(0x01)
 
-    //- MARK: Type Methods
+    // MARK: - Type Methods
 
     // No type methods yet.
 }

--- a/src/bitcoin/util/RIPEMD160.swift
+++ b/src/bitcoin/util/RIPEMD160.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// RIPE Message Digest 160 Swift implementation. Reference implementation [here](https://github.com/MiclausCorp/ripemd160-Swift/)
 struct RIPEMD160 {
-    // MARK: Internal Variables
+    // MARK: - Internal Variables
     /// Message Digest buffer
     private var MDbuffer: (UInt32, UInt32, UInt32, UInt32, UInt32)
 


### PR DESCRIPTION
Correction, the bug discovered and reported is #60 

Improved on some of the script errors thrown by `checkMultisig`.
Refactored invalid transaction test: better verification flag handling.
Corrected some malformed Xcode `// MARK: - ` comments.