### PR TITLE
Initial _basic_  blockchain and mempool data structures

### DIFF
--- a/src/bitcoin-crypto/Constants.swift
+++ b/src/bitcoin-crypto/Constants.swift
@@ -1,0 +1,12 @@
+/// Text used to signify that a signed message follows and to prevent inadvertently signing a transaction.
+let messageMagic = "\u{18}Bitcoin Signed Message:\n"
+
+let secretKeySize = 32
+let messageHashSize = 32
+let signatureSize = 72
+let compactSignatureSize = 65
+let uncompressedKeySize = 65
+let compressedKeySize = 33
+
+let taprootControlBaseSize = 33
+let taprootControlNodeSize = 32

--- a/src/bitcoin-crypto/base+segwit/checkCompressedPublicKeyEncoding.swift
+++ b/src/bitcoin-crypto/base+segwit/checkCompressedPublicKeyEncoding.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// BIP143: Checks that the public key is  compressed.
 public func checkCompressedPublicKeyEncoding(_ publicKey: Data) -> Bool {
-    let compressedKeySize = 33
 
     if publicKey.count != compressedKeySize {
         //  Non-canonical public key: invalid length for compressed key

--- a/src/bitcoin-crypto/base+segwit/checkPublicKeyEncoding.swift
+++ b/src/bitcoin-crypto/base+segwit/checkPublicKeyEncoding.swift
@@ -2,8 +2,6 @@ import Foundation
 
 /// Checks that the public key is either compressed or uncompressed but always has a valid encoding.
 public func checkPublicKeyEncoding(_ publicKey: Data) -> Bool {
-    let keySize = 65
-    let compressedKeySize = 33
 
     // Non-canonical public key: too short
     if publicKey.count < compressedKeySize { return false }
@@ -11,7 +9,7 @@ public func checkPublicKeyEncoding(_ publicKey: Data) -> Bool {
     guard let firstByte = publicKey.first else { preconditionFailure() }
     if firstByte == 0x04 {
         // Non-canonical public key: invalid length for uncompressed key
-        if publicKey.count != keySize { return false }
+        if publicKey.count != uncompressedKeySize { return false }
     } else if firstByte == 0x02 || firstByte == 0x03 {
         // Non-canonical public key: invalid length for compressed key
         if publicKey.count != compressedKeySize { return false }

--- a/src/bitcoin-crypto/ecc/getPublicKey.swift
+++ b/src/bitcoin-crypto/ecc/getPublicKey.swift
@@ -13,12 +13,12 @@ public func getPublicKey(secretKey secretKeyData: Data, compress: Bool = true) -
         preconditionFailure()
     }
 
-    var pubKeyBytes = [UInt8](repeating: 0, count: compress ? 33 : 65)
+    var pubKeyBytes = [UInt8](repeating: 0, count: compress ? compressedKeySize : uncompressedKeySize)
     var pubKeyBytesCount = pubKeyBytes.count
     guard secp256k1_ec_pubkey_serialize(secp256k1_context_static, &pubKeyBytes, &pubKeyBytesCount, &pubKey, UInt32(compress ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED)) != 0 else {
         preconditionFailure()
     }
-    assert(compress && pubKeyBytesCount == 33 || (!compress && pubKeyBytesCount == 65))
+    assert(compress && pubKeyBytesCount == compressedKeySize || (!compress && pubKeyBytesCount == uncompressedKeySize))
 
     return Data(pubKeyBytes)
 }

--- a/src/bitcoin-crypto/ecc/recoverCompact.swift
+++ b/src/bitcoin-crypto/ecc/recoverCompact.swift
@@ -1,0 +1,30 @@
+import Foundation
+import LibSECP256k1
+
+public func recoverCompact(message: Data, signature: Data) -> Data? {
+
+    precondition(signature.count == compactSignatureSize) // throw?
+
+    let hash = [UInt8](messageHash(message))
+
+    let recid = Int32((signature[0] - 27) & 3)
+    let comp = ((signature[0] - 27) & 4) != 0
+
+    let signatureSansPrefix = [UInt8](signature[1...])
+    var sig = secp256k1_ecdsa_recoverable_signature()
+    guard secp256k1_ecdsa_recoverable_signature_parse_compact(secp256k1_context_static, &sig, signatureSansPrefix, recid) != 0 else {
+        preconditionFailure() // throw?
+    }
+
+    var pubkey = secp256k1_pubkey()
+    guard secp256k1_ecdsa_recover(secp256k1_context_static, &pubkey, &sig, hash) != 0 else {
+        return .none
+    }
+
+    var publen = comp ? compressedKeySize : uncompressedKeySize
+    var pub = [UInt8](repeating: 0, count: publen)
+    guard secp256k1_ec_pubkey_serialize(secp256k1_context_static, &pub, &publen, &pubkey, UInt32(comp ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED)) != 0 else {
+        preconditionFailure()
+    }
+    return Data(pub)
+}

--- a/src/bitcoin-crypto/ecc/signCompact.swift
+++ b/src/bitcoin-crypto/ecc/signCompact.swift
@@ -1,0 +1,45 @@
+import Foundation
+import LibSECP256k1
+
+/// Requires global signing context to be initialized.
+public func signCompact(message: Data, secretKey secretKeyData: Data, compressedPublicKey: Bool) -> Data {
+
+    precondition(secretKeyData.count == secretKeySize)
+
+    guard let eccSigningContext else { preconditionFailure() }
+
+    let hash = [UInt8](messageHash(message))
+    let secretKey = [UInt8](secretKeyData)
+
+    var rsig = secp256k1_ecdsa_recoverable_signature()
+    guard secp256k1_ecdsa_sign_recoverable(eccSigningContext, &rsig, hash, secretKey, secp256k1_nonce_function_rfc6979, nil) != 0 else {
+        preconditionFailure()
+    }
+
+    var sig = [UInt8](repeating: 0, count: compactSignatureSize)
+    var rec: Int32 = -1
+    guard secp256k1_ecdsa_recoverable_signature_serialize_compact(eccSigningContext, &sig[1], &rec, &rsig) != 0 else {
+        preconditionFailure()
+    }
+
+    precondition(rec >= 0 && rec < UInt8.max - 27 - (compressedPublicKey ? 4 : 0))
+    sig[0] = UInt8(27 + rec + (compressedPublicKey ? 4 : 0))
+
+    // Additional verification step to prevent using a potentially corrupted signature
+
+    var epk = secp256k1_pubkey()
+    guard secp256k1_ec_pubkey_create(eccSigningContext, &epk, secretKey) != 0 else {
+        preconditionFailure()
+    }
+
+    var rpk = secp256k1_pubkey()
+    guard secp256k1_ecdsa_recover(secp256k1_context_static, &rpk, &rsig, hash) != 0 else {
+        preconditionFailure()
+    }
+
+    guard secp256k1_ec_pubkey_cmp(secp256k1_context_static, &epk, &rpk) == 0 else {
+        preconditionFailure()
+    }
+
+    return Data(sig)
+}

--- a/src/bitcoin-crypto/ecc/tweakPublicKey.swift
+++ b/src/bitcoin-crypto/ecc/tweakPublicKey.swift
@@ -13,11 +13,11 @@ public func tweakPublicKey(_ keyData: Data, tweak: Data) -> Data {
     result = secp256k1_ec_pubkey_tweak_add(secp256k1_context_static, &pubkey, &tweakBytes)
     assert(result != 0)
 
-    let tweakedKey: [UInt8] = .init(unsafeUninitializedCapacity: 33) { buf, len in
-        len = 33
+    let tweakedKey: [UInt8] = .init(unsafeUninitializedCapacity: compressedKeySize) { buf, len in
+        len = compressedKeySize
         result = secp256k1_ec_pubkey_serialize(secp256k1_context_static, buf.baseAddress!, &len, &pubkey, UInt32(SECP256K1_EC_COMPRESSED))
         assert(result != 0)
-        assert(len == 33)
+        assert(len == compressedKeySize)
 
     }
     return Data(tweakedKey)

--- a/src/bitcoin-crypto/hash/messageHash.swift
+++ b/src/bitcoin-crypto/hash/messageHash.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public func messageHash(_ payload: Data) -> Data {
+    hash256(messageMagic.data(using: .utf8)! + payload.varLenData)
+}

--- a/src/bitcoin-crypto/taproot/computeMerkleRoot.swift
+++ b/src/bitcoin-crypto/taproot/computeMerkleRoot.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public func computeMerkleRoot(controlBlock: Data, tapLeafHash: Data) -> Data {
-    let pathLen = (controlBlock.count - 33) / 32
+    let pathLen = (controlBlock.count - taprootControlBaseSize) / taprootControlNodeSize
     var k = tapLeafHash
     for i in 0 ..< pathLen {
-        let startIndex = controlBlock.startIndex.advanced(by: 33 + 32 * i)
-        let endIndex = startIndex + 31
-        let node = controlBlock[startIndex ... endIndex]
+        let startIndex = controlBlock.startIndex.advanced(by: taprootControlBaseSize + taprootControlNodeSize * i)
+        let endIndex = startIndex.advanced(by: taprootControlNodeSize)
+        let node = controlBlock[startIndex ..< endIndex]
         let payload = k.lexicographicallyPrecedes(node) ? k + node : node + k
         k = taggedHash(tag: "TapBranch", payload: payload)
     }

--- a/src/bitcoin-utility/BitcoinUtility.swift
+++ b/src/bitcoin-utility/BitcoinUtility.swift
@@ -6,5 +6,5 @@ struct BitcoinUtility: AsyncParsableCommand {
         commandName: "bcutil",
         abstract: "An all-purpose Bitcoin Utility.",
         version: "1.0.0",
-        subcommands: [Node.self, Seed.self, ECNew.self, ECToPublic.self, ECToAddress.self, ScriptToAddress.self, ScriptDecode.self, HDNew.self, HDToPublic.self, HDPrivate.self, HDPublic.self, MnemonicNew.self, MnemonicToSeed.self],
+        subcommands: [Node.self, Seed.self, ECNew.self, ECToPublic.self, ECToAddress.self, ScriptToAddress.self, ScriptDecode.self, HDNew.self, HDToPublic.self, HDPrivate.self, HDPublic.self, MnemonicNew.self, MnemonicToSeed.self, ECToWIF.self, WIFToEC.self, MessageSign.self, MessageVerify.self],
         defaultSubcommand: Node.self)}

--- a/src/bitcoin-utility/commands/ECToPublic.swift
+++ b/src/bitcoin-utility/commands/ECToPublic.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Bitcoin
+import BitcoinCrypto
 import Foundation
 
 /// Computes the public key corresponding to the provided secret key.
@@ -14,5 +15,6 @@ struct ECToPublic: ParsableCommand {
 
     mutating func run() throws {
         print(try Wallet.getPublicKey(secretKey: secretKey))
+        destroyECCSigningContext()
     }
 }

--- a/src/bitcoin-utility/commands/ECToWIF.swift
+++ b/src/bitcoin-utility/commands/ECToWIF.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import Bitcoin
+import Foundation
+
+/// Converts a raw private key to the Wallet Interchange Format (WIF).
+struct ECToWIF: ParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        abstract: "Converts a raw private key to the Wallet Interchange Format (WIF)."
+    )
+
+    @Argument(help: "The secret key in raw hex format.")
+    var secretKey: String
+
+    @Option(name: .shortAndLong, help: "Whether the corresponding public key will be in compressed format.")
+    var compressedPublicKey = true
+
+    @Option(name: .shortAndLong, help: "The network for which the produced address will be valid..")
+    var network = WalletNetwork.main
+
+    mutating func run() throws {
+        print(try Wallet.convertToWIF(secretKey: secretKey, compressedPublicKey: compressedPublicKey, network: network))
+    }
+}

--- a/src/bitcoin-utility/commands/MessageSign.swift
+++ b/src/bitcoin-utility/commands/MessageSign.swift
@@ -1,0 +1,23 @@
+import ArgumentParser
+import Bitcoin
+import BitcoinCrypto
+import Foundation
+
+/// Signs a message with a private key. The signature is encoded in Base64 format.
+struct MessageSign: ParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        abstract: "Signs a message with a private key.The signature is encoded in Base64 format."
+    )
+
+    @Argument(help: "The secret key in raw hex format.")
+    var secretKey: String
+
+    @Argument(help: "The message to sign.")
+    var message: String
+
+    mutating func run() throws {
+        print(try Wallet.sign(secretKey: secretKey, message: message))
+        destroyECCSigningContext()
+    }
+}

--- a/src/bitcoin-utility/commands/MessageVerify.swift
+++ b/src/bitcoin-utility/commands/MessageVerify.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import Bitcoin
+import Foundation
+
+/// Verifies a message signatue using the specified Bitcoin address.
+struct MessageVerify: ParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        abstract: "Verifies a message signatue using the specified Bitcoin address."
+    )
+
+    @Argument(help: "The Bitcoin address used to verify the signature.")
+    var address: String
+
+    @Argument(help: "The signature encoded in Base64 format.")
+    var signature: String
+
+    @Argument(help: "The message to verify.")
+    var message: String
+
+    mutating func run() throws {
+        print(try Wallet.verify(address: address, signature: signature, message: message))
+    }
+}

