### PR TITLE
Signer for public key spends

### DIFF
--- a/src/bitcoin-base/script/ScriptOperation.swift
+++ b/src/bitcoin-base/script/ScriptOperation.swift
@@ -43,7 +43,7 @@ public enum ScriptOperation: Equatable, Sendable {
         }
     }
 
-    var isPush: Bool {
+    public var isPush: Bool {
         switch self {
         case .zero, .oneNegate, .constant(_), .pushBytes(_), .pushData1(_), .pushData2(_), .pushData4(_): true
         default: false

--- a/src/bitcoin-base/script/SignatureHash.swift
+++ b/src/bitcoin-base/script/SignatureHash.swift
@@ -2,7 +2,7 @@ import Foundation
 import BitcoinCrypto
 
 /// A hash function which takes a transaction along with some context and produces a hash value for use with signature operations. The function only accepts a signature hash type which allows for commitments to different parts of the transaction.
-public struct SignatureHash {
+public class SignatureHash {
 
     public init(transaction: BitcoinTransaction, input inputIndex: Int, sigVersion: SigVersion = .base, prevout: TransactionOutput, scriptCode: Data? = .none, tapscriptExtension: TapscriptExtension? = .none, sighashType: SighashType = .all) {
         precondition(inputIndex < transaction.inputs.count)
@@ -16,7 +16,7 @@ public struct SignatureHash {
         self.sighashType = sighashType
     }
 
-    public init(transaction: BitcoinTransaction, input inputIndex: Int, sigVersion: SigVersion = .base, prevouts: [TransactionOutput], scriptCode: Data? = .none, tapscriptExtension: TapscriptExtension? = .none, sighashType: SighashType? = Optional.none) {
+    public init(transaction: BitcoinTransaction, input inputIndex: Int = 0, sigVersion: SigVersion = .base, prevouts: [TransactionOutput], scriptCode: Data? = .none, tapscriptExtension: TapscriptExtension? = .none, sighashType: SighashType? = Optional.none) {
         precondition(inputIndex < transaction.inputs.count)
         precondition(prevouts.count == transaction.inputs.count || (prevouts.count == 1 && (sigVersion == .base || sigVersion == .witnessV0)))
         self.transaction = transaction
@@ -34,13 +34,13 @@ public struct SignatureHash {
     public private(set) var prevouts: [TransactionOutput]
     public private(set) var scriptCode: Data?
     public private(set) var tapscriptExtension: TapscriptExtension?
-    public private(set) var sighashType: SighashType?
+    public var sighashType: SighashType?
 
     public var prevout: TransactionOutput {
         if prevouts.count == 1 { prevouts[0] } else { prevouts[inputIndex] }
     }
 
-    public mutating func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevout: TransactionOutput) {
+    public func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevout: TransactionOutput) {
         if inputIndex != self.inputIndex {
             scriptCode = .none
             tapscriptExtension = .none
@@ -54,13 +54,13 @@ public struct SignatureHash {
         precondition(transaction.inputs.count == 1 || self.sigVersion == .base || self.sigVersion == .witnessV0)
     }
 
-    public mutating func set(input: Int, sigVersion: SigVersion? = .none, prevouts: [TransactionOutput]? = .none, sighashType: SighashType?) {
+    public func set(input: Int, sigVersion: SigVersion? = .none, prevouts: [TransactionOutput]? = .none, sighashType: SighashType?) {
         set(input: input, sigVersion: sigVersion, prevouts: prevouts)
         self.sighashType = sighashType
         precondition(sigVersion == .witnessV1 || sighashType != Optional.none)
     }
 
-    public mutating func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevouts newPrevouts: [TransactionOutput]? = .none) {
+    public func set(input inputIndex: Int, sigVersion: SigVersion? = .none, prevouts newPrevouts: [TransactionOutput]? = .none) {
         if inputIndex != self.inputIndex {
             scriptCode = .none
             tapscriptExtension = .none

--- a/src/bitcoin-base/transaction/BitcoinTransaction+Verification.swift
+++ b/src/bitcoin-base/transaction/BitcoinTransaction+Verification.swift
@@ -113,7 +113,7 @@ extension BitcoinTransaction {
             guard let witnessVersion, let witnessProgram else { preconditionFailure() }
             if witnessVersion == 0 {
                 try verifyWitness(&context, witnessVersion: witnessVersion, witnessProgram: witnessProgram)
-            } else if witnessVersion == 1 && witnessProgram.count == 32 && !isPayToScriptHash {
+            } else if witnessVersion == 1 && witnessProgram.count == PublicKey.xOnlyLength && !isPayToScriptHash {
                 // BIP341
                 try verifyTaproot(&context, witnessVersion: witnessVersion, witnessProgram: witnessProgram)
             } else if config.contains(.discourageUpgradableWitnessProgram) {

--- a/src/bitcoin-wallet/BitcoinAddress.swift
+++ b/src/bitcoin-wallet/BitcoinAddress.swift
@@ -8,6 +8,10 @@ public struct BitcoinAddress: CustomStringConvertible {
     public let isScript: Bool
     public let hash: Data
 
+    public init(_ secretKey: SecretKey, mainnet: Bool = true) {
+        self.init(secretKey.publicKey, mainnet: mainnet)
+    }
+
     public init(_ publicKey: PublicKey, mainnet: Bool = true) {
         isMainnet = mainnet
         isScript = false
@@ -41,6 +45,18 @@ public struct BitcoinAddress: CustomStringConvertible {
         }
         data.append(hash)
         return Base58Encoder().encode(data)
+    }
+
+    public var script: BitcoinScript {
+        if isScript {
+            .payToScriptHash(hash)
+        } else {
+            .payToPublicKeyHash(hash)
+        }
+    }
+
+    public func output(_ value: BitcoinAmount) -> TransactionOutput {
+        .init(value: value, script: script)
     }
 }
 

--- a/src/bitcoin-wallet/BitcoinScript+.swift
+++ b/src/bitcoin-wallet/BitcoinScript+.swift
@@ -1,0 +1,43 @@
+import BitcoinBase
+import BitcoinCrypto
+
+extension BitcoinScript {
+
+    var isPayToPublicKey: Bool {
+        if (size == PublicKey.compressedLength + 2 || size == PublicKey.uncompressedLength + 2),
+           operations.count == 2,
+           case .pushBytes(_) = operations[0],
+           operations[1] == .checkSig { true } else { false }
+    }
+
+    var isPayToPublicKeyHash: Bool {
+        if size == RIPEMD160.Digest.byteCount + 5,
+           operations.count == 5,
+           operations[0] == .dup,
+           operations[1] == .hash160,
+           case .pushBytes(_) = operations[2],
+           operations[3] == .equalVerify,
+           operations[4] == .checkSig { true } else { false }
+    }
+
+    var isPayToTaproot: Bool {
+        if size == PublicKey.xOnlyLength + 2,
+           operations.count == 2,
+           operations[0] == .constant(1),
+           case .pushBytes(_) = operations[1] { true } else { false }
+    }
+
+    var isPayToWitnessKeyHash: Bool {
+        if size == RIPEMD160.Digest.byteCount + 2,
+           operations.count == 2,
+           operations[0] == .zero,
+           case .pushBytes(_) = operations[1] { true } else { false }
+    }
+
+    var isPayToWitnessScriptHash: Bool {
+        if size == SHA256.Digest.byteCount + 2,
+           operations.count == 2,
+           operations[0] == .zero,
+           case .pushBytes(_) = operations[1] { true } else { false }
+    }
+}

--- a/src/bitcoin-wallet/TaprootAddress.swift
+++ b/src/bitcoin-wallet/TaprootAddress.swift
@@ -7,19 +7,32 @@ public struct TaprootAddress: CustomStringConvertible {
     public let network: WalletNetwork
     public let outputKey: PublicKey
 
-    public init(_ publicKey: PublicKey, scripts: [BitcoinScript] = [], network: WalletNetwork = .main) {
+    public init(_ secretKey: SecretKey, scripts: [BitcoinScript] = [], network: WalletNetwork = .main) {
+        self.init(secretKey.taprootInternalKey, scripts: scripts, network: network)
+    }
+
+    public init(_ internalKey: PublicKey, scripts: [BitcoinScript] = [], network: WalletNetwork = .main) {
         precondition(scripts.count <= 8)
         precondition(scripts.allSatisfy { $0.sigVersion == .witnessV1})
+        precondition(internalKey.hasEvenY)
         self.network = network
         if scripts.isEmpty {
-            outputKey = publicKey.taprootOutputKey()
+            outputKey = internalKey.taprootOutputKey()
             return
         }
         let scriptTree = ScriptTree(scripts.map(\.data), leafVersion: 192)
-        outputKey = publicKey.taprootOutputKey(scriptTree)
+        outputKey = internalKey.taprootOutputKey(scriptTree)
     }
 
     public var description: String {
         try! SegwitAddressEncoder(hrp: network.bech32HRP, version: 1).encode(outputKey.xOnlyData)
+    }
+
+    public var script: BitcoinScript {
+        .payToTaproot(outputKey)
+    }
+
+    public func output(_ value: BitcoinAmount) -> TransactionOutput {
+        .init(value: value, script: script)
     }
 }

--- a/src/bitcoin-wallet/TransactionSigner.swift
+++ b/src/bitcoin-wallet/TransactionSigner.swift
@@ -1,0 +1,62 @@
+import BitcoinBase
+import BitcoinCrypto
+
+public class TransactionSigner {
+
+    public init(transaction: BitcoinTransaction, prevouts: [TransactionOutput]) {
+        self.transaction = transaction
+        hasher = .init(transaction: transaction, prevouts: prevouts, sighashType: .all)
+    }
+
+    public init(transaction: BitcoinTransaction, prevouts: [TransactionOutput], sighashType: SighashType? = Optional.none) {
+        self.transaction = transaction
+        hasher = .init(transaction: transaction, prevouts: prevouts, sighashType: sighashType)
+    }
+
+    public private(set) var transaction: BitcoinTransaction
+    private let hasher: SignatureHash
+
+    public var sighashType: SighashType? {
+        get { hasher.sighashType }
+        set { hasher.sighashType = newValue }
+    }
+
+
+    @discardableResult
+    public func sign(input inputIndex: Int, with secretKey: SecretKey) -> BitcoinTransaction {
+        let lockScript = hasher.prevouts[inputIndex].script
+        if lockScript.isPayToPublicKey || lockScript.isPayToPublicKeyHash || lockScript.isPayToWitnessKeyHash || lockScript.isPayToTaproot {
+
+            let sigVersion: SigVersion = if lockScript.isPayToWitnessKeyHash { .witnessV0 }
+                             else if lockScript.isPayToTaproot { .witnessV1 }
+                             else { .base }
+
+            hasher.set(input: inputIndex, sigVersion: sigVersion)
+            let sighash = hasher.value
+
+            guard let signature = if lockScript.isPayToTaproot {
+                secretKey.taprootSecretKey().sign(hash: sighash, signatureType: .schnorr)
+            } else {
+                secretKey.sign(hash: sighash)
+            } else { preconditionFailure() }
+
+            let signatureExt = ExtendedSignature(signature, hasher.sighashType)
+            // For pay-to-public key we just need to sign the hash and add the signature to the input's unlock script.
+            var witnessData = [signatureExt.data]
+            if lockScript.isPayToPublicKeyHash || lockScript.isPayToWitnessKeyHash {
+                // For pay-to-public-key-hash we need to also add the public key to the unlock script.
+                witnessData.append(secretKey.publicKey.data)
+            }
+            if lockScript.isPayToWitnessKeyHash || lockScript.isPayToTaproot {
+                // For pay-to-witness-public-key-hash we sign a different hash and we add the signature and public key to the input's _witness_.
+                transaction = transaction.withWitness(witnessData, input: inputIndex)
+            } else {
+                let ops = witnessData.map { ScriptOperation.pushBytes($0) }
+                transaction = transaction.withUnlockScript(.init(ops), input: inputIndex)
+            }
+        } else {
+            fatalError("Other output types not yet implemented")
+        }
+        return transaction
+    }
+}

--- a/test/bitcoin/WalletDocumentationExamples.swift
+++ b/test/bitcoin/WalletDocumentationExamples.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+import BitcoinCrypto
+import BitcoinBase
+import BitcoinWallet
+
+struct WalletDocumentationExamples {
+
+    @Test func signingTransactions() async throws {
+        let sk = SecretKey()
+
+        let addressA = BitcoinAddress(sk)
+        let addressB = SegwitAddress(sk)
+        let addressC = TaprootAddress(sk)
+
+        // The funding transaction.
+        let fund = BitcoinTransaction(inputs: [.init(outpoint: .coinbase)], outputs: [
+            .init(value: 21_000_000, script: .payToPublicKey(sk.publicKey)),
+            addressA.output(21_000_000),
+            addressB.output(21_000_000),
+            addressC.output(21_000_000),
+        ])
+
+        // A transaction spending all of the outputs from the funding transaction.
+        let spend = BitcoinTransaction(inputs: [
+            .init(outpoint: try #require(fund.outpoint(0))),
+            .init(outpoint: try #require(fund.outpoint(1))),
+            .init(outpoint: try #require(fund.outpoint(2))),
+            .init(outpoint: try #require(fund.outpoint(3))),
+        ], outputs: [
+            .init(value: 21_000_000)
+        ])
+
+        // Do the signing.
+        let prevouts = [fund.outputs[0], fund.outputs[1], fund.outputs[2], fund.outputs[3] ]
+        let signer = TransactionSigner(transaction: spend, prevouts: prevouts, sighashType: .all)
+        signer.sign(input: 0, with: sk)
+        signer.sign(input: 1, with: sk)
+        signer.sign(input: 2, with: sk)
+        signer.sighashType = Optional.none
+        let signed = signer.sign(input: 3, with: sk)
+
+        // Verify transaction signatures.
+        let result = signed.verifyScript(prevouts: prevouts)
+        #expect(result)
+    }
+}


### PR DESCRIPTION
New signer with support for P2PK, P2PKH, P2WPKH and P2TR locking scripts.

New output from address funnctionality for legacy, segwit and taproot addresses. Wallet tests suitable for getting started sample code.

WIP for #240