### PR TITLE
BIP342 - Reimplemented `OP_SUCCESS`.

### DIFF
--- a/src/bitcoin/script/ScriptConfigurarion.swift
+++ b/src/bitcoin/script/ScriptConfigurarion.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Script verification flags represented by configuration options. All flags are intended to be soft forks: the set of acceptable scripts under flags (A | B) is a subset of the acceptable scripts under flag (A).
 public struct ScriptConfigurarion {
 
-    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true, checkLockTimeVerify: Bool = true, checkSequenceVerify: Bool = true, constantScriptCode: Bool = true, witness: Bool = true, witnessCompressedPublicKey: Bool = true, minimalIf: Bool = true, nullFail: Bool = true, discourageUpgradableWitnessProgram: Bool = true, taproot: Bool = true, discourageUpgradableTaprootVersion: Bool = true) {
+    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true, checkLockTimeVerify: Bool = true, checkSequenceVerify: Bool = true, constantScriptCode: Bool = true, witness: Bool = true, witnessCompressedPublicKey: Bool = true, minimalIf: Bool = true, nullFail: Bool = true, discourageUpgradableWitnessProgram: Bool = true, taproot: Bool = true, discourageUpgradableTaprootVersion: Bool = true, discourageOpSuccess: Bool = true) {
         self.strictDER = strictDER || lowS || strictEncoding
         self.pushOnly = pushOnly
         self.lowS = lowS
@@ -21,6 +21,7 @@ public struct ScriptConfigurarion {
         self.discourageUpgradableWitnessProgram = discourageUpgradableWitnessProgram && self.witness
         self.taproot = taproot && self.witness
         self.discourageUpgradableTaprootVersion = discourageUpgradableTaprootVersion && self.taproot
+        self.discourageOpSuccess = discourageOpSuccess && self.taproot
     }
 
     /// BIP66 (consensus) and BIP62 rule 1 (policy)
@@ -81,6 +82,9 @@ public struct ScriptConfigurarion {
     /// Making unknown Taproot leaf versions non-standard.
     public let discourageUpgradableTaprootVersion: Bool
 
+    /// Making unknown `OP_SUCCESS` non-standard.
+    public let discourageOpSuccess: Bool
+
     /// Standard script verification flags that standard transactions will comply with. However we do not ban/disconnect nodes that forward txs violating the additional (non-mandatory) rules here, to improve forwards and backwards compatability.
     public static let standard = ScriptConfigurarion()
 
@@ -103,6 +107,7 @@ public struct ScriptConfigurarion {
         nullFail: false,
         discourageUpgradableWitnessProgram: false,
         // taproot: true, // From chain start with 1 block excepted on mainnet
-        discourageUpgradableTaprootVersion: false
+        discourageUpgradableTaprootVersion: false,
+        discourageOpSuccess: false
     )
 }

--- a/src/bitcoin/script/ScriptError.swift
+++ b/src/bitcoin/script/ScriptError.swift
@@ -39,6 +39,7 @@ enum ScriptError: Error {
          invalidTaprootTweak,
          missingTaprootWitness,
          disallowedTaprootVersion,
+         disallowedOpSuccess,
          sigopBudgetExceeded,
          initialStackLimitExceeded,
          stacksLimitExceeded,

--- a/src/bitcoin/script/ScriptOperation.swift
+++ b/src/bitcoin/script/ScriptOperation.swift
@@ -289,7 +289,7 @@ public enum ScriptOperation: Equatable {
         case .pushBytes(let d), .pushData1(let d), .pushData2(let d), .pushData4(let d): try opPushBytes(data: d, stack: &stack, context: context)
         case .oneNegate: op1Negate(&stack)
         case .reserved(_): throw ScriptError.invalidScript
-        case .success(_): opSuccess(context: &context)
+        case .success(_): preconditionFailure()
         case .constant(let k): opConstant(k, stack: &stack)
         case .noOp: break
         case .ver: throw ScriptError.invalidScript

--- a/src/bitcoin/scriptOperations/opSuccess.swift
+++ b/src/bitcoin/scriptOperations/opSuccess.swift
@@ -1,3 +1,0 @@
-func opSuccess(context: inout ScriptContext) {
-    context.setSucceedUnconditionally()
-}

--- a/test/bitcoin/BitcoinCoreTaprootTests.swift
+++ b/test/bitcoin/BitcoinCoreTaprootTests.swift
@@ -36,7 +36,8 @@ final class BitcoinCoreTaprootTests: XCTestCase {
                 nullFail: includeFlags.contains("NULLFAIL"),
                 discourageUpgradableWitnessProgram: includeFlags.contains("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"),
                 taproot: includeFlags.contains("TAPROOT"),
-                discourageUpgradableTaprootVersion: true
+                discourageUpgradableTaprootVersion: true,
+                discourageOpSuccess: true
             )
             let allOff = ScriptConfigurarion.init(strictDER: false, pushOnly: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false)
             if let success = testCase.success {

--- a/test/bitcoin/InvalidTransactionTests.swift
+++ b/test/bitcoin/InvalidTransactionTests.swift
@@ -48,13 +48,14 @@ final class InvalidTransactionTests: XCTestCase {
                 nullFail: includeFlags.contains("NULLFAIL"),
                 discourageUpgradableWitnessProgram: includeFlags.contains("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"),
                 taproot: false,
-                discourageUpgradableTaprootVersion: false
+                discourageUpgradableTaprootVersion: false,
+                discourageOpSuccess: false
             )
             let result = tx.verifyScript(previousOutputs: previousOutputs, configuration: config)
             XCTAssertFalse(result)
 
             if !includeFlags.isEmpty {
-                let configSuccess = ScriptConfigurarion.init(strictDER: false, pushOnly: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, taproot: false, discourageUpgradableTaprootVersion: false)
+                let configSuccess = ScriptConfigurarion.init(strictDER: false, pushOnly: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, taproot: false, discourageUpgradableTaprootVersion: false, discourageOpSuccess: false)
                 let resultSuccess = tx.verifyScript(previousOutputs: previousOutputs, configuration: configSuccess)
                 XCTAssert(resultSuccess)
             }

--- a/test/bitcoin/ValidTransactionTests.swift
+++ b/test/bitcoin/ValidTransactionTests.swift
@@ -42,7 +42,8 @@ final class ValidTransactionTests: XCTestCase {
                 nullFail: !excludeFlags.contains("NULLFAIL"),
                 discourageUpgradableWitnessProgram:  !excludeFlags.contains("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"),
                 taproot: true,
-                discourageUpgradableTaprootVersion: true
+                discourageUpgradableTaprootVersion: true,
+                discourageOpSuccess: true
             )
             let result = tx.verifyScript(previousOutputs: previousOutputs, configuration: config)
             XCTAssert(result)


### PR DESCRIPTION
Fixes bug where a script containing an OP_SUCCESS op code could actually fail. Implemented standardness rule for discouraging unknown OP_SUCCESS operations. Some readability improvements to script context.

Fixes #81