### PR TITLE
Improved on `SignatureHasher` API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8650765f37c4095c17654e0c3c062b5d5c7b2c1d6d17c2fa77ef5fc89e5e791f",
+  "originHash" : "1311b8645ee596a220e98a284ff8d03916c00461e7d61cb6a823d5b3eb3b554e",
   "pins" : [
     {
       "identity" : "secp256k1",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "9746cf80e29edfef2a39924a66731249223f42a3",
-        "version" : "2.72.0"
+        "revision" : "1b33db2dea6a64d5b619b9e888175133c6d7f410",
+        "version" : "2.73.0"
       }
     },
     {

--- a/src/bitcoin-base/BitcoinCrypto+.swift
+++ b/src/bitcoin-base/BitcoinCrypto+.swift
@@ -20,8 +20,7 @@ extension PublicKey {
 
     /// Self is an x-only internal public key.
     func tapTweak(merkleRoot: Data) -> Data {
-        // TODO: Reactivate pre-condition and fix creation of x-only public key from private key by forcing an even Y
-        // precondition(hasEvenY)
+        precondition(hasEvenY)
         return Data(SHA256.hash(data: xOnlyData + merkleRoot, tag: "TapTweak"))
     }
 

--- a/src/bitcoin-base/ExtendedSignature.swift
+++ b/src/bitcoin-base/ExtendedSignature.swift
@@ -4,11 +4,20 @@ import BitcoinCrypto
 /// A signature with sighash type extension.
 public struct ExtendedSignature {
 
-    public let signature: Signature
-    public let sighashType: SighashType?
-
     public init(_ signature: Signature, _ sighashType: SighashType?) {
         self.signature = signature
+        self.sighashType = sighashType
+    }
+
+    init?(_ data: Data, skipCheck: Bool = false) {
+        guard let last = data.last, let signature = Signature(data.dropLast()) else {
+            return nil
+        }
+        self.signature = signature
+        let sighashType = SighashType(rawValue: last)
+        if !skipCheck && !sighashType.isDefined {
+            return nil
+        }
         self.sighashType = sighashType
     }
 
@@ -16,21 +25,24 @@ public struct ExtendedSignature {
         var sigTmp = schnorrData
         let sighashType: SighashType?
         if sigTmp.count == Signature.schnorrSignatureExtendedLength, let rawValue = sigTmp.popLast(), let maybeHashType = SighashType(rawValue) {
-            // If the sig is 64 bytes long, return Verify(q, hashTapSighash(0x00 || SigMsg(0x00, 0)), sig), where Verify is defined in BIP340.
+            // If the sig is 65 bytes long, return sig[64] ≠ 0x00 and Verify(q, hashTapSighash(0x00 || SigMsg(sig[64], 0)), sig[0:64]).
             sighashType = maybeHashType
         } else if sigTmp.count == Signature.schnorrSignatureLength {
-            // If the sig is 65 bytes long, return sig[64] ≠ 0x00 and Verify(q, hashTapSighash(0x00 || SigMsg(sig[64], 0)), sig[0:64]).
+            // If the sig is 64 bytes long, return Verify(q, hashTapSighash(0x00 || SigMsg(0x00, 0)), sig), where Verify is defined in BIP340.
             sighashType = SighashType?.none
         } else {
             // Otherwise, fail.
             throw ScriptError.invalidSchnorrSignatureFormat
         }
-        guard let signature = Signature(sigTmp) else {
+        guard let signature = Signature(sigTmp, type: .schnorr) else {
             throw ScriptError.invalidSchnorrSignature
         }
         self.signature = signature
         self.sighashType = sighashType
     }
+
+    public let signature: Signature
+    public let sighashType: SighashType?
 
     public var data: Data {
         signature.data + sighashType.data

--- a/src/bitcoin-base/script/SighashType.swift
+++ b/src/bitcoin-base/script/SighashType.swift
@@ -3,8 +3,12 @@ import BitcoinCrypto
 
 public struct SighashType: Equatable, Sendable {
 
+    init(rawValue: UInt8) {
+        self.value = rawValue
+    }
+
     init?(_ value: UInt8) {
-        self.value = value
+        self.init(rawValue: value)
         if !isDefined { return nil }
     }
 
@@ -47,46 +51,7 @@ public struct SighashType: Equatable, Sendable {
     public static let singleAnyCanPay = Self(Self.sighashSingle | Self.sighashAnyCanPay)!
 }
 
-/// BIP341: Used to represent the `default` signature hash type.
-//extension Optional where Wrapped == SighashType {
-//
-//    private var assumed: SighashType { .all }
-//
-//    var isNone: Bool {
-//        if case let .some(wrapped) = self {
-//            return wrapped.isNone
-//        }
-//        return assumed.isNone
-//    }
-//
-//    var isAll: Bool {
-//        if case let .some(wrapped) = self {
-//            return wrapped.isAll
-//        }
-//        return assumed.isAll
-//    }
-//
-//    var isSingle: Bool {
-//        if case let .some(wrapped) = self {
-//            return wrapped.isSingle
-//        }
-//        return assumed.isSingle
-//    }
-//
-//    var isAnyCanPay: Bool {
-//        if case let .some(wrapped) = self {
-//            return wrapped.isAnyCanPay
-//        }
-//        return assumed.isAnyCanPay
-//    }
-//}
-
 extension SighashType {
-
-    init?(_ data: Data) {
-        guard let value = data.first else { return nil }
-        self.value = value
-    }
 
     var data: Data {
         Data(value: value)
@@ -97,6 +62,7 @@ extension SighashType {
     }
 }
 
+/// BIP341: Used to represent the `default` signature hash type.
 extension Optional where Wrapped == SighashType {
 
     var data: Data {

--- a/src/bitcoin-base/script/SignatureHasher.swift
+++ b/src/bitcoin-base/script/SignatureHasher.swift
@@ -1,121 +1,93 @@
 import Foundation
 import BitcoinCrypto
 
-public struct SignatureHash {
+public struct SignatureHasher {
 
-    public enum Error: Swift.Error {
-        case singlePrevoutRequired,
-             prevoutsInputsMismatch,
-             sighashTypeRequired,
-             inputOutOfRange,
-             inputOutOfOutputsRange
-    }
-
-    public init(transaction: BitcoinTransaction, input: Int, prevout: TransactionOutput, sigVersion: SigVersion = .base, sighashType: SighashType? = Optional(.all)) {
+    public init(transaction: BitcoinTransaction, input inputIndex: Int, sigVersion: SigVersion = .base, prevout: TransactionOutput, scriptCode: Data? = .none, tapscriptExtension: TapscriptExtension? = .none, sighashType: SighashType = .all) {
+        precondition(inputIndex < transaction.inputs.count)
+        precondition(transaction.inputs.count == 1 || sigVersion == .base || sigVersion == .witnessV0)
         self.transaction = transaction
-        self.input = input
+        self.inputIndex = inputIndex
+        self.sigVersion = sigVersion
         self.prevouts = [prevout]
-        self.sigVersion = sigVersion
+        self.scriptCode = scriptCode
+        self.tapscriptExtension = tapscriptExtension
         self.sighashType = sighashType
     }
 
-    public init(transaction: BitcoinTransaction, input: Int, prevouts: [TransactionOutput] = [], sigVersion: SigVersion = .base, sighashType: SighashType? = Optional(.all)) {
+    public init(transaction: BitcoinTransaction, input inputIndex: Int, sigVersion: SigVersion = .base, prevouts: [TransactionOutput], scriptCode: Data? = .none, tapscriptExtension: TapscriptExtension? = .none, sighashType: SighashType? = Optional.none) {
+        precondition(inputIndex < transaction.inputs.count)
+        precondition(prevouts.count == transaction.inputs.count || (prevouts.count == 1 && (sigVersion == .base || sigVersion == .witnessV0)))
         self.transaction = transaction
-        self.input = input
-        self.prevouts = prevouts
+        self.inputIndex = inputIndex
         self.sigVersion = sigVersion
+        self.prevouts = prevouts
+        self.scriptCode = scriptCode
+        self.tapscriptExtension = tapscriptExtension
         self.sighashType = sighashType
     }
 
-    public var transaction: BitcoinTransaction
-    public var input: Int
-    public var prevouts: [TransactionOutput]
-    public var sigVersion: SigVersion
-    public var sighashType: SighashType?
+    public let transaction: BitcoinTransaction
+    public private(set) var inputIndex: Int
+    public private(set) var sigVersion: SigVersion
+    public private(set) var prevouts: [TransactionOutput]
+    public private(set) var scriptCode: Data?
+    public private(set) var tapscriptExtension: TapscriptExtension?
+    public private(set) var sighashType: SighashType?
 
-    public var prevout: TransactionOutput? {
-        get {
-            if prevouts.count == 1 { prevouts[0] } else { .none }
-        }
-        set {
-            if let newValue {
-                prevouts = [newValue]
-            } else {
-                prevouts = []
-            }
-        }
+    public var prevout: TransactionOutput {
+        if prevouts.count == 1 { prevouts[0] } else { prevouts[inputIndex] }
     }
 
-    public mutating func set(input: Int, prevout: TransactionOutput) {
-        self.input = input
-        self.prevout = prevout
-        if prevout.script.isSegwit {
-            let witnessVersion = prevout.script.witnessVersion
-            if witnessVersion == 0 {
-                sigVersion = .witnessV0
-            } else if witnessVersion == 1 {
-                // This will fail to produce a sighash since we are only setting one prevout
-                sigVersion = .witnessV1
-            }
-        } else {
-            sigVersion = .base
+    public mutating func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevout: TransactionOutput) {
+        if inputIndex != self.inputIndex {
+            scriptCode = .none
+            tapscriptExtension = .none
         }
-        if (sigVersion == .base || sigVersion == .witnessV0) && sighashType == Optional.none {
-            sighashType = .all
+        self.inputIndex = inputIndex
+        self.prevouts = [prevout]
+        if let sigVersion {
+            self.sigVersion = sigVersion
         }
+        precondition(inputIndex < transaction.inputs.count)
+        precondition(transaction.inputs.count == 1 || self.sigVersion == .base || self.sigVersion == .witnessV0)
     }
 
-    public mutating func set(input: Int, prevouts newPrevouts: [TransactionOutput]? = .none) {
-        self.input = input
+    public mutating func set(input: Int, sigVersion: SigVersion? = .none, prevouts: [TransactionOutput]? = .none, sighashType: SighashType?) {
+        set(input: input, sigVersion: sigVersion, prevouts: prevouts)
+        self.sighashType = sighashType
+        precondition(sigVersion == .witnessV1 || sighashType != Optional.none)
+    }
+
+    public mutating func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevouts newPrevouts: [TransactionOutput]? = .none) {
+        if inputIndex != self.inputIndex {
+            scriptCode = .none
+            tapscriptExtension = .none
+        }
+        self.inputIndex = inputIndex
         if let newPrevouts {
             prevouts = newPrevouts
         }
-        guard input < prevouts.count else { return }
-        let prevout = prevouts[input]
-        if prevout.script.isSegwit {
-            let witnessVersion = prevout.script.witnessVersion
-            if witnessVersion == 0 {
-                // This will eventually fail to produce a sighash since we are setting too many outputs
-                sigVersion = .witnessV0
-            } else if witnessVersion == 1 {
-                sigVersion = .witnessV1
-            }
-        } else {
-            // This will eventually fail to produce a sighash since we are setting too many outputs
-            sigVersion = .base
+        if let sigVersion {
+            self.sigVersion = sigVersion
         }
-        if (sigVersion == .base || sigVersion == .witnessV0) && sighashType == Optional.none {
-            sighashType = .all
+        precondition(inputIndex < transaction.inputs.count)
+        precondition(prevouts.count == transaction.inputs.count || (prevouts.count == 1 && (self.sigVersion == .base || self.sigVersion == .witnessV0)))
+
+    }
+
+    public var value: Data {
+        switch sigVersion {
+        case .base:
+            return signatureHash
+        case .witnessV0:
+            return signatureHashSegwit
+        case .witnessV1:
+            var sighashCache = SighashCache()
+            return signatureHashSchnorr(sighashCache: &sighashCache)
         }
     }
 
-    public var value: Data { get throws {
-        guard input < transaction.inputs.count else { throw Error.inputOutOfRange }
-        switch sigVersion {
-        case .base:
-            guard prevouts.count == 1 else { throw Error.singlePrevoutRequired }
-            guard let sighashType else { throw Error.sighashTypeRequired }
-            return transaction.signatureHash(sighashType: sighashType, inputIndex: input, prevout: prevouts[0])
-        case .witnessV0:
-            guard prevouts.count == 1 else { throw Error.singlePrevoutRequired }
-            guard let sighashType else { throw Error.sighashTypeRequired }
-            return transaction.signatureHashSegwit(sighashType: sighashType, inputIndex: input, prevout: prevouts[0])
-        case .witnessV1:
-            guard prevouts.count == transaction.inputs.count else { throw Error.prevoutsInputsMismatch }
-            if (sighashType ?? .all).isSingle {
-                guard input < transaction.outputs.count else { throw Error.inputOutOfOutputsRange }
-            }
-            return transaction.signatureHashSchnorr(sighashType: sighashType, inputIndex: input, prevouts: prevouts)
-        }
-    } }
-}
-
-// TODO: Deduplicate these variables which also exist on BitcoinTransaction+Verification.swift
-private let taprootControlBaseSize = 33
-private let taprootControlNodeSize = 32
-
-// TODO: Move into the SignatureHash struct and out of the BitcoinTransaction struct.
-extension BitcoinTransaction {
     /// Signature hash for legacy inputs.
     /// - Parameters:
     ///   - sighashType: Signature hash type.
@@ -123,29 +95,33 @@ extension BitcoinTransaction {
     ///   - prevout: Previous unspent transaction output corresponding to the transaction input being signed/verified.
     ///   - scriptCode: The executed script. For Pay-to-Script-Hash outputs it should correspond to the redeem script.
     /// - Returns: A hash value for use while either signing or verifying a transaction input.
-    func signatureHash(sighashType: SighashType, inputIndex: Int, prevout: TransactionOutput, scriptCode: Data? = .none) -> Data {
-        if sighashType.isSingle && inputIndex >= outputs.count {
+    private var signatureHash: Data {
+        guard let sighashType else { preconditionFailure() }
+
+        if sighashType.isSingle && inputIndex >= transaction.outputs.count {
             // Note: The transaction that uses SIGHASH_SINGLE type of signature should not have more inputs than outputs. However if it does (because of the pre-existing implementation), it shall not be rejected, but instead for every "illegal" input (meaning: an input that has an index bigger than the maximum output index) the node should still verify it, though assuming the hash of 0000000000000000000000000000000000000000000000000000000000000001
             //
             // From [https://en.bitcoin.it/wiki/BIP_0143]:
             // In the original algorithm, a uint256 of 0x0000......0001 is committed if the input index for a SINGLE signature is greater than or equal to the number of outputs.
             return Data([0x01]) + Data(repeating: 0, count: 31)
         }
-        let scriptCode = scriptCode ?? prevout.script.data
-        let sigMsg = signatureMessage(sighashType: sighashType, inputIndex: inputIndex, scriptCode: scriptCode)
-        return Data(Hash256.hash(data: sigMsg))
+        return Data(Hash256.hash(data: signatureMessage))
     }
 
     /// Aka sigMsg. See https://en.bitcoin.it/wiki/OP_CHECKSIG
-    func signatureMessage(sighashType: SighashType, inputIndex: Int, scriptCode: Data) -> Data {
+    private var signatureMessage: Data {
+        guard let sighashType else { preconditionFailure() }
+
+        let scriptCode = scriptCode ?? prevout.script.data
+
         var newIns = [TransactionInput]()
         if sighashType.isAnyCanPay {
             // Procedure for Hashtype SIGHASH_ANYONECANPAY
             // The txCopy input vector is resized to a length of one.
             // The current transaction input (with scriptPubKey modified to subScript) is set as the first and only member of this vector.
-            newIns.append(.init(outpoint: inputs[inputIndex].outpoint, sequence: inputs[inputIndex].sequence, script: .init(scriptCode)))
+            newIns.append(.init(outpoint: transaction.inputs[inputIndex].outpoint, sequence: transaction.inputs[inputIndex].sequence, script: .init(scriptCode)))
         } else {
-            inputs.enumerated().forEach { i, input in
+            transaction.inputs.enumerated().forEach { i, input in
                 newIns.append(.init(
                     outpoint: input.outpoint,
                     // SIGHASH_NONE | SIGHASH_SINGLE - All other txCopy inputs aside from the current input are set to have an nSequence index of zero.
@@ -164,7 +140,7 @@ extension BitcoinTransaction {
             // All other txCopy outputs aside from the output that is the same as the current input index are set to a blank script and a value of (long) -1.
             newOuts = []
 
-            outputs.enumerated().forEach { i, out in
+            transaction.outputs.enumerated().forEach { i, out in
                 guard i <= inputIndex else {
                     return
                 }
@@ -178,11 +154,11 @@ extension BitcoinTransaction {
         } else if sighashType.isNone {
             newOuts = []
         } else {
-            newOuts = outputs
+            newOuts = transaction.outputs
         }
         let txCopy = BitcoinTransaction(
-            version: version,
-            locktime: locktime,
+            version: transaction.version,
+            locktime: transaction.locktime,
             inputs: newIns,
             outputs: newOuts
         )
@@ -190,28 +166,32 @@ extension BitcoinTransaction {
     }
 
     /// BIP143
-    func signatureHashSegwit(sighashType: SighashType, inputIndex: Int, prevout: TransactionOutput, scriptCode scriptCodeCandidate: Data? = .none) -> Data {
-        let scriptCode: Data
-        if prevout.script.isSegwit, prevout.script.witnessProgram.count == Hash160.Digest.byteCount {
-            scriptCode = BitcoinScript.segwitPKHScriptCode(prevout.script.witnessProgram).data
-            precondition(scriptCodeCandidate == .none || scriptCodeCandidate == scriptCode)
-        } else if let scriptCodeCandidate {
-            scriptCode = scriptCodeCandidate
-        } else {
-            preconditionFailure()
-        }
-        return Data(Hash256.hash(data: signatureMessageSegwit(sighashType: sighashType, inputIndex: inputIndex, scriptCode: scriptCode, amount: prevout.value)))
+    private var signatureHashSegwit: Data {
+        Data(Hash256.hash(data: signatureMessageSegwit))
     }
 
     /// BIP143: SegWit v0 signature message (sigMsg).
-    func signatureMessageSegwit(sighashType: SighashType, inputIndex: Int, scriptCode: Data, amount: BitcoinAmount) -> Data {
+    private var signatureMessageSegwit: Data {
+        guard let sighashType else { preconditionFailure() }
+
+        let resolvedScriptCode: Data
+        if prevout.script.isSegwit, prevout.script.witnessProgram.count == Hash160.Digest.byteCount {
+            resolvedScriptCode = BitcoinScript.segwitPKHScriptCode(prevout.script.witnessProgram).data
+            precondition(scriptCode == .none || scriptCode == scriptCode)
+        } else if let scriptCode {
+            resolvedScriptCode = scriptCode
+        } else {
+            preconditionFailure()
+        }
+
+        let amount = prevout.value
         //If the ANYONECANPAY flag is not set, hashPrevouts is the double SHA256 of the serialization of all input outpoints;
         // Otherwise, hashPrevouts is a uint256 of 0x0000......0000.
         var hashPrevouts: Data
         if sighashType.isAnyCanPay {
             hashPrevouts = Data(repeating: 0, count: 32)
         } else {
-            let prevouts = inputs.reduce(Data()) { $0 + $1.outpoint.data }
+            let prevouts = transaction.inputs.reduce(Data()) { $0 + $1.outpoint.data }
             hashPrevouts = Data(Hash256.hash(data: prevouts))
         }
 
@@ -219,7 +199,7 @@ extension BitcoinTransaction {
         // Otherwise, hashSequence is a uint256 of 0x0000......0000.
         let hashSequence: Data
         if !sighashType.isAnyCanPay && !sighashType.isSingle && !sighashType.isNone {
-            let sequence = inputs.reduce(Data()) {
+            let sequence = transaction.inputs.reduce(Data()) {
                 $0 + $1.sequence.data
             }
             hashSequence = Data(Hash256.hash(data: sequence))
@@ -232,33 +212,27 @@ extension BitcoinTransaction {
         // Otherwise, hashOutputs is a uint256 of 0x0000......0000.[7]
         let hashOuts: Data
         if !sighashType.isSingle && !sighashType.isNone {
-            let outsData = outputs.reduce(Data()) { $0 + $1.data }
+            let outsData = transaction.outputs.reduce(Data()) { $0 + $1.data }
             hashOuts = Data(Hash256.hash(data: outsData))
-        } else if sighashType.isSingle && inputIndex < outputs.count {
-            hashOuts = Data(Hash256.hash(data: outputs[inputIndex].data))
+        } else if sighashType.isSingle && inputIndex < transaction.outputs.count {
+            hashOuts = Data(Hash256.hash(data: transaction.outputs[inputIndex].data))
         } else {
             hashOuts = Data(repeating: 0, count: 32)
         }
 
-        let outpointData = inputs[inputIndex].outpoint.data
-        let scriptCodeData = scriptCode.varLenData
+        let outpointData = transaction.inputs[inputIndex].outpoint.data
+        let scriptCodeData = resolvedScriptCode.varLenData
         let amountData = withUnsafeBytes(of: amount) { Data($0) }
-        let sequenceData = inputs[inputIndex].sequence.data
+        let sequenceData = transaction.inputs[inputIndex].sequence.data
 
-        let remaindingData = sequenceData + hashOuts + locktime.data + sighashType.data32
-        return version.data + hashPrevouts + hashSequence + outpointData + scriptCodeData + amountData + remaindingData
+        let remaindingData = sequenceData + hashOuts + transaction.locktime.data + sighashType.data32
+        return transaction.version.data + hashPrevouts + hashSequence + outpointData + scriptCodeData + amountData + remaindingData
     }
 
     /// BIP341
-    func signatureHashSchnorr(sighashType: SighashType?, inputIndex: Int, prevouts: [TransactionOutput]) -> Data {
-        var sighashCache = SighashCache()
-        return signatureHashSchnorr(sighashType: sighashType, inputIndex: inputIndex, prevouts: prevouts, sighashCache: &sighashCache)
-    }
-
-    /// BIP341
-    func signatureHashSchnorr(sighashType: SighashType?, inputIndex: Int, prevouts: [TransactionOutput], tapscriptExtension: TapscriptExtension? = .none, sighashCache: inout SighashCache) -> Data {
+    func signatureHashSchnorr(sighashCache: inout SighashCache) -> Data {
         var hasher = SHA256(tag: "TapSighash")
-        hasher.update(data: signatureMessageSchnorr(sighashType: sighashType, extFlag: tapscriptExtension == .none ? 0 : 1, inputIndex: inputIndex, prevouts: prevouts, sighashCache: &sighashCache))
+        hasher.update(data: signatureMessageSchnorr(sighashCache: &sighashCache))
         if let tapscriptExtension {
             hasher.update(data: tapscriptExtension.data)
         }
@@ -268,15 +242,15 @@ extension BitcoinTransaction {
     /// BIP341: SegWit v1 (Schnorr / TapRoot) signature message (sigMsg). More at https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#common-signature-message .
     /// https://github.com/bitcoin/bitcoin/blob/58da1619be7ac13e686cb8bbfc2ab0f836eb3fa5/src/script/interpreter.cpp#L1477
     /// https://bitcoin.stackexchange.com/questions/115328/how-do-you-calculate-a-taproot-sighash
-    func signatureMessageSchnorr(sighashType: SighashType?, extFlag: UInt8 = 0, inputIndex: Int, prevouts: [TransactionOutput], sighashCache: inout SighashCache) -> Data {
+    func signatureMessageSchnorr(sighashCache: inout SighashCache) -> Data {
 
-        precondition(prevouts.count == inputs.count, "The corresponding (aligned) UTXO for each transaction input is required.")
+        let extFlag = UInt8(tapscriptExtension == .none ? 0 : 1)
 
         // For testing purposes we reset the hit count on each precomputed hash
         sighashCache.resetHits()
 
         // (the original witness stack has two or more witness elements, and the first byte of the last element is 0x50)
-        let annex = inputs[inputIndex].witness?.taprootAnnex
+        let annex = transaction.inputs[inputIndex].witness?.taprootAnnex
 
         // Epoch:
         // epoch (0).
@@ -288,13 +262,13 @@ extension BitcoinTransaction {
 
         let sighashType = sighashType ?? .all
 
-        precondition(!sighashType.isSingle || inputIndex < outputs.count, "For single hash type, the selected input needs to have a matching output.")
+        precondition(!sighashType.isSingle || inputIndex < transaction.outputs.count, "For single hash type, the selected input needs to have a matching output.")
 
         // Transaction data:
         // nVersion (4): the nVersion of the transaction.
-        var txData = version.data
+        var txData = transaction.version.data
         // nLockTime (4): the nLockTime of the transaction.
-        txData.append(locktime.data)
+        txData.append(transaction.locktime.data)
 
         //If the hash_type & 0x80 does not equal SIGHASH_ANYONECANPAY:
         if !sighashType.isAnyCanPay {
@@ -304,7 +278,7 @@ extension BitcoinTransaction {
                 shaPrevouts = cached
                 sighashCache.shaPrevoutsHit = true
             } else {
-                let prevouts = inputs.reduce(Data()) { $0 + $1.outpoint.data }
+                let prevouts = transaction.inputs.reduce(Data()) { $0 + $1.outpoint.data }
                 shaPrevouts = Data(SHA256.hash(data: prevouts))
                 sighashCache.shaPrevouts = shaPrevouts
             }
@@ -340,7 +314,7 @@ extension BitcoinTransaction {
                 shaSequences = cached
                 sighashCache.shaSequencesHit = true
             } else {
-                let sequences = inputs.reduce(Data()) { $0 + $1.sequence.data }
+                let sequences = transaction.inputs.reduce(Data()) { $0 + $1.sequence.data }
                 shaSequences = Data(SHA256.hash(data: sequences))
                 sighashCache.shaSequences = shaSequences
             }
@@ -355,7 +329,7 @@ extension BitcoinTransaction {
                 shaOuts = cached
                 sighashCache.shaOutsHit = true
             } else {
-                let outsData = outputs.reduce(Data()) { $0 + $1.data }
+                let outsData = transaction.outputs.reduce(Data()) { $0 + $1.data }
                 shaOuts = Data(SHA256.hash(data: outsData))
                 sighashCache.shaOuts = shaOuts
             }
@@ -371,7 +345,7 @@ extension BitcoinTransaction {
         // If hash_type & 0x80 equals SIGHASH_ANYONECANPAY:
         if sighashType.isAnyCanPay {
             // outpoint (36): the COutPoint of this input (32-byte hash + 4-byte little-endian).
-            let outpoint = inputs[inputIndex].outpoint.data
+            let outpoint = transaction.inputs[inputIndex].outpoint.data
             inputData.append(outpoint)
             // amount (8): value of the previous output spent by this input.
             let amount = prevouts[inputIndex].valueData
@@ -380,7 +354,7 @@ extension BitcoinTransaction {
             let scriptPubKey = prevouts[inputIndex].script.prefixedData
             inputData.append(scriptPubKey)
             // nSequence (4): nSequence of this input.
-            let sequence = inputs[inputIndex].sequence.data
+            let sequence = transaction.inputs[inputIndex].sequence.data
             inputData.append(sequence)
         } else { // If hash_type & 0x80 does not equal SIGHASH_ANYONECANPAY:
             // input_index (4): index of this input in the transaction input vector. Index of the first input is 0.
@@ -400,7 +374,7 @@ extension BitcoinTransaction {
         var outputData = Data()
         if sighashType.isSingle {
             //sha_single_output (32): the SHA256 of the corresponding output in CTxOut format.
-            let shaSingleOutput = Data(SHA256.hash(data: outputs[inputIndex].data))
+            let shaSingleOutput = Data(SHA256.hash(data: transaction.outputs[inputIndex].data))
             outputData.append(shaSingleOutput)
         }
 

--- a/src/bitcoin-base/script/TapscriptExtension.swift
+++ b/src/bitcoin-base/script/TapscriptExtension.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// BIP342: The TapRoot Script (Tapscript) Common Message Extension as defined in BIP342
-struct TapscriptExtension: Equatable {
+public struct TapscriptExtension: Equatable {
     // We define the tapscript message extension ext to BIP341 Common Signature Message, indicated by ext_flag = 1:
     let tapLeafHash: Data // tapleaf_hash (32): the tapleaf hash as defined in BIP341
     let keyVersion: UInt8 // key_version (1): a constant value 0x00 representing the current version of public keys in the tapscript signature opcode execution.

--- a/src/bitcoin-crypto/ecc/SecretKey.swift
+++ b/src/bitcoin-crypto/ecc/SecretKey.swift
@@ -41,11 +41,15 @@ public struct SecretKey: Equatable, CustomStringConvertible {
         .init(self)
     }
 
-    public func sign(_ message: String, signatureType: SignatureType = .schnorr, recoverCompressedKeys: Bool = true) -> Signature? {
+    package var xOnlyPublicKey: PublicKey {
+        .init(self, requireEvenY: true)
+    }
+
+    public func sign(_ message: String, signatureType: SignatureType = .ecdsa, recoverCompressedKeys: Bool = true) -> Signature? {
         .init(message: message, secretKey: self, type: signatureType, recoverCompressedKeys: recoverCompressedKeys)
     }
 
-    public func sign(messageHash: Data, signatureType: SignatureType = .schnorr, recoverCompressedKeys: Bool = true) -> Signature? {
+    public func sign(messageHash: Data, signatureType: SignatureType = .ecdsa, recoverCompressedKeys: Bool = true) -> Signature? {
         .init(messageHash: messageHash, secretKey: self, type: signatureType, recoverCompressedKeys: recoverCompressedKeys)
     }
 

--- a/src/bitcoin-crypto/ecc/Signature.swift
+++ b/src/bitcoin-crypto/ecc/Signature.swift
@@ -10,18 +10,18 @@ public enum SignatureType: Equatable, Sendable {
 /// Elliptic curve SECP256K1 signature supporting both ECDSA and Schnorr algorithms.
 public struct Signature: Equatable, Sendable, CustomStringConvertible {
 
-    public init?(message: String, secretKey: SecretKey, type: SignatureType = .schnorr, recoverCompressedKeys: Bool = true) {
+    public init?(message: String, secretKey: SecretKey, type: SignatureType = .ecdsa, recoverCompressedKeys: Bool = true) {
         guard let messageData = message.data(using: .utf8) else {
             return nil
         }
         self.init(messageData: messageData, secretKey: secretKey, type: type, recoverCompressedKeys: recoverCompressedKeys)
     }
 
-    public init(messageData: Data, secretKey: SecretKey, type: SignatureType, additionalEntropy: Data? = .none, recoverCompressedKeys: Bool = true) {
+    public init(messageData: Data, secretKey: SecretKey, type: SignatureType = .ecdsa, additionalEntropy: Data? = .none, recoverCompressedKeys: Bool = true) {
         self.init(messageHash: getMessageHash(messageData: messageData, type: type), secretKey: secretKey, type: type, additionalEntropy: additionalEntropy, recoverCompressedKeys: recoverCompressedKeys)
     }
 
-    public init(messageHash: Data, secretKey: SecretKey, type: SignatureType, additionalEntropy: Data? = .none, recoverCompressedKeys: Bool = true) {
+    public init(messageHash: Data, secretKey: SecretKey, type: SignatureType = .ecdsa, additionalEntropy: Data? = .none, recoverCompressedKeys: Bool = true) {
         precondition(messageHash.count == Self.hashLength)
         switch type {
         case .ecdsa:
@@ -38,14 +38,14 @@ public struct Signature: Equatable, Sendable, CustomStringConvertible {
         self.type = type
     }
 
-    public init?(_ hex: String, type: SignatureType = .schnorr) {
+    public init?(_ hex: String, type: SignatureType = .ecdsa) {
         guard let data = Data(hex: hex) else {
             return nil
         }
         self.init(data, type: type)
     }
 
-    public init?(_ data: Data, type: SignatureType = .schnorr) {
+    public init?(_ data: Data, type: SignatureType = .ecdsa) {
         switch type {
         case .ecdsa:
             guard data.count >= Self.compactSignatureLength && data.count <= Self.ecdsaSignatureMaxLength else {

--- a/src/bitcoin-wallet/ExtendedKey.swift
+++ b/src/bitcoin-wallet/ExtendedKey.swift
@@ -195,10 +195,10 @@ public extension ExtendedKey {
             secretKey = parsedSecretKey
         } else {
             let publicKeyData = data.prefix(PublicKey.compressedLength)
-            guard let parsedPublicKey = PublicKey(publicKeyData) else {
+            guard let parsedPublicKey = PublicKey(publicKeyData, skipCheck: true) else {
                 throw Error.invalidPublicKeyEncoding
             }
-            guard parsedPublicKey.isPointOnCurve() else {
+            guard parsedPublicKey.check() else {
                 throw Error.invalidPublicKey
             }
             publicKey = parsedPublicKey

--- a/src/bitcoin/Documentation.docc/GettingStarted.md
+++ b/src/bitcoin/Documentation.docc/GettingStarted.md
@@ -77,7 +77,7 @@ We now need to sign the transaction using our secret key.
 let sighash = unsignedTransaction.signatureHash(sighashType: .all, inputIndex: 0, prevout: prevout, scriptCode: prevout.script.data)
 
 // Obtain the signature using our secret key and append the signature hash type.
-let signature = Signature(messageHash: sighash, secretKey: secretKey, type: .ecdsa)
+let signature = Signature(messageHash: sighash, secretKey: secretKey)
 let signatureData = signature.data + [SighashType.all.value]
 
 // Sign our input by including the signature and public key.

--- a/test/bitcoin-base/BIP341Tests.swift
+++ b/test/bitcoin-base/BIP341Tests.swift
@@ -227,7 +227,8 @@ struct BIP341Tests {
         )
 
         var cache = SighashCache()
-        _ = tx.signatureMessageSchnorr(sighashType: SighashType?.none, inputIndex: 0, prevouts: utxosSpent, sighashCache: &cache)
+        let hasher = SignatureHasher(transaction: tx, input: 0, prevouts: utxosSpent, sighashType: SighashType?.none)
+        _ = hasher.signatureMessageSchnorr(sighashCache: &cache)
         if let shaAmounts = cache.shaAmounts, let shaOuts = cache.shaOuts, let shaPrevouts = cache.shaPrevouts, let shaScriptPubKeys = cache.shaScriptPubKeys, let shaSequences = cache.shaSequences {
             #expect(shaAmounts == intermediary.hashAmounts)
             #expect(shaOuts == intermediary.hashOutputs)
@@ -454,7 +455,7 @@ struct BIP341Tests {
             let expectedWitness = testCase.expectedWitness
 
             let secretKey = try #require(SecretKey(secretKeyData))
-            let internalPublicKey = secretKey.publicKey
+            let internalPublicKey = secretKey.xOnlyPublicKey
             let internalPublicKeyData = internalPublicKey.xOnlyData
             #expect(internalPublicKeyData == expectedInternalPublicKey)
 
@@ -464,7 +465,8 @@ struct BIP341Tests {
             let tweakedSecretKey = secretKey.tweakXOnly(tweak)
             #expect(tweakedSecretKey.data == expectedTweakedSecretKey)
 
-            let sigMsg = tx.signatureMessageSchnorr(sighashType: sighashType, inputIndex: inputIndex, prevouts: utxosSpent, sighashCache: &cache)
+            let hasher = SignatureHasher(transaction: tx, input: inputIndex, prevouts: utxosSpent, sighashType: sighashType)
+            let sigMsg = hasher.signatureMessageSchnorr(sighashCache: &cache)
 
             #expect(cache.shaAmountsHit == testCase.intermediary.precomputedUsed.hashAmounts)
             #expect(cache.shaOutsHit == testCase.intermediary.precomputedUsed.hashOutputs)
@@ -473,7 +475,7 @@ struct BIP341Tests {
             #expect(cache.shaScriptPubKeysHit == testCase.intermediary.precomputedUsed.hashScriptPubkeys)
             #expect(sigMsg == expectedSigMsg)
 
-            let sighash = tx.signatureHashSchnorr(sighashType: sighashType, inputIndex: inputIndex, prevouts: utxosSpent, sighashCache: &cache)
+            let sighash = hasher.signatureHashSchnorr(sighashCache: &cache)
             #expect(sighash == expectedSighash)
 
             let hashTypeSuffix: Data

--- a/test/bitcoin-base/InvalidTransactionTests.swift
+++ b/test/bitcoin-base/InvalidTransactionTests.swift
@@ -1639,7 +1639,7 @@ fileprivate let testVectors: [TestVector] = [
     // MARK: - SCRIPT_VERIFY_CONST_SCRIPTCODE tests
     // All transactions are copied from OP_CODESEPARATOR tests in tx_valid.json
 
-    // Test that SignatureHash() removes OP_CODESEPARATOR with FindAndDelete()
+    // Test that SignatureHasher() removes OP_CODESEPARATOR with FindAndDelete()
     .init(
         prevouts: [
             .init(

--- a/test/bitcoin-base/ValidTransactionTests.swift
+++ b/test/bitcoin-base/ValidTransactionTests.swift
@@ -697,7 +697,7 @@ fileprivate let testVectors: [TestVector] = [
 
     // MARK: - OP_CODESEPARATOR tests
 
-    // Test that SignatureHash() removes OP_CODESEPARATOR with FindAndDelete()
+    // Test that SignatureHasher() removes OP_CODESEPARATOR with FindAndDelete()
     .init(
         prevouts: [
             .init(

--- a/test/bitcoin-blockchain/BitcoinServiceTests.swift
+++ b/test/bitcoin-blockchain/BitcoinServiceTests.swift
@@ -41,10 +41,10 @@ struct BitcoinServiceTests {
             ])
 
         // Sign the transaction by first calculating the signature hash.
-        let sighash = try SignatureHash(transaction: unsignedTransaction, input: 0, prevout: prevout).value
+        let sighash = try SignatureHasher(transaction: unsignedTransaction, input: 0, prevout: prevout).value
 
         // Obtain the signature using our secret key and append the signature hash type.
-        let signature = try #require(Signature(messageHash: sighash, secretKey: secretKey, type: .ecdsa))
+        let signature = try #require(Signature(messageHash: sighash, secretKey: secretKey))
         let signatureData = ExtendedSignature(signature, .all).data
 
         // Sign our input by including the signature and public key.

--- a/test/bitcoin-crypto/BitcoinCryptoTests.swift
+++ b/test/bitcoin-crypto/BitcoinCryptoTests.swift
@@ -14,7 +14,7 @@ struct BitcoinCryptoTests {
         #expect(publicKey == publicKeyCopy)
 
         let message = "Hello, Bitcoin!"
-        let signature = try #require(secretKey.sign(message))
+        let signature = try #require(secretKey.sign(message, signatureType: .schnorr))
 
         let isSignatureValid = publicKey.verify(signature, for: message)
         #expect(isSignatureValid)
@@ -36,12 +36,12 @@ struct BitcoinCryptoTests {
         #expect(publicKey == publicKeyCopy)
 
         let message = "Hello, Bitcoin!"
-        let signature = try #require(Signature("c211fc6a0d3b89170af26e1bfcc511de813a01e855b862788e1fa576280a7abc202f1bc1535dc51c54ecbae48dcc9b5752ffa4a8852f7d81aafb695f5efd8876"))
+        let signature = try #require(Signature("c211fc6a0d3b89170af26e1bfcc511de813a01e855b862788e1fa576280a7abc202f1bc1535dc51c54ecbae48dcc9b5752ffa4a8852f7d81aafb695f5efd8876", type: .schnorr))
 
         let isSignatureValid = publicKey.verify(signature, for: message)
         #expect(isSignatureValid)
 
-        let signatureCopy = try #require(secretKey.sign(message))
+        let signatureCopy = try #require(secretKey.sign(message, signatureType: .schnorr))
         #expect(signature == signatureCopy)
 
         // ECDSA signature
@@ -68,7 +68,7 @@ struct BitcoinCryptoTests {
         let secretKey = SecretKey()
 
         let message = "Hello, Bitcoin!"
-        let signature = try #require(secretKey.sign(message))
+        let signature = try #require(secretKey.sign(message, signatureType: .schnorr))
 
         let publicKey = secretKey.publicKey
         #expect(publicKey.matches(secretKey))
@@ -78,7 +78,7 @@ struct BitcoinCryptoTests {
         // Tweak
         let tweak = Data(Hash256.hash(data: "I am Satoshi.".data(using: .utf8)!))
         let tweakedSecretKey = secretKey.tweakXOnly(tweak)
-        let signature2 = try #require(tweakedSecretKey.sign(message))
+        let signature2 = try #require(tweakedSecretKey.sign(message, signatureType: .schnorr))
 
         let tweakedPublicKey = publicKey.tweakXOnly(tweak)
         let valid2 = tweakedPublicKey.verify(signature2, for: message)

--- a/test/bitcoin/DocumentationExamples.swift
+++ b/test/bitcoin/DocumentationExamples.swift
@@ -43,10 +43,10 @@ struct DocumentationExamples {
         // # We now need to sign the transaction using our secret key.
 
         // Sign the transaction by first calculating the signature hash.
-        let sighash = try SignatureHash(transaction: unsignedTransaction, input: 0, prevout: prevout).value
+        let sighash = try SignatureHasher(transaction: unsignedTransaction, input: 0, prevout: prevout).value
 
         // Obtain the signature using our secret key and append the signature hash type.
-        let signature = try #require(Signature(messageHash: sighash, secretKey: secretKey, type: .ecdsa))
+        let signature = try #require(Signature(messageHash: sighash, secretKey: secretKey))
         let signatureData = ExtendedSignature(signature, .all).data
 
         // Sign our input by including the signature and public key.


### PR DESCRIPTION
Refinements to ExtededSignature.
Moved all sighash logic out of transaction and into SignatureHasher. Clearer examples and tests.
Moved remaining logic into Signature and PublicKey. Refactored PublicKey to allow unchecked uncompressed signatures: