### PR TITLE
Removed work-around for isolation checker on linux.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: sersoft-gmbh/swifty-linux-action@v3
         with:
             branch-name: swift-6.0-branch
-            version-tag: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-22-a
+            version-tag: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-03-a
             # release-version: 6.0
       - name: Build
         run: swift build --build-tests --disable-xctest

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "33f65a3cbc52f8c19295723af9cbecc2195484e1",
-        "version" : "3.5.0"
+        "revision" : "46072478ca365fe48370993833cb22de9b41567f",
+        "version" : "3.5.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
-        "version" : "2.67.0"
+        "revision" : "fc79798d5a150d61361a27ce0c51169b889e23de",
+        "version" : "2.68.0"
       }
     },
     {

--- a/src/bitcoin/service/BitcoinService.swift
+++ b/src/bitcoin/service/BitcoinService.swift
@@ -135,11 +135,6 @@ public actor BitcoinService: Sendable {
         }
     }
 
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    public func generateTo(_ address: String) {
-        generateTo(address, blockTime: .now)
-    }
-
     public func generateTo(_ address: String, blockTime: Date = .now) {
         if blockTransactions.isEmpty {
             createGenesisBlock()
@@ -252,11 +247,6 @@ public actor BitcoinService: Sendable {
         if new > powLimitTarget { new = powLimitTarget }
 
         return new.toCompact()
-    }
-
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    private func getMedianTimePast() -> Date {
-        getMedianTimePast(for: .none)
     }
 
     private func getMedianTimePast(for height: Int? = .none) -> Date {

--- a/src/bitcoin/transport/NodeService.swift
+++ b/src/bitcoin/transport/NodeService.swift
@@ -102,21 +102,6 @@ public actor NodeService: Sendable {
         await send(.getheaders, payload: getHeaders.data, to: id)
     }
 
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    public func addPeer() async -> UUID {
-        await addPeer(host: IPv4Address.empty.description, port: 0)
-    }
-
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    public func addPeer(incoming: Bool) async -> UUID {
-        await addPeer(host: IPv4Address.empty.description, port: 0, incoming: incoming)
-    }
-
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0) async -> UUID {
-        await addPeer(host: host, port: port, incoming: true)
-    }
-
     /// Registers a peer with the node. Incoming means we are the listener. Otherwise we are the node initiating the connection.
     public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) async -> UUID {
         let id = UUID()
@@ -208,11 +193,6 @@ public actor NodeService: Sendable {
         case .getaddr, .addrv2, .inv, .getdata, .notfound, .unknown:
             break
         }
-    }
-
-    /// TODO: Remove the following function declaration which is a work-around for _ pattern that the region based isolation checker does not understand how to check. Please file a bug_ in Swift 6 nightly linux image as of 2024-06-13.
-    private func send(_ command: MessageCommand, to id: UUID) async {
-        await peerOuts[id]?.send(.init(command, payload: .init(), network: network))
     }
 
     /// Sends a message.


### PR DESCRIPTION
Part of Swift 6 migration #210