--- a/src/bitcoin-utility/commands/WIFToEC.swift
+++ b/src/bitcoin-utility/commands/WIFToEC.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+import Bitcoin
+import BitcoinCrypto
+import Foundation
+
+/// Converts a secret key in the Wallet Interchange Format (WIF) to hex raw format.
+struct WIFToEC: ParsableCommand {
+
+    static var configuration = CommandConfiguration(
+        abstract: "Converts a secret key in the Wallet Interchange Format (WIF) to hex raw format."
+    )
+
+    @Argument(help: "The secret key Wallet Interchange Format (WIF).")
+    var secretKey: String
+
+    mutating func run() throws {
+        print(try Wallet.wifToEC(secretKey: secretKey).secretKey.hex)
+        destroyECCSigningContext()
+    }
+}

--- a/src/bitcoin/block/TransactionBlock.swift
+++ b/src/bitcoin/block/TransactionBlock.swift
@@ -18,8 +18,12 @@ public struct TransactionBlock: Equatable {
 
     // MARK: - Computed Properties
 
+    public var hash: Data {
+        hash256(header.data)
+    }
+
     public var identifier: Data {
-        Data(hash256(header.data).reversed())
+        Data(hash.reversed())
     }
 
     // MARK: - Instance Methods

--- a/src/bitcoin/service/Arithmetic256.swift
+++ b/src/bitcoin/service/Arithmetic256.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+enum Arithmetic256 {
+
+    static let bytes = 256 / 8
+    static let width = 256 / 32
+
+    static func isZero(_ a: [UInt32]) -> Bool {
+        a.allSatisfy { $0 == 0 }
+    }
+
+    static func compare(_ a: [UInt32], to b: [UInt32]) -> Int {
+        for i in (0 ..< width).reversed() {
+            if a[i] < b[i] {
+                return -1
+            }
+            if a[i] > b[i] {
+                return 1
+            }
+        }
+        return 0
+    }
+
+    static func assignTo(_ pn: inout [UInt32], _ b: UInt64) {
+        pn[0] = UInt32(b)
+        pn[1] = UInt32(b >> 32)
+        for i in 2 ..< width {
+            pn[i] = 0
+        }
+    }
+
+    static func shiftLeft(_ a: [UInt32], shift: UInt32) -> [UInt32] {
+        var pn = a
+        for i in 0 ..< width {
+            pn[i] = 0
+        }
+        let k = Int(shift / 32)
+        let shift = shift % 32
+        for i in 0 ..< width {
+            if i + k + 1 < width && shift != 0 {
+                pn[i + k + 1] |= (a[i] >> (32 - shift))
+            }
+            if i + k < width {
+                pn[i + k] |= (a[i] << shift)
+            }
+        }
+        return pn
+    }
+
+    static func shiftRight(_ a: [UInt32], shift: UInt32) -> [UInt32] {
+        var pn = a
+        for i in 0 ..< width {
+            pn[i] = 0
+        }
+        let k = Int(shift / 32)
+        let shift = shift % 32
+        for i in 0 ..< width {
+            if i - k - 1 >= 0 && shift != 0 {
+                pn[i - k - 1] |= (a[i] << (32 - shift))
+            }
+            if i - k >= 0 {
+                pn[i - k] |= (a[i] >> shift)
+            }
+        }
+        return pn
+    }
+
+    static func multiply(_ a: [UInt32], _ b32: UInt32) -> [UInt32] {
+        var pn = a
+        var carry = UInt64(0)
+        for i in 0 ..< width {
+            let n = carry + UInt64(b32) * UInt64(pn[i])
+            pn[i] = UInt32(n & 0xffffffff)
+            carry = n >> 32
+        }
+        return pn
+    }
+
+
+    // Returns the position of the highest bit set plus one, or zero if the value is zero.
+    static func getBits(_ pn: [UInt32]) -> UInt32 {
+        for pos in (0 ..< width).reversed() {
+            if pn[pos] != 0 {
+                for nbits in (1 ... 31).reversed() {
+                    if (pn[pos] & UInt32(1) << nbits) != 0 {
+                        return UInt32(32 * pos + nbits + 1)
+                    }
+                }
+                return UInt32(32 * pos + 1)
+            }
+        }
+        return 0
+    }
+
+    static func getLow64(_ pn: [UInt32]) -> UInt64 {
+        UInt64(pn[0]) | UInt64(pn[1]) << 32
+    }
+
+    /// This implementation directly uses shifts instead of going through an intermediate MPI representation.
+    ///
+    /// Also known as `SetCompact()`.
+    ///
+    static func makeCompact(compact: UInt32, negative: inout Bool, overflow: inout Bool) -> [UInt32] {
+        var this = [UInt32](repeating: 0, count: width)
+        let size = Int32(compact >> 24)
+        var word: UInt32 = compact & 0x007fffff
+        if (size <= 3) {
+            word >>= 8 * (3 - size)
+            assignTo(&this, UInt64(word))
+        } else {
+            assignTo(&this, UInt64(word))
+            this = shiftLeft(this, shift: UInt32(8 * (size - 3)))
+        }
+        if negative {
+            negative = word != 0 && (compact & 0x00800000) != 0
+        }
+        if overflow {
+            overflow = word != 0 && ((size > 34) ||
+                                     (word > 0xff && size > 33) ||
+                                     (word > 0xffff && size > 32))
+        }
+        return this
+    }
+
+    static func getCompact(_ this: [UInt32], negative: Bool) -> UInt32 {
+        var size = Int32((getBits(this) + 7) / 8)
+        var compact = UInt32(0)
+        if size <= 3 {
+            compact = UInt32(getLow64(this) << 8 * (3 - UInt64(size)))
+        } else {
+            let bn: [UInt32] = multiply(shiftRight(this, shift: 8), UInt32(size - 3))
+            compact = UInt32(getLow64(bn))
+        }
+        // The 0x00800000 bit denotes the sign.
+        // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
+        if (compact & 0x00800000) != 0 {
+            compact >>= 8
+            size += 1
+        }
+        assert((compact & ~UInt32(0x007fffff)) == 0)
+        assert(size < 256)
+        compact |= UInt32(size << 24)
+        compact |= negative && (compact & 0x007fffff) != 0 ? 0x00800000 : 0
+        return compact
+    }
+
+    static func arith256ToData(_ a: [UInt32]) -> Data {
+        precondition(a.count == width)
+        var ret = Data(count: bytes)
+        var offset = ret.startIndex
+        for i in 0 ..< width {
+            offset = ret.addBytes(a[i], at: offset)
+        }
+        return ret
+    }
+
+    static func dataToArith256(_ data: Data) -> [UInt32] {
+        precondition(data.count == bytes)
+        var data = data
+        var ret = [UInt32](repeating: 0, count: width)
+        for i in 0 ..< width {
+            ret[i] = data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            data = data.dropFirst(MemoryLayout<UInt32>.size)
+        }
+        return ret
+    }
+}

--- a/src/bitcoin/service/BitcoinService.swift
+++ b/src/bitcoin/service/BitcoinService.swift
@@ -1,0 +1,131 @@
+import Foundation
+import BitcoinCrypto
+
+fileprivate let blockSubsidy = 50 * 100_000_000
+
+public actor BitcoinService {
+
+    public private(set) var blockchain = [TransactionBlock]()
+    public private(set) var mempool = [BitcoinTransaction]()
+
+    public init() { }
+
+    public var genesisBlock: TransactionBlock {
+        blockchain[0]
+    }
+
+    public func addTransaction(_ transaction: BitcoinTransaction) {
+        mempool.append(transaction)
+    }
+
+    public var bits: Int {
+        // TODO: Calculate difficulty based on blockchain history #135
+        0x207fffff
+    }
+
+    public func createGenesisBlock(blockTime: Date = .now) {
+        guard blockchain.isEmpty else { return }
+
+        let satoshiPublicKey = "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f"
+        let genesisMessage = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks"
+
+        let genesisTx = BitcoinTransaction(
+            version: .v1,
+            inputs: [.init(
+                outpoint: .coinbase,
+                sequence: .final,
+                script: .init([
+                    .pushBytes(Data([0xff, 0xff, 0x00, 0x1d])),
+                    .pushBytes(Data([0x04])),
+                    .pushBytes(genesisMessage.data(using: .ascii)!)
+                ]))],
+            outputs: [
+                .init(value: blockSubsidy,
+                      script: .init([
+                        .pushBytes(.init(hex: satoshiPublicKey)!),
+                        .checkSig]))
+            ])
+
+        let genesisBlock = TransactionBlock(
+            header: .init(
+                version: 1,
+                previous: Data(repeating: 0, count: 32),
+                merkleRoot: genesisTx.identifier,
+                time: blockTime,
+                target: 0x207fffff,
+                nonce: 2
+            ),
+            transactions: [genesisTx])
+
+        blockchain.append(genesisBlock)
+    }
+
+    public func generateTo(_ address: String, blockTime: Date = .now) {
+        if blockchain.isEmpty {
+            createGenesisBlock()
+        }
+
+        guard let addressData = Base58.base58CheckDecode(address),
+              addressData[addressData.startIndex] == Int8(WalletNetwork.regtest.base58Version)
+        else { return }
+
+        let destinationPublicKeyHash = addressData[addressData.startIndex.advanced(by: 1)...]
+
+        // BIP141 Commitment Structure https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure
+        let witnessReservedValue = Data(repeating: 0, count: 32)
+        let coinbaseTxIdentifier = Data(repeating: 0, count: 32)
+
+        let witnessCommitmentHeader = Data([0xaa, 0x21, 0xa9, 0xed])
+        let witnessRootHash = coinbaseTxIdentifier // Merkle root
+        let witnessCommitmentHash = hash256(witnessRootHash + witnessReservedValue)
+
+        let witnessCommitmentScript = BitcoinScript([
+            .return,
+            .pushBytes(witnessCommitmentHeader + witnessCommitmentHash),
+        ])
+
+        let blockHeight = blockchain.count
+        let coinbaseTx = BitcoinTransaction(version: .v2, inputs: [
+            .init(outpoint: .coinbase, sequence: .final, script: .init([.encodeMinimally(blockHeight), .zero]), witness: .init([witnessReservedValue]))
+        ], outputs: [
+            .init(value: blockSubsidy, script: .init([
+                .dup,
+                .hash160,
+                .pushBytes(destinationPublicKeyHash),
+                .equalVerify,
+                .checkSig
+            ])),
+            .init(value: 0, script: witnessCommitmentScript)
+        ])
+
+        let previousBlockHash = blockchain.last!.identifier
+        let blockTransactions = [coinbaseTx] + mempool
+        let merkleRoot = calculateMerkleRoot(blockTransactions)
+
+        var neg: Bool = true
+        var over: Bool = true
+        let target = Arithmetic256.makeCompact(compact: UInt32(bits), negative: &neg, overflow: &over)
+        if Arithmetic256.isZero(target) || neg || over {
+            preconditionFailure()
+        }
+
+        var nonce = 0
+        var block: TransactionBlock
+        repeat {
+            block = TransactionBlock(
+                header: .init(
+                    version: 0x20000000,
+                    previous: previousBlockHash,
+                    merkleRoot: merkleRoot,
+                    time: blockTime,
+                    target: bits,
+                    nonce: nonce
+                ),
+                transactions: blockTransactions)
+            nonce += 1
+        } while Arithmetic256.compare(Arithmetic256.dataToArith256(block.hash), to: target) > 0
+
+        blockchain.append(block)
+        mempool = .init()
+    }
+}

--- a/src/bitcoin/service/calculateMerkleRoot.swift
+++ b/src/bitcoin/service/calculateMerkleRoot.swift
@@ -1,0 +1,23 @@
+import Foundation
+import BitcoinCrypto
+
+func calculateMerkleRoot(_ transactions: [BitcoinTransaction]) -> Data {
+    calculateMerkleRoot(transactions.map(\.identifier))
+}
+
+func calculateMerkleRoot(_ hashes: [Data]) -> Data {
+    precondition(!hashes.isEmpty)
+    if hashes.count == 1 {
+        return hashes[0]
+    }
+    let hashes = if hashes.count % 2 == 1 {
+        hashes + [hashes[hashes.endIndex]]
+    } else {
+        hashes
+    }
+    var nextHashes = [Data]()
+    for i in stride(from: hashes.startIndex, to: hashes.endIndex, by: 2) {
+        nextHashes.append(hash256(hashes[i] + hashes[i + 1]))
+    }
+    return calculateMerkleRoot(nextHashes)
+}

--- a/src/bitcoin/wallet/Wallet+Signing.swift
+++ b/src/bitcoin/wallet/Wallet+Signing.swift
@@ -1,0 +1,100 @@
+import Foundation
+import BitcoinCrypto
+
+extension Wallet {
+
+    public static func convertToWIF(secretKey: String, compressedPublicKey: Bool = true, network: WalletNetwork = .main) throws -> String {
+
+        guard let secretKey = Data(hex: secretKey) else {
+            throw WalletError.invalidHexString
+        }
+
+        return try convertToWIF(secretKey: secretKey, network: network)
+    }
+
+    public static func convertToWIF(secretKey: Data, compressedPublicKey: Bool = true, network: WalletNetwork = .main) throws -> String {
+        var data = Data()
+        data.appendBytes(UInt8(network.base58VersionPrivate))
+        data.append(secretKey)
+        if compressedPublicKey {
+            data.appendBytes(UInt8(0x01))
+        }
+        return Base58.base58CheckEncode(data)
+    }
+
+    public static func wifToEC(secretKey: String) throws -> (secretKey: Data, compressedPublicKey: Bool) {
+
+        guard var secretKeyData = Base58.base58CheckDecode(secretKey) else {
+            throw WalletError.invalidSecretKeyEncoding
+        }
+
+        guard let versionByte = secretKeyData.popFirst(), versionByte == WalletNetwork.main.base58VersionPrivate || versionByte == WalletNetwork.test.base58VersionPrivate else {
+            throw WalletError.invalidSecretKeyEncoding
+        }
+
+        let isPublicKeyCompressed: Bool
+        if secretKeyData.count == 33, let last = secretKeyData.last {
+            guard last == 0x01 else {
+                throw WalletError.invalidSecretKeyEncoding
+            }
+            isPublicKeyCompressed = true
+        } else {
+            guard secretKeyData.count == 32 else {
+                throw WalletError.invalidSecretKeyEncoding
+            }
+            isPublicKeyCompressed = false
+        }
+
+        let endIndex = isPublicKeyCompressed ? secretKeyData.endIndex.advanced(by: -1) : secretKeyData.endIndex
+        let secretKey = secretKeyData[secretKeyData.startIndex ..< endIndex]
+
+        guard checkSecretKey(secretKey) else {
+            throw WalletError.invalidSecretKey
+        }
+        return (secretKey, isPublicKeyCompressed)
+    }
+
+    public static func sign(secretKey: String, message: String) throws -> String {
+
+        let (secretKey, compressedPublicKey) = try wifToEC(secretKey: secretKey)
+
+        guard let messageData = message.data(using: .utf8) else {
+            throw WalletError.invalidMessageEncoding
+        }
+
+        return try sign(secretKey: secretKey, message: messageData, compressedPublicKey: compressedPublicKey).base64EncodedString()
+    }
+
+    public static func sign(secretKey: Data, message: Data, compressedPublicKey: Bool) throws -> Data {
+        signCompact(message: message, secretKey: secretKey, compressedPublicKey: compressedPublicKey)
+    }
+
+    public static func verify(address: String, signature: String, message: String) throws -> Bool {
+
+        // Decode P2PKH address
+        guard let addressData = Base58.base58CheckDecode(address),
+              let first = addressData.first,
+              first == WalletNetwork.main.base58Version || first == WalletNetwork.test.base58Version
+        else {
+            throw WalletError.invalidAddress
+        }
+        let publicKeyHash = addressData[addressData.startIndex.advanced(by: 1)...]
+
+        guard let signature = signature.data(using: .utf8), let signature = Data(base64Encoded: signature) else {
+            throw WalletError.invalidSignatureEncoding
+        }
+
+        guard let message = message.data(using: .utf8) else {
+            throw WalletError.invalidMessageEncoding
+        }
+
+        return try verify(publicKeyHash: publicKeyHash, signature: signature, message: message)
+    }
+
+    public static func verify(publicKeyHash: Data, signature: Data, message: Data) throws -> Bool {
+        guard let publicKey = recoverCompact(message: message, signature: signature) else {
+            return false
+        }
+        return hash160(publicKey) == publicKeyHash
+    }
+}

--- a/src/bitcoin/wallet/WalletError.swift
+++ b/src/bitcoin/wallet/WalletError.swift
@@ -43,4 +43,19 @@ public enum WalletError: Error {
 
     /// A limited amount of tapscript leaves is enforced.
     case tooManyTapscriptLeaves
+
+    /// The  address could not be decoded.
+    case invalidAddress
+
+    /// The signature could not be decoded as Base64.
+    case invalidSignatureEncoding
+
+    /// The message could not be decoded as UTF-8.
+    case invalidMessageEncoding
+
+    /// The secret key could not be decoded as WIF.
+    case invalidSecretKeyEncoding
+
+    /// The secret key is not valid.
+    case invalidSecretKey
 }

--- a/test/bitcoin/playground/BitcoinServiceTests.swift
+++ b/test/bitcoin/playground/BitcoinServiceTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Bitcoin // @testable for signatureHash(), SigHashType
+import BitcoinCrypto
+
+final class BitcoinServiceTests: XCTestCase {
+
+    /// Tests mining empty blocks, spending a coinbase transaction and mine again.
+    func testMineAndSpend() async throws {
+        let service = BitcoinService()
+        await service.createGenesisBlock()
+        for _ in 0 ..< 100 {
+            await service.generateTo("miueyHbQ33FDcjCYZpVJdC7VBbaVQzAUg5")
+        }
+
+        // Create spending transaction
+        let previousTransaction = await service.blockchain[1].transactions[0]
+        let previousOutput = previousTransaction.outputs[0]
+        let outpoint = previousTransaction.outpoint(for: 0)!
+        let unsignedInput = TransationInput(outpoint: outpoint, sequence: .final)
+        let unsignedTransaction = BitcoinTransaction(
+            version: .v1,
+            inputs: [unsignedInput],
+            outputs: [
+                .init(value: 49_98_000_000, script: .init([
+                    .dup,
+                    .hash160,
+                    .pushBytes(Data(hex: "25337bc59613aa8717459c5f7e6bf29479ddd0ed")!),
+                    .equalVerify,
+                    .checkSig
+                ]))
+            ])
+
+        // Sign the transaction
+        let sigHash = unsignedTransaction.signatureHash(sighashType: .all, inputIndex: 0, previousOutput: previousOutput, scriptCode: previousOutput.script.data)
+        let sig = signECDSA(message: sigHash, secretKey: Data(hex: "45851ee2662f0c36f4fd2a7d53a08f7b06c7abfd61953c5216cc397c4f2cae8c")!) + [SighashType.all.value]
+        let signedInput = TransationInput(
+            outpoint: unsignedInput.outpoint,
+            sequence: unsignedInput.sequence,
+            script: .init([
+                .pushBytes(sig),
+                .pushBytes(Data(hex: "035ac9d1487868eca64e932a06ee8d6d2e89d98659db7f247410d3e79f88f8d005")!)
+            ]),
+            witness: unsignedInput.witness)
+        let signedTransaction = BitcoinTransaction(
+            version: unsignedTransaction.version,
+            locktime: unsignedTransaction.locktime,
+            inputs: [signedInput],
+            outputs: unsignedTransaction.outputs)
+        XCTAssert(signedTransaction.verifyScript(previousOutputs: [previousOutput]))
+
+        await service.addTransaction(signedTransaction)
+        let mempoolBefore = await service.mempool.count
+        XCTAssertEqual(mempoolBefore, 1)
+        await service.generateTo("miueyHbQ33FDcjCYZpVJdC7VBbaVQzAUg5")
+        let mempoolAfter = await service.mempool.count
+        XCTAssertEqual(mempoolAfter, 0)
+        let blocks = await service.blockchain.count
+        XCTAssertEqual(blocks, 102)
+        guard let lastBlock = await service.blockchain.last else {
+            XCTFail(); return
+        }
+        XCTAssertEqual(lastBlock.transactions[1], signedTransaction)
+        // createrawtransaction [{"txid":"hex","vout":n,"sequence":n},...] [{"address":amount,...},{"data":"hex"},...] ( locktime replaceable )
+        // createrawtransaction '[{"txid":"72752d9bcb30dcb9bd48e4a881bbdf7e6ddf36df815e48fb54b65ef7a165c7be","vout":0}]' '[{"miueyHbQ33FDcjCYZpVJdC7VBbaVQzAUg5":49.99}]'
+        // 0200000001bec765a1f75eb654fb485e81df36df6d7edfbb81a8e448bdb9dc30cb9b2d75720000000000fdffffff01c0aff629010000001976a91425337bc59613aa8717459c5f7e6bf29479ddd0ed88ac00000000
+
+        //  bx ec-to-wif -v 239 45851ee2662f0c36f4fd2a7d53a08f7b06c7abfd61953c5216cc397c4f2cae8c
+        // cPuqe8derNHnWuMtRfDUb8CGwuStiEeVAniZTHrmf9yTWyu7n481
+
+        // signrawtransactionwithkey "hexstring" ["privatekey",...] ( [{"txid":"hex","vout":n,"scriptPubKey":"hex","redeemScript":"hex","witnessScript":"hex","amount":amount},...] "sighashtype" )
+
+        // signrawtransactionwithkey "0200000001bec765a1f75eb654fb485e81df36df6d7edfbb81a8e448bdb9dc30cb9b2d75720000000000fdffffff01c0aff629010000001976a91425337bc59613aa8717459c5f7e6bf29479ddd0ed88ac00000000" '["cPuqe8derNHnWuMtRfDUb8CGwuStiEeVAniZTHrmf9yTWyu7n481"]'
+        //  bc generatetoaddress 99 miuey…
+
+    }
+}

--- a/test/bitcoin/playground/BitcoinUtilityTests.swift
+++ b/test/bitcoin/playground/BitcoinUtilityTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import Bitcoin
+
+final class BitcoinUtilityTests: XCTestCase {
+
+    /// Test signing messages
+    func testMessageSigning() async throws {
+        let secretKey = Data(hex: "45851ee2662f0c36f4fd2a7d53a08f7b06c7abfd61953c5216cc397c4f2cae8c")!
+        let compressedPublicKey = true
+        let wif = try Wallet.convertToWIF(secretKey: secretKey, compressedPublicKey: compressedPublicKey, network: .regtest)
+        XCTAssertEqual(wif, "cPuqe8derNHnWuMtRfDUb8CGwuStiEeVAniZTHrmf9yTWyu7n481")
+
+        let (secretKey2, compressedPublicKey2) = try Wallet.wifToEC(secretKey: wif)
+        XCTAssertEqual(secretKey2, secretKey)
+        XCTAssertEqual(compressedPublicKey2, compressedPublicKey)
+
+        let message = "Hello, Bitcoin!"
+        let signature = try Wallet.sign(secretKey: wif, message: message)
+        XCTAssertEqual(signature, "IN97K44jABXPVVQ5dnPo0AcLpmG/Q0b73Yxr6JQvIFtPJJQhshb4NJ2nHjqtRhKIUNGnFGr+tlHxzoOw6xpmJ5I=")
+
+        let result = try Wallet.verify(address: "miueyHbQ33FDcjCYZpVJdC7VBbaVQzAUg5", signature: signature, message: message)
+        XCTAssert(result)
+    }
+}


### PR DESCRIPTION
fix #148 message signing and verifying with address (logic and CLI). Tested. fix #149 WIF private key encoding (logic and CLI). Tested.

Bitcoin service actor and playground tests.
256-bit arithmetic helper functions for dealing with difficulty target and compact bits formats.

Most work done for #128 (block hash vs target comparison). Tests pending. Merkle root calculation, fix #129
Genesis block calculation, fix #130
Some work done for #132 (target compact bits to difficulty conversion) but tests are pending. Work done for #134 but BIP implementation/testing is still pending.

Additional testing for transaction signing.
Some bug fixing and refactors of ECC functions.