### PR TITLE
BIP62 rules 3 and 4 (aka MINIMALDATA) implemented

### DIFF
--- a/src/bitcoin/script/BitcoinScript.swift
+++ b/src/bitcoin/script/BitcoinScript.swift
@@ -98,7 +98,7 @@ public struct BitcoinScript: Equatable {
         if sigVersion != .base && sigVersion != .witnessV0 &&
            operations.contains(where: { if case .success(_) = $0 { true } else { false }}) {
             if configuration.discourageOpSuccess {
-                throw ScriptError.disallowedTaprootVersion
+                throw ScriptError.disallowedOpSuccess
             }
             return // Do not run the script.
         }
@@ -119,7 +119,6 @@ public struct BitcoinScript: Equatable {
             if sigVersion != .base && stack.count + context.altStack.count > Self.maxStackElements {
                 throw ScriptError.stacksLimitExceeded
             }
-
             context.programCounter += operation.size
         }
         guard context.pendingIfOperations.isEmpty, context.pendingElseOperations == 0 else {

--- a/src/bitcoin/script/ScriptConfigurarion.swift
+++ b/src/bitcoin/script/ScriptConfigurarion.swift
@@ -3,9 +3,10 @@ import Foundation
 /// Script verification flags represented by configuration options. All flags are intended to be soft forks: the set of acceptable scripts under flags (A | B) is a subset of the acceptable scripts under flag (A).
 public struct ScriptConfigurarion {
 
-    public init(strictDER: Bool = true, pushOnly: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true, checkLockTimeVerify: Bool = true, checkSequenceVerify: Bool = true, discourageUpgradableNoOps: Bool = true, constantScriptCode: Bool = true, witness: Bool = true, witnessCompressedPublicKey: Bool = true, minimalIf: Bool = true, nullFail: Bool = true, discourageUpgradableWitnessProgram: Bool = true, taproot: Bool = true, discourageUpgradableTaprootVersion: Bool = true, discourageOpSuccess: Bool = true, discourageUpgradablePublicKeyType: Bool = true) {
+    public init(strictDER: Bool = true, pushOnly: Bool = true, minimalData: Bool = true, lowS: Bool = true, cleanStack: Bool = true, nullDummy: Bool = true, strictEncoding: Bool = true, payToScriptHash: Bool = true, checkLockTimeVerify: Bool = true, checkSequenceVerify: Bool = true, discourageUpgradableNoOps: Bool = true, constantScriptCode: Bool = true, witness: Bool = true, witnessCompressedPublicKey: Bool = true, minimalIf: Bool = true, nullFail: Bool = true, discourageUpgradableWitnessProgram: Bool = true, taproot: Bool = true, discourageUpgradableTaprootVersion: Bool = true, discourageOpSuccess: Bool = true, discourageUpgradablePublicKeyType: Bool = true) {
         self.strictDER = strictDER || lowS || strictEncoding
         self.pushOnly = pushOnly
+        self.minimalData = minimalData
         self.lowS = lowS
         self.cleanStack = cleanStack && payToScriptHash
         self.nullDummy = nullDummy
@@ -33,6 +34,12 @@ public struct ScriptConfigurarion {
     /// BIP62 rule 2
     /// Using a non-push operator in the scriptSig causes script failure.
     public let pushOnly: Bool
+
+    /// BIP62 rule 3-4
+    /// Require minimal encodings for all push operations (`OP_0`…`OP_16`, `OP_1NEGATE` where possible, direct  pushes up to 75 bytes, `OP_PUSHDATA` up to 255 bytes, `OP_PUSHDATA2` for anything larger).
+    /// Evaluating any other push causes the script to fail (BIP62 rule 3).
+    /// In addition, whenever a stack element is interpreted as a number, it must be of minimal length (BIP62 rule 4).
+    public let minimalData: Bool
 
     /// BIP62 rule 5
     /// Passing a non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure.
@@ -106,6 +113,7 @@ public struct ScriptConfigurarion {
     public static let mandatory = ScriptConfigurarion(
         // strictDER: true, // After DEPLOYMENT_DERSIG (BIP66) buried deployment block (1st)
         pushOnly: false,
+        minimalData: false,
         lowS: false,
         cleanStack: false,
         // nullDummy: false, // After DEPLOYMENT_SEGWIT (BIP147) buried deployment block (3rd)

--- a/src/bitcoin/script/ScriptError.swift
+++ b/src/bitcoin/script/ScriptError.swift
@@ -13,6 +13,9 @@ enum ScriptError: Error {
          unknownOperation,
          disabledOperation,
          numberOverflow,
+         negativeZero, /// BIP62 rule 4
+         zeroPaddedNumber, /// BIP62 rule 4
+         nonMinimalPush, /// BIP62 rule 3
          nonMinimalBoolean,
          nonLowSSignature,
          invalidPublicKeyEncoding,

--- a/src/bitcoin/script/ScriptNumber.swift
+++ b/src/bitcoin/script/ScriptNumber.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 /// A numerical value in the context of a script execution.
+///
+/// From BIP62 (https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#numbers )…
+///
+/// The native data type of stack elements is byte arrays, but some operations interpret arguments as integers. The used encoding is little endian with an explicit sign bit (the highest bit of the last byte). The shortest encodings for numbers are (with the range boundaries encodings given in hex).
+///
+/// `0`: `OP_0` (`0x00`)
+/// `1`…`16`: `OP_1`…`OP_16` (`0x51`…`0x60`)
+/// `-1`: `OP_1NEGATE` (`0x79`)
+/// `-127`…-`2` and `17`…`127`: normal 1-byte data push (`01 FF`…`01 82` and `01 11`…`01 7F`).
+/// `-32767`…`-128` and `128`…`32767`: normal 2-byte data push; (`02 FF FF`…`02 80 80` and `02 80 00`…`02 FF 7F`)
+/// `-8388607`…`-32768` and `32768`…`8388607`: normal 3-byte data push; (`03 FF FF FF`…`03 00 80 80` and `03 00 80 00`…`03 FF FF 7F`)
+/// `-2147483647`…`-8388608` and `8388608`…`2147483647`: normal 4-byte data push; (`04 FF FF FF FF`…`04 00 00 80 80` and `04 00 00 80 00`…`04 FF FF FF 7F`)
+///
+/// Any other numbers cannot be encoded.
+///
+/// In particular, note that zero could be encoded as `01 80` (negative zero) if using the non-shortest form is allowed.
+///
 struct ScriptNumber: Equatable {
 
     static let zero = Self(unsafeValue: 0)
@@ -22,6 +39,7 @@ struct ScriptNumber: Equatable {
     init(_ value: UInt8) {
         self.init(unsafeValue: Int(value))
     }
+
     private init(unsafeValue value: Int) {
         self.value = value
     }
@@ -45,8 +63,8 @@ struct ScriptNumber: Equatable {
 
 extension ScriptNumber {
 
-    init(_ data: Data, extendedLength: Bool = false) throws {
-        // TODO: optionally enforce MINIMALDATA (no leading zero bytes unless next previous byte is max)
+    /// BIP62 rule 4: Zero-padded number pushes Any time a script opcode consumes a stack value that is interpreted as a number, it must be encoded in its shortest possible form. 'Negative zero' is not allowed.
+    init(_ data: Data, extendedLength: Bool = false, minimal: Bool = false) throws {
         if data.isEmpty {
             value = 0
             return
@@ -60,6 +78,31 @@ extension ScriptNumber {
         data[data.endIndex - 1] &= 0b01111111 // We make it positive
         let padded = data + Data(repeating: 0, count: MemoryLayout<Int>.size - data.count)
         let magnitude = padded.withUnsafeBytes { $0.load(as: Int.self) }
+
+        // Negative zero has a special error code.
+        if minimal, magnitude == 0, negative {
+            throw ScriptError.negativeZero
+        }
+
+        // This would also catch negative zeroes.
+        if minimal {
+            // Check that the number is encoded with the minimum possible
+            // number of bytes.
+            //
+            // If the most-significant-byte - excluding the sign bit - is zero
+            // then we're not minimal. Note how this test also rejects the
+            // negative-zero encoding, 0x80.
+            if data.last! & 0x7f == 0 {
+                // One exception: if there's more than one byte and the most
+                // significant bit of the second-most-significant-byte is set
+                // it would conflict with the sign bit. An example of this case
+                // is +-255, which encode to 0xff00 and 0xff80 respectively.
+                // (big-endian).
+                if data.count <= 1 || (data[data.endIndex.advanced(by: -2)] & 0x80 == 0) {
+                    throw ScriptError.zeroPaddedNumber
+                }
+            }
+        }
         value = (negative ? -1 : 1) * magnitude
     }
 

--- a/src/bitcoin/script/ScriptUtils.swift
+++ b/src/bitcoin/script/ScriptUtils.swift
@@ -1,12 +1,27 @@
 import Foundation
 import BitcoinCrypto
 
+func getUnaryNumericParam(_ stack: inout [Data], context: inout ScriptContext) throws -> ScriptNumber {
+    let first = try getUnaryParam(&stack)
+    let minimal = context.configuration.minimalData
+    let a = try ScriptNumber(first, minimal: minimal)
+    return a
+}
+
 func getUnaryParam(_ stack: inout [Data], keep: Bool = false) throws -> Data {
     guard let param = stack.last else {
         throw ScriptError.missingStackArgument
     }
     if !keep { stack.removeLast() }
     return param
+}
+
+func getBinaryNumericParams(_ stack: inout [Data], context: inout ScriptContext) throws -> (ScriptNumber, ScriptNumber) {
+    let (first, second) = try getBinaryParams(&stack)
+    let minimal = context.configuration.minimalData
+    let a = try ScriptNumber(first, minimal: minimal)
+    let b = try ScriptNumber(second, minimal: minimal)
+    return (a, b)
 }
 
 func getBinaryParams(_ stack: inout [Data]) throws -> (Data, Data) {
@@ -16,6 +31,15 @@ func getBinaryParams(_ stack: inout [Data]) throws -> (Data, Data) {
     let second = stack.removeLast()
     let first = stack.removeLast()
     return (first, second)
+}
+
+func getTernaryNumericParams(_ stack: inout [Data], context: inout ScriptContext) throws -> (ScriptNumber, ScriptNumber, ScriptNumber) {
+    let (first, second, third) = try getTernaryParams(&stack)
+    let minimal = context.configuration.minimalData
+    let a = try ScriptNumber(first, minimal: minimal)
+    let b = try ScriptNumber(second, minimal: minimal)
+    let c = try ScriptNumber(third, minimal: minimal)
+    return (a, b, c)
 }
 
 func getTernaryParams(_ stack: inout [Data]) throws -> (Data, Data, Data) {
@@ -50,10 +74,10 @@ func getCheckMultiSigParams(_ stack: inout [Data], configuration: ScriptConfigur
     guard stack.count > 4 else {
         throw ScriptError.missingMultiSigArgument
     }
-    let n = try ScriptNumber(stack.removeLast()).value
+    let n = try ScriptNumber(stack.removeLast(), minimal: configuration.minimalData).value
     let publicKeys = Array(stack[(stack.endIndex - n)...].reversed())
     stack.removeLast(n)
-    let m = try ScriptNumber(stack.removeLast()).value
+    let m = try ScriptNumber(stack.removeLast(), minimal: configuration.minimalData).value
     let sigs = Array(stack[(stack.endIndex - m)...].reversed())
     stack.removeLast(m)
     guard stack.count > 0 else {

--- a/src/bitcoin/scriptOperations/op0NotEqual.swift
+++ b/src/bitcoin/scriptOperations/op0NotEqual.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 /// Returns 0 if the input is 0. 1 otherwise.
-func op0NotEqual(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    let a = try ScriptNumber(first)
+func op0NotEqual(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let a = try getUnaryNumericParam(&stack, context: &context)
     stack.append(ScriptBoolean(a != .zero).data)
 }

--- a/src/bitcoin/scriptOperations/op1Add.swift
+++ b/src/bitcoin/scriptOperations/op1Add.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// 1 is added to the input.
-func op1Add(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    var a = try ScriptNumber(first)
+func op1Add(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var a = try getUnaryNumericParam(&stack, context: &context)
     try a.add(.one)
     stack.append(a.data)
 }

--- a/src/bitcoin/scriptOperations/op1Sub.swift
+++ b/src/bitcoin/scriptOperations/op1Sub.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// b is subtracted from a.
-func op1Sub(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    var a = try ScriptNumber(first)
+func op1Sub(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var a = try getUnaryNumericParam(&stack, context: &context)
     try a.add(.negativeOne)
     stack.append(a.data)
 }

--- a/src/bitcoin/scriptOperations/opAbs.swift
+++ b/src/bitcoin/scriptOperations/opAbs.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// The input is made positive.
-func opAbs(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    var a = try ScriptNumber(first)
+func opAbs(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var a = try getUnaryNumericParam(&stack, context: &context)
     if a.value < 0 {
         a.negate()
     }

--- a/src/bitcoin/scriptOperations/opAdd.swift
+++ b/src/bitcoin/scriptOperations/opAdd.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 /// a is added to b.
-func opAdd(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    var a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opAdd(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var a: ScriptNumber
+    let b: ScriptNumber
+    (a, b) = try getBinaryNumericParams(&stack, context: &context)
     try a.add(b)
     stack.append(a.data)
 }

--- a/src/bitcoin/scriptOperations/opBoolAnd.swift
+++ b/src/bitcoin/scriptOperations/opBoolAnd.swift
@@ -1,10 +1,7 @@
 import Foundation
 
 /// If both a and b are not 0, the output is 1. Otherwise 0.
-func opBoolAnd(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
-    // stack.append(ScriptBoolean(first).and(ScriptBoolean(second)).data)
+func opBoolAnd(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a != .zero && b != .zero).data)
 }

--- a/src/bitcoin/scriptOperations/opBoolOr.swift
+++ b/src/bitcoin/scriptOperations/opBoolOr.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// If a or b is not 0, the output is 1. Otherwise 0.
-func opBoolOr(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opBoolOr(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a != .zero || b != .zero).data)
 }

--- a/src/bitcoin/scriptOperations/opCheckLockTimeVerify.swift
+++ b/src/bitcoin/scriptOperations/opCheckLockTimeVerify.swift
@@ -3,7 +3,7 @@ import Foundation
 /// [BIP65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 func opCheckLockTimeVerify(_ stack: inout [Data], context: ScriptContext) throws {
     let first = try getUnaryParam(&stack, keep: true)
-    let locktime64 = try ScriptNumber(first, extendedLength: true).value
+    let locktime64 = try ScriptNumber(first, extendedLength: true, minimal: context.configuration.minimalData).value
 
     guard
         first.count < 6,

--- a/src/bitcoin/scriptOperations/opCheckSequenceVerify.swift
+++ b/src/bitcoin/scriptOperations/opCheckSequenceVerify.swift
@@ -3,7 +3,7 @@ import Foundation
 /// [BIP112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 func opCheckSequenceVerify(_ stack: inout [Data], context: ScriptContext) throws {
     let first = try getUnaryParam(&stack, keep: true)
-    let sequence64 = try ScriptNumber(first, extendedLength: true).value
+    let sequence64 = try ScriptNumber(first, extendedLength: true, minimal: context.configuration.minimalData).value
 
     guard
         first.count < 6,

--- a/src/bitcoin/scriptOperations/opCheckSigAdd.swift
+++ b/src/bitcoin/scriptOperations/opCheckSigAdd.swift
@@ -11,7 +11,7 @@ func opCheckSigAdd(_ stack: inout [Data], context: inout ScriptContext) throws {
     // If fewer than 3 elements are on the stack, the script MUST fail and terminate immediately.
     let (sig, nData, publicKey) = try getTernaryParams(&stack)
 
-    var n = try ScriptNumber(nData)
+    var n = try ScriptNumber(nData, minimal: context.configuration.minimalData)
     guard n.size <= 4 else {
         // - If n is larger than 4 bytes, the script MUST fail and terminate immediately.
         throw ScriptError.invalidCheckSigAddArgument

--- a/src/bitcoin/scriptOperations/opGreaterThan.swift
+++ b/src/bitcoin/scriptOperations/opGreaterThan.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if a is greater than b, 0 otherwise.
-func opGreaterThan(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opGreaterThan(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a.value > b.value).data)
 }

--- a/src/bitcoin/scriptOperations/opGreaterThanOrEqual.swift
+++ b/src/bitcoin/scriptOperations/opGreaterThanOrEqual.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if a is greater than or equal to b, 0 otherwise.
-func opGreaterThanOrEqual(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opGreaterThanOrEqual(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a.value >= b.value).data)
 }

--- a/src/bitcoin/scriptOperations/opLessThan.swift
+++ b/src/bitcoin/scriptOperations/opLessThan.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if a is less than b, 0 otherwise.
-func opLessThan(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opLessThan(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a.value < b.value).data)
 }

--- a/src/bitcoin/scriptOperations/opLessThanOrEqual.swift
+++ b/src/bitcoin/scriptOperations/opLessThanOrEqual.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if a is less than or equal to b, 0 otherwise.
-func opLessThanOrEqual(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opLessThanOrEqual(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a.value <= b.value).data)
 }

--- a/src/bitcoin/scriptOperations/opMax.swift
+++ b/src/bitcoin/scriptOperations/opMax.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns the larger of a and b.
-func opMax(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opMax(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append((a.value > b.value ? a : b).data)
 }

--- a/src/bitcoin/scriptOperations/opMin.swift
+++ b/src/bitcoin/scriptOperations/opMin.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns the smaller of a and b.
-func opMin(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opMin(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append((a.value < b.value ? a : b).data)
 }

--- a/src/bitcoin/scriptOperations/opNegate.swift
+++ b/src/bitcoin/scriptOperations/opNegate.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// The sign of the input is flipped.
-func opNegate(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    var a = try ScriptNumber(first)
+func opNegate(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var a = try getUnaryNumericParam(&stack, context: &context)
     a.negate()
     stack.append(a.data)
 }

--- a/src/bitcoin/scriptOperations/opNot.swift
+++ b/src/bitcoin/scriptOperations/opNot.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 /// If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
-func opNot(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    let a = try ScriptNumber(first)
+func opNot(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let a = try getUnaryNumericParam(&stack, context: &context)
     stack.append(ScriptBoolean(a == .zero).data)
 }

--- a/src/bitcoin/scriptOperations/opNumEqual.swift
+++ b/src/bitcoin/scriptOperations/opNumEqual.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if the numbers are equal, 0 otherwise.
-func opNumEqual(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opNumEqual(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a == b).data)
 }

--- a/src/bitcoin/scriptOperations/opNumEqualVerify.swift
+++ b/src/bitcoin/scriptOperations/opNumEqualVerify.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Same as `OP_NUMEQUAL`,  but runs `OP_VERIFY` afterward.
-func opNumEqualVerify(_ stack: inout [Data]) throws {
-    try opNumEqual(&stack)
+func opNumEqualVerify(_ stack: inout [Data], context: inout ScriptContext) throws {
+    try opNumEqual(&stack, context: &context)
     try opVerify(&stack)
 }

--- a/src/bitcoin/scriptOperations/opNumNotEqual.swift
+++ b/src/bitcoin/scriptOperations/opNumNotEqual.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 /// Returns 1 if the numbers are not equal, 0 otherwise.
-func opNumNotEqual(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let b = try ScriptNumber(second)
+func opNumNotEqual(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, b) = try getBinaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(a != b).data)
 }

--- a/src/bitcoin/scriptOperations/opPick.swift
+++ b/src/bitcoin/scriptOperations/opPick.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// The item n back in the stack is copied to the top.
-func opPick(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    let n = try ScriptNumber(first).value
+func opPick(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let n = try getUnaryNumericParam(&stack, context: &context).value
     guard n >= 0 && n < stack.count else {
         throw ScriptError.invalidStackOperation
     }

--- a/src/bitcoin/scriptOperations/opRoll.swift
+++ b/src/bitcoin/scriptOperations/opRoll.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// The item n back in the stack is moved to the top.
-func opRoll(_ stack: inout [Data]) throws {
-    let first = try getUnaryParam(&stack)
-    let n = try ScriptNumber(first).value
+func opRoll(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let n = try getUnaryNumericParam(&stack, context: &context).value
     guard n >= 0 && n < stack.count else {
         throw ScriptError.invalidStackOperation
     }

--- a/src/bitcoin/scriptOperations/opSub.swift
+++ b/src/bitcoin/scriptOperations/opSub.swift
@@ -1,10 +1,8 @@
 import Foundation
 
 /// b is subtracted from a.
-func opSub(_ stack: inout [Data]) throws {
-    let (first, second) = try getBinaryParams(&stack)
-    var a = try ScriptNumber(first)
-    var b = try ScriptNumber(second)
+func opSub(_ stack: inout [Data], context: inout ScriptContext) throws {
+    var (a, b) = try getBinaryNumericParams(&stack, context: &context)
     b.negate()
     try a.add(b)
     stack.append(a.data)

--- a/src/bitcoin/scriptOperations/opWithin.swift
+++ b/src/bitcoin/scriptOperations/opWithin.swift
@@ -1,10 +1,7 @@
 import Foundation
 
 /// Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.
-func opWithin(_ stack: inout [Data]) throws {
-    let (first, second, third) = try getTernaryParams(&stack)
-    let a = try ScriptNumber(first)
-    let min = try ScriptNumber(second)
-    let max = try ScriptNumber(third)
+func opWithin(_ stack: inout [Data], context: inout ScriptContext) throws {
+    let (a, min, max) = try getTernaryNumericParams(&stack, context: &context)
     stack.append(ScriptBoolean(min.value <= a.value && a.value < max.value).data)
 }

--- a/test/bitcoin/BitcoinCoreTaprootTests.swift
+++ b/test/bitcoin/BitcoinCoreTaprootTests.swift
@@ -10,7 +10,8 @@ final class BitcoinCoreTaprootTests: XCTestCase {
             includeFlags.remove("NONE")
             let config = ScriptConfigurarion(
                 strictDER: includeFlags.contains("DERSIG"),
-                pushOnly:  includeFlags.contains("SIGPUSHONLY"),
+                pushOnly: includeFlags.contains("SIGPUSHONLY"),
+                minimalData: includeFlags.contains("MINIMALDATA"),
                 lowS: includeFlags.contains("LOW_S"),
                 cleanStack: includeFlags.contains("CLEANSTACK"),
                 nullDummy: includeFlags.contains("NULLDUMMY"),
@@ -30,7 +31,7 @@ final class BitcoinCoreTaprootTests: XCTestCase {
                 discourageOpSuccess: true,
                 discourageUpgradablePublicKeyType: true
             )
-            let allOff = ScriptConfigurarion.init(strictDER: false, pushOnly: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, discourageUpgradableNoOps: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, discourageOpSuccess: false, discourageUpgradablePublicKeyType: false)
+            let allOff = ScriptConfigurarion.init(strictDER: false, pushOnly: false, minimalData: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, discourageUpgradableNoOps: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, discourageOpSuccess: false, discourageUpgradablePublicKeyType: false)
 
             let unsignedTx = BitcoinTransaction(Data(hex: testCase.tx)!)!
             let previousOutputs = testCase.previousOutputs.map { TransactionOutput(Data(hex: $0)!)! }

--- a/test/bitcoin/InvalidTransactionTests.swift
+++ b/test/bitcoin/InvalidTransactionTests.swift
@@ -25,7 +25,8 @@ final class InvalidTransactionTests: XCTestCase {
             includeFlags.remove("BADTX")
             let config = ScriptConfigurarion(
                 strictDER: includeFlags.contains("DERSIG"),
-                pushOnly:  includeFlags.contains("SIGPUSHONLY"),
+                pushOnly: includeFlags.contains("SIGPUSHONLY"),
+                minimalData: includeFlags.contains("MINIMALDATA"),
                 lowS: includeFlags.contains("LOW_S"),
                 cleanStack: includeFlags.contains("CLEANSTACK"),
                 nullDummy: includeFlags.contains("NULLDUMMY"),
@@ -49,7 +50,7 @@ final class InvalidTransactionTests: XCTestCase {
             XCTAssertFalse(result)
 
             if !includeFlags.isEmpty {
-                let configSuccess = ScriptConfigurarion.init(strictDER: false, pushOnly: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, discourageUpgradableNoOps: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, taproot: false, discourageUpgradableTaprootVersion: false, discourageOpSuccess: false, discourageUpgradablePublicKeyType: false)
+                let configSuccess = ScriptConfigurarion.init(strictDER: false, pushOnly: false, minimalData: false, lowS: false, cleanStack: false, nullDummy: false, strictEncoding: false, payToScriptHash: false, checkLockTimeVerify: false, checkSequenceVerify: false, discourageUpgradableNoOps: false, constantScriptCode: false, witness: false, witnessCompressedPublicKey: false, minimalIf: false, nullFail: false, discourageUpgradableWitnessProgram: false, taproot: false, discourageUpgradableTaprootVersion: false, discourageOpSuccess: false, discourageUpgradablePublicKeyType: false)
                 let resultSuccess = tx.verifyScript(previousOutputs: previousOutputs, configuration: configSuccess)
                 XCTAssert(resultSuccess)
             }

--- a/test/bitcoin/ValidTransactionTests.swift
+++ b/test/bitcoin/ValidTransactionTests.swift
@@ -19,7 +19,8 @@ final class ValidTransactionTests: XCTestCase {
             excludeFlags.remove("NONE")
             let config = ScriptConfigurarion(
                 strictDER: !excludeFlags.contains("DERSIG"),
-                pushOnly:  !excludeFlags.contains("SIGPUSHONLY"),
+                pushOnly: !excludeFlags.contains("SIGPUSHONLY"),
+                minimalData: !excludeFlags.contains("MINIMALDATA"),
                 lowS: !excludeFlags.contains("LOW_S"),
                 cleanStack: !excludeFlags.contains("CLEANSTACK"),
                 nullDummy: !excludeFlags.contains("NULLDUMMY"),
@@ -41,7 +42,7 @@ final class ValidTransactionTests: XCTestCase {
             )
             let result = tx.verifyScript(previousOutputs: previousOutputs, configuration: config)
             XCTAssert(result)
-            if !excludeFlags.isEmpty && !excludeFlags.contains("MINIMALDATA") {
+            if !excludeFlags.isEmpty {
                  let failure = tx.verifyScript(previousOutputs: previousOutputs, configuration: .standard)
                  XCTAssertFalse(failure)
             }

--- a/test/bitcoin/playground/ScriptNumberTests.swift
+++ b/test/bitcoin/playground/ScriptNumberTests.swift
@@ -151,4 +151,159 @@ final class ScriptNumberTests: XCTestCase {
         dataBack = b.data
         XCTAssertEqual(dataBack, zeroData)
     }
+
+    func testMinimalData() throws {
+        var number: ScriptNumber = .negativeOne
+
+        let zero = Data([])
+        XCTAssertNoThrow(number = try ScriptNumber(zero))
+        XCTAssertEqual(number, .zero)
+        XCTAssertNoThrow(number = try ScriptNumber(zero, minimal: true))
+        XCTAssertEqual(number, .zero)
+
+        let explicitZero = Data([0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(explicitZero))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(explicitZero, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let zeroPaddedZero = Data([0b00000000, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(zeroPaddedZero))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(zeroPaddedZero, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let doublePaddedZero = Data([0b00000000, 0b00000000, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(doublePaddedZero))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(doublePaddedZero, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let negativeZero = Data([0b10000000])
+        XCTAssertNoThrow(number = try ScriptNumber(negativeZero))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(negativeZero, minimal: true)
+        } catch ScriptError.negativeZero {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let negativeZeroPadded = Data([0b00000000, 0b10000000]) // Little endian
+        XCTAssertNoThrow(number = try ScriptNumber(negativeZeroPadded))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(negativeZeroPadded, minimal: true)
+        } catch ScriptError.negativeZero {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let negativeZeroDoublePadded = Data([0b00000000, 0b00000000, 0b10000000])
+        XCTAssertNoThrow(number = try ScriptNumber(negativeZeroDoublePadded))
+        XCTAssertEqual(number, .zero)
+        do {
+            _ = try ScriptNumber(negativeZeroDoublePadded, minimal: true)
+        } catch ScriptError.negativeZero {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let negativeOne = Data([0b10000001])
+        XCTAssertNoThrow(number = try ScriptNumber(negativeOne))
+        XCTAssertEqual(number, .negativeOne)
+        XCTAssertNoThrow(number = try ScriptNumber(negativeOne, minimal: true))
+        XCTAssertEqual(number, .negativeOne)
+
+        let negativeOnePadded = Data([0b00000001, 0b10000000])
+        XCTAssertNoThrow(number = try ScriptNumber(negativeOnePadded))
+        XCTAssertEqual(number, .negativeOne)
+        do {
+            _ = try ScriptNumber(negativeOnePadded, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let negativeOneDoublePadded = Data([0b00000001, 0b00000000, 0b10000000])
+        XCTAssertNoThrow(number = try ScriptNumber(negativeOneDoublePadded))
+        XCTAssertEqual(number, .negativeOne)
+        do {
+            _ = try ScriptNumber(negativeOneDoublePadded, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let minus127 = Data([0b11111111])
+        XCTAssertNoThrow(number = try ScriptNumber(minus127))
+        XCTAssertEqual(number.value, -127)
+        XCTAssertNoThrow(number = try ScriptNumber(minus127, minimal: true))
+        XCTAssertEqual(number.value, -127)
+
+        let possitive255 = Data([0b11111111, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(possitive255))
+        XCTAssertEqual(number.value, 255)
+        XCTAssertNoThrow(number = try ScriptNumber(possitive255, minimal: true))
+        XCTAssertEqual(number.value, 255)
+
+        let possitive255Padded = Data([0b11111111, 0b00000000, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(possitive255Padded))
+        XCTAssertEqual(number.value, 255)
+        do {
+            _ = try ScriptNumber(possitive255Padded, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let maxBytesPadded = Data([0b00000000, 0b00000000, 0b00000000, 0b01000000, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(maxBytesPadded, extendedLength: true))
+        XCTAssertEqual(number.value, 0x40000000)
+        do {
+            _ = try ScriptNumber(maxBytesPadded, extendedLength: true, minimal: true)
+        } catch ScriptError.zeroPaddedNumber {
+            // Expected
+        } catch {
+            // Wrong error
+            XCTFail()
+        }
+
+        let maxBytesPaddingOk = Data([0b00000000, 0b00000000, 0b00000000, 0b10000000, 0b00000000])
+        XCTAssertNoThrow(number = try ScriptNumber(maxBytesPaddingOk, extendedLength: true))
+        XCTAssertEqual(number.value, 0x80000000)
+        XCTAssertNoThrow(number = try ScriptNumber(maxBytesPaddingOk, extendedLength: true, minimal: true))
+        XCTAssertEqual(number.value, 0x80000000)
+
+    }
 }

--- a/test/bitcoin/playground/ScriptOperation+opIf.swift
+++ b/test/bitcoin/playground/ScriptOperation+opIf.swift
@@ -198,16 +198,13 @@ final class OpIfTests: XCTestCase {
     }
 
     func testOpSuccess() {
-        // TODO: When tapscript is implemented…
-        // ```
-        // var script = ParsedScript([.constant(1), .if, .constant(2), .else, .success(80)])
-        // var stack = [Data]()
-        // XCTAssertNoThrow(try script.run(&stack))
-        //
-        // script = ParsedScript([.constant(1), .if, .success(80), .else, .constant(2), .endIf])
-        // stack = []
-        // XCTAssertNoThrow(try script.run(&stack))
-        // ```
+        var script = BitcoinScript([.constant(1), .if, .constant(2), .else, .success(80)], sigVersion: .witnessV1)
+        var stack = [Data]()
+        XCTAssertNoThrow(try script.runV1(&stack))
+
+        script = BitcoinScript([.constant(1), .if, .success(80), .else, .constant(2), .endIf], sigVersion: .witnessV1)
+        stack = []
+        XCTAssertNoThrow(try script.runV1(&stack))
     }
 
     func testIfMalformed() {

--- a/test/bitcoin/testingUtils.swift
+++ b/test/bitcoin/testingUtils.swift
@@ -9,6 +9,11 @@ extension BitcoinScript {
     func run(_ stack: inout [Data]) throws {
         try run(&stack, transaction: .empty, inputIndex: -1, previousOutputs: [], configuration: .standard)
     }
+
+    func runV1(_ stack: inout [Data]) throws {
+        let configuration = ScriptConfigurarion(discourageOpSuccess: false)
+        try run(&stack, transaction: .init(version: .v1, locktime: .init(0), inputs: [.init(outpoint: .coinbase, sequence: .final, script: .empty, witness: .init([]))], outputs: []), inputIndex: 0, previousOutputs: [], configuration: configuration)
+    }
 }
 
 // - MARK: Hexadecimal encoding/decoding


### PR DESCRIPTION
Script verification option (configuration flag) for minimal data. Script number optionally checks for minimal representation when decoding. Push ops now checked to be minimal.
All relevant op codes updated to honour new flag.
Minimal data numeric tests.
Enabled MINIMALDATA flag in transaction tests.

Fixed small bug causing a disallowed OP_SUCCESS to be misreported. Re-enabled some OP_SUCCESS tests.