### PR TITLE
Logic for initial `getheaders` message implemented

### DIFF
--- a/src/bitcoin-node/MessageCoder.swift
+++ b/src/bitcoin-node/MessageCoder.swift
@@ -17,7 +17,7 @@ final class MessageCoder: ByteToMessageDecoder, MessageToByteEncoder {
         let peekFrom = buffer.readableBytesView.startIndex.advanced(by: BitcoinMessage.payloadSizeStartIndex)
         let peek = buffer.readableBytesView[peekFrom...]
         let payloadLength = Int(peek.withUnsafeBytes {
-            $0.load(as: UInt32.self)
+            $0.loadUnaligned(as: UInt32.self)
         })
 
         let messageLength = BitcoinMessage.baseSize + payloadLength

--- a/src/bitcoin-node/services/RPCService.swift
+++ b/src/bitcoin-node/services/RPCService.swift
@@ -205,6 +205,8 @@ actor RPCService: Service {
                 try await outbound.write(.init(id: request.id, result: .string(await bitcoinService.blockchain.last!.hash.hex) as JSONObject))
             case "ping-all":
                 await bitcoinNode.pingAll()
+            case "request-headers":
+                await bitcoinNode.requestHeaders()
             default:
                 try await outbound.write(.init(id: request.id, error: .init(.invalidParams("method"), description: "Method `\(request.method)` does not exist.")))
             }

--- a/src/bitcoin/transport/BitcoinMessage.swift
+++ b/src/bitcoin/transport/BitcoinMessage.swift
@@ -23,7 +23,7 @@ public struct BitcoinMessage: Equatable, Sendable {
     public var isChecksumOk: Bool {
         let hash = hash256(payload)
         let realChecksum = hash.withUnsafeBytes {
-            $0.load(as: UInt32.self)
+            $0.loadUnaligned(as: UInt32.self)
         }
         return checksum == realChecksum
     }

--- a/src/bitcoin/transport/GetHeadersMessage.swift
+++ b/src/bitcoin/transport/GetHeadersMessage.swift
@@ -5,10 +5,10 @@ fileprivate let hashLength = 32
 /// Return a `headers` packet containing the headers of blocks starting right after the last known hash in the block locator object, up to `hash_stop` or 2000 blocks, whichever comes first. To receive the next block headers, one needs to issue `getheaders` again with a new block locator object. Keep in mind that some clients may provide headers of blocks which are invalid if the block locator object contains a hash on the invalid branch.
 public struct GetHeadersMessage: Equatable {
 
-    public init(protocolVersion: ProtocolVersion, locatorHashes: [Data], stopHash: Data) {
+    public init(protocolVersion: ProtocolVersion, locatorHashes: [Data], stopHash: Data? = .none) {
         self.protocolVersion = protocolVersion
         self.locatorHashes = locatorHashes
-        self.stopHash = stopHash
+        self.stopHash = stopHash ?? .init(count: hashLength)
     }
 
     /// The protocol version number; the same as sent in the `version` message.

--- a/src/bitcoin/transport/ProtocolVersion.swift
+++ b/src/bitcoin/transport/ProtocolVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ProtocolVersion: Int, Comparable, Sendable {
+public enum ProtocolVersion: Int, Sendable, Comparable {
 
     case unsupported = 70015, latest = 70016, future = 70017
 


### PR DESCRIPTION
Headers requested manually through special RPC command. Fixed bug related to decoding misaligned messages.