### PR TITLE
Miniscript module and DSL definition with tests #357

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/BitcoinMiniscript.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BitcoinMiniscript.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcoinMiniscript"
+               BuildableName = "BitcoinMiniscript"
+               BlueprintName = "BitcoinMiniscript"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BitcoinMiniscript"
+            BuildableName = "BitcoinMiniscript"
+            BlueprintName = "BitcoinMiniscript"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/BitcoinPSBT.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BitcoinPSBT.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcoinPSBT"
+               BuildableName = "BitcoinPSBT"
+               BlueprintName = "BitcoinPSBT"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BitcoinPSBT"
+            BuildableName = "BitcoinPSBT"
+            BlueprintName = "BitcoinPSBT"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-bitcoin-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-bitcoin-Package.xcscheme
@@ -147,6 +147,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcoinMiniscript"
+               BuildableName = "BitcoinMiniscript"
+               BlueprintName = "BitcoinMiniscript"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -243,6 +257,16 @@
                BlueprintIdentifier = "BitcoinPSBTTests"
                BuildableName = "BitcoinPSBTTests"
                BlueprintName = "BitcoinPSBTTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BitcoinMiniscriptTests"
+               BuildableName = "BitcoinMiniscriptTests"
+               BlueprintName = "BitcoinMiniscriptTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .library(name: "BitcoinBlockchain", targets: ["BitcoinBlockchain"]),
         .library(name: "BitcoinPSBT", targets: ["BitcoinPSBT"]),
         .library(name: "BitcoinWallet", targets: ["BitcoinWallet"]),
+        .library(name: "BitcoinMiniscript", targets: ["BitcoinMiniscript"]),
         .library(name: "BitcoinBase", targets: ["BitcoinBase"]),
         .library(name: "BitcoinCrypto", targets: ["BitcoinCrypto"]),
         .executable(name: "bcnode", targets: ["BitcoinNode"]),
@@ -41,7 +42,7 @@ let package = Package(
     targets: [
         // Exposed libraries
         .target(name: "Bitcoin",
-            dependencies: ["BitcoinRPC", "BitcoinTransport", "BitcoinBlockchain", "BitcoinPSBT", "BitcoinWallet", "BitcoinBase", "BitcoinCrypto"],
+            dependencies: ["BitcoinRPC", "BitcoinTransport", "BitcoinBlockchain", "BitcoinPSBT", "BitcoinWallet", "BitcoinMiniscript", "BitcoinBase", "BitcoinCrypto"],
             path: "src/bitcoin"),
         .target(name: "BitcoinRPC", dependencies: ["BitcoinTransport", "BitcoinBlockchain", "BitcoinPSBT", "BitcoinWallet", "BitcoinBase", "BitcoinCrypto", "JSONRPC"], path: "src/bitcoin-rpc"),
         .target(
@@ -64,6 +65,7 @@ let package = Package(
             dependencies: ["BitcoinWallet", "BitcoinBase", "BitcoinCrypto"],
             path: "src/bitcoin-psbt"),
         .target(name: "BitcoinWallet", dependencies: ["BitcoinBase", "BitcoinCrypto"], path: "src/bitcoin-wallet"),
+        .target(name: "BitcoinMiniscript", dependencies: ["BitcoinBase", "BitcoinCrypto"], path: "src/bitcoin-miniscript"),
         .target(name: "BitcoinBase", dependencies: ["BitcoinCrypto"], path: "src/bitcoin-base"),
         .target(name: "BitcoinCrypto", dependencies: ["ECCHelper",
                 .product(name: "Crypto", package: "swift-crypto")],
@@ -90,6 +92,7 @@ let package = Package(
         .testTarget(name: "BitcoinBlockchainTests", dependencies: ["BitcoinBlockchain"], path: "test/bitcoin-blockchain"),
         .testTarget(name: "BitcoinPSBTTests", dependencies: ["BitcoinPSBT", "BitcoinWallet", "BitcoinBase"], path: "test/bitcoin-psbt"),
         .testTarget(name: "BitcoinWalletTests", dependencies: ["BitcoinWallet"], path: "test/bitcoin-wallet"),
+        .testTarget(name: "BitcoinMiniscriptTests", dependencies: ["BitcoinMiniscript", "BitcoinBase", "BitcoinCrypto"], path: "test/bitcoin-miniscript"),
         .testTarget(name: "LMDBTests", dependencies: ["LMDB", "BitcoinCrypto"], path: "test/lmdb"),
         .testTarget(name: "BitcoinCryptoTests", dependencies: ["BitcoinCrypto"], path: "test/bitcoin-crypto"),
         .testTarget(name: "BitcoinBaseTests", dependencies: ["BitcoinBase"], path: "test/bitcoin-base",

--- a/src/bitcoin-base/script/ScriptOp.swift
+++ b/src/bitcoin-base/script/ScriptOp.swift
@@ -211,7 +211,7 @@ public enum ScriptOp: Equatable, Sendable {
         case .negate: "OP_NEGATE"
         case .abs: "OP_ABS"
         case .not: "OP_NOT"
-        case .zeroNotEqual: "OP_ZERONOTEQUAL"
+        case .zeroNotEqual: "OP_0NOTEQUAL"
         case .add: "OP_ADD"
         case .sub: "OP_SUB"
         case .mul: "OP_MUL"

--- a/src/bitcoin-blockchain/Documentation.docc/BitcoinBlockchain.md
+++ b/src/bitcoin-blockchain/Documentation.docc/BitcoinBlockchain.md
@@ -65,7 +65,9 @@ await blockchain.stop()
 - [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
 - [Crypto Library][crypto]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Transport Library][transport]
 - [RPC Library][rpc]
 - [Bitcoin Utility (bcutil) Command][bcutil]
@@ -76,7 +78,9 @@ await blockchain.stop()
 [swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
 [crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
 [bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/

--- a/src/bitcoin-crypto/Documentation.docc/BitcoinCrypto.md
+++ b/src/bitcoin-crypto/Documentation.docc/BitcoinCrypto.md
@@ -50,7 +50,9 @@ Encode and decode binary data into and from strings using Base58 or Bech32 encod
 
 - [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Blockchain Library][blockchain]
 - [Transport Library][transport]
 - [RPC Library][rpc]
@@ -61,7 +63,9 @@ Encode and decode binary data into and from strings using Base58 or Bech32 encod
 
 [swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
 [transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/

--- a/src/bitcoin-miniscript/Documentation.docc/BitcoinMiniscript.md
+++ b/src/bitcoin-miniscript/Documentation.docc/BitcoinMiniscript.md
@@ -1,26 +1,32 @@
-# ``BitcoinRPC``
+# ``BitcoinMiniscript``
 
 @Metadata {
-    @DisplayName("Bitcoin RPC")
+    @DisplayName("Bitcoin Miniscript")
     @TitleHeading("Swift Bitcoin Library")
 }
 
-Bitcoin RPC (Remote Procedure Call) contains the basic JSON-RPC types along with implementations for the various commands.
+_Miniscript_ is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more. Bitcoin Miniscript provides a DSL with all the checks and guarantees of Miniscript performed at compile-time.
 
 ## Overview
 
-_BitcoinRPC_ example:
+_BitcoinMiniscript_ example:
 
 ```swift
-import BitcoinRPC
+import BitcoinMiniscript
 
-let command = GetBlockchainInfoCommand(blockchain: satoshiChain)
-let output = await command.run(.init(id: "1", method: "get-blockchain-info", params: .none))
-let result = try #require(output.result)
-guard case .string(let blockchainInfo) = result else { fatalError() }
-print(blockchainInfo)
+// The BOLT #3 received HTLC policy
 
-// {"blocks": 2, "hashes": ["0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",    "23b822b7912cf1b96f1ec5bb07fba40fdd0e889b1f650662f2c0336db9220851"],"headers": 2}
+let key1 = …, key 2…, key3…
+
+// Remote key: key1; Local key: key2; Revocation: key3
+
+// The Miniscript
+let exp = AndOr(PK(key1), OrI(AndV(Vx(PKH(key2)), Hash160(key2HashData)), Older(1008)), PK(key3))
+
+#expect(exp.description == "andor(pk(\(key1Hex)),or_i(and_v(v:pkh(\(key2Hex)),hash160(\(key2Hash))),older(1008)),pk(\(key3Hex)))")
+let asm = BitcoinScript(exp.compiled).asm()
+#expect(asm == "\(key1Hex) OP_CHECKSIG OP_NOTIF \(key3Hex) OP_CHECKSIG OP_ELSE OP_IF OP_DUP OP_HASH160 \(key2Hash) OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_SIZE 20 OP_EQUALVERIFY OP_HASH160 \(key2Hash) OP_EQUAL OP_ELSE f003 OP_CHECKSEQUENCEVERIFY OP_ENDIF OP_ENDIF ")
+
 ```
 
 ## See Also

--- a/src/bitcoin-miniscript/Miniscript.swift
+++ b/src/bitcoin-miniscript/Miniscript.swift
@@ -1,0 +1,772 @@
+import Foundation
+import BitcoinBase
+import BitcoinCrypto
+
+/// Generic miniscript expression.
+///
+/// Every miniscript expression has one of four basic types: ``ExpB``, ``ExpK``, ``ExpV``, ``ExpW``.
+public protocol MiniscriptExp: Sendable, CustomStringConvertible {
+    var compiled: [ScriptOp] { get }
+}
+
+/// B, K or V
+public protocol ExpBKV: MiniscriptExp { }
+
+/// "B" Base expressions. These take their inputs from the top of the stack. When satisfied, they push a nonzero value of up to 4 bytes onto the stack. When dissatisfied, they push an exact 0 onto the stack (if dissatisfaction without aborting is possible at all). This type is used for most expressions, and required for the top level expression. An example is `older(n) = <n> CHECKSEQUENCEVERIFY`.
+public protocol ExpB: ExpBKV { }
+
+/// "K" Key expressions. They again take their inputs from the top of the stack, but instead of verifying a condition directly they always push a public key onto the stack, for which a signature is still required to satisfy the expression. A "K" can be converted into a "B" using the c: wrapper (CHECKSIG). An example is `pk_h(key) = DUP HASH160 <Hash160(key)> EQUALVERIFY`
+public protocol ExpK: ExpBKV { }
+
+/// "V" Verify expressions. Like "B", these take their inputs from the top of the stack. Upon satisfaction however, they continue without pushing anything. They cannot be dissatisfied (will abort instead). A "V" can be obtained using the v: wrapper on a "B" expression, or by combining other "V" expressions using `and_v`, `or_i`, `or_c`, or `andor`. An example is `v:pk(key) = <key> CHECKSIGVERIFY`.
+public protocol ExpV: ExpBKV { }
+
+/// "W" Wrapped expressions. They take their inputs from one below the top of the stack, and push a nonzero (in case of satisfaction) or zero (in case of dissatisfaction) either on top of the stack, or one below. So for example a 3-input "W" would take the stack "A B C D E F" and turn it into "A B F 0" or "A B 0 F" in case of dissatisfaction, and "A B F n" or "A B n F" in case of satisfaction (with n a nonzero value). Every "W" is either `s:B` (`SWAP B`) or `a:B` (`TOALTSTACK B FROMALTSTACK`). An example is `s:pk(key) = SWAP <key> CHECKSIG`.
+public protocol ExpW: MiniscriptExp { }
+
+/// "z" Zero-arg: this expression always consumes exactly 0 stack elements.
+public protocol ModZ: MiniscriptExp { }
+
+/// "o" One-arg: this expression always consumes exactly 1 stack element.
+public protocol ModO: MiniscriptExp { }
+
+/// "n" Nonzero: this expression always consumes at least 1 stack element, no satisfaction for this expression requires the top input stack element to be zero.
+public protocol ModN: MiniscriptExp { }
+
+/// "d" Dissatisfiable: a dissatisfaction for this expression can unconditionally be constructed. This implies the dissatisfaction cannot include any signature or hash preimage, and cannot rely on timelocks being satisfied.
+public protocol ModD: MiniscriptExp { }
+public protocol ModD_: MiniscriptExp { }
+
+extension Never: @retroactive CustomStringConvertible {}
+extension Never: ExpB, ExpW, ModD, ModD_ {
+    public var compiled: [BitcoinBase.ScriptOp] { fatalError() }
+    public var description: String { fatalError() }
+}
+
+/// "u" Unit: when satisfied, this expression will put an exact 1 on the stack (as opposed to any nonzero value).
+public protocol ModU: MiniscriptExp { }
+
+/// Semantics: `false`; Miniscript: `0`;  BitcoinScript: `0`
+public struct Zero: ExpB, ModZ, ModU, ModD {
+    public init() { }
+
+    public var compiled: [ScriptOp] {
+        [.zero]
+    }
+
+    public var description: String { "0" }
+}
+
+/// Semantics: `true`; Miniscript: `1`; BitcoinScript: `1`.
+public struct One: ExpB, ModZ, ModU {
+    public init() { }
+
+    public var compiled: [ScriptOp] {
+        [.constant(1)]
+    }
+
+    public var description: String { "1" }
+}
+
+/// Semantics: `check(key)`; Miniscript: `pk_k(key)`; BitcoinScript: `<key>`.
+public struct PK_K: ExpK, ModO, ModN, ModD, ModU {
+    public init(_ key: PubKey) { self.key = key }
+    let key: PubKey
+
+    public var compiled: [ScriptOp] {
+        // For tapscript should be key.xOnlyData
+        [.pushBytes(key.compressedData!)]
+    }
+
+    public var description: String {
+        "pk_k(\(key.compressedData!.hex))"
+    }
+}
+
+/// Semantics: `check(key)`; Miniscript: `pk_h(key)`; BitcoinScript: `DUP HASH160 <HASH160(key)> EQUALVERIFY`.
+public struct PK_H: ExpK, ModN, ModD, ModU {
+    public init(_ key: PubKey) { self.key = key }
+    let key: PubKey
+
+    public var compiled: [ScriptOp] {
+        guard let keyData = key.compressedData else { // For tapscript should be key.xOnlyData
+            preconditionFailure()
+        }
+        let hash = Data(BitcoinCrypto.Hash160.hash(data: keyData))
+        return [.dup, .hash160,  .pushBytes(hash), .equalVerify]
+    }
+
+    public var description: String {
+        "pk_h(\(key.compressedData!.hex))"
+    }
+}
+
+/// Semantics: `check(key)`; Miniscript: `pk(key) = c:pk_k(key)`; BitcoinScript: `<key> CHECKSIG`.
+public struct PK: ExpB, ModO, ModN, ModD, ModU {
+    public init(_ key: PubKey) { self.key = key }
+    let key: PubKey
+    public var compiled: [ScriptOp] { Cx(PK_K(key)).compiled }
+
+    public var description: String {
+        "pk(\(key.compressedData!.hex))"
+    }
+}
+
+/// Semantics: `check(key)`; Miniscript: `pkh(key) = c:pk_h(key)`; BitcoinScript: `DUP HASH160 <HASH160(key)> EQUALVERIFY CHECKSIG`.
+public struct PKH: ExpB, ModN, ModD, ModU {
+    public init(_ key: PubKey) { self.key = key }
+    let key: PubKey
+    public var compiled: [ScriptOp] { Cx(PK_H(key)).compiled }
+
+    public var description: String {
+        "pkh(\(key.compressedData!.hex))"
+    }
+}
+
+/// Semantics: `nSequence ≥ n (and compatible)`; Miniscript: `older(n)`; BitcoinScript: `<n> CHECKSEQUENCEVERIFY`.
+public struct Older: ExpB, ModZ {
+    public init(_ n: Int) { self.n = n }
+    let n: Int
+
+    public var compiled: [ScriptOp] {
+        [.encodeMinimally(n), .checkSequenceVerify]
+    }
+
+    public var description: String {
+        "older(\(n))"
+    }
+}
+
+/// Semantics: `nLockTime ≥ n (and compatible)`; Miniscript: `after(n)`; BitcoinScript: `<n> CHECKLOCKTIMEVERIFY`.
+public struct After: ExpB, ModZ {
+    public init(_ n: Int) { self.n = n }
+    let n: Int
+
+    public var compiled: [ScriptOp] {
+        [.encodeMinimally(n), .checkLockTimeVerify]
+    }
+
+    public var description: String {
+        "after(\(n))"
+    }
+}
+
+/// Semantics: `len(x) = 32 and SHA256(x) = h`; Miniscript: `sha256(h)`; BitcoinScript: `SIZE <20> EQUALVERIFY SHA256 <h> EQUAL`.
+public struct SHA256: ExpB, ModO, ModN, ModD, ModU {
+
+    public init(_ h: Data) {
+        precondition(h.count == BitcoinCrypto.SHA256.Digest.byteCount)
+        self.h = h
+    }
+    let h: Data
+
+    public var compiled: [ScriptOp] {
+        [.size, .encodeMinimally(0x20), .equalVerify, .sha256, .pushBytes(h), .equal]
+    }
+
+    public var description: String {
+        "sha256(\(h.hex))"
+    }
+}
+
+/// Semantics: `len(x) = 32 and HASH256(x) = h`; Miniscript: `hash256(h)`; BitcoinScript: `SIZE <20> EQUALVERIFY HASH256 <h> EQUAL`.
+public struct Hash256: ExpB, ModO, ModN, ModD, ModU {
+
+    public init(_ h: Data) {
+        precondition(h.count == BitcoinCrypto.Hash256.Digest.byteCount)
+        self.h = h
+    }
+
+    let h: Data
+
+    public var compiled: [ScriptOp] {
+        [.size, .encodeMinimally(0x20), .equalVerify, .hash256, .pushBytes(h), .equal]
+    }
+
+    public var description: String {
+        "hash256(\(h.hex))"
+    }
+}
+
+/// Semantics: `len(x) = 32 and RIPEMD160(x) = h`; Miniscript: `ripemd160(h)`; BitcoinScript: `SIZE <20> EQUALVERIFY RIPEMD160 <h> EQUAL`.
+public struct RIPEMD160: ExpB, ModO, ModN, ModD, ModU {
+
+    public init(_ h: Data) {
+        precondition(h.count == BitcoinCrypto.RIPEMD160.Digest.byteCount)
+        self.h = h
+    }
+
+    let h: Data
+
+    public var compiled: [ScriptOp] {
+        [.size, .encodeMinimally(0x20), .equalVerify, .ripemd160, .pushBytes(h), .equal]
+    }
+
+    public var description: String {
+        "ripemd160(\(h.hex))"
+    }
+}
+
+/// Semantics: `len(x) = 32 and HASH160(x) = h`; Miniscript: `hash160(h)`; BitcoinScript: `SIZE <20> EQUALVERIFY HASH160 <h> EQUAL`.
+public struct Hash160: ExpB, ModO, ModN, ModD, ModU {
+
+    public init(_ h: Data) {
+        precondition(h.count == BitcoinCrypto.Hash160.Digest.byteCount)
+        self.h = h
+    }
+
+    let h: Data
+
+    public var compiled: [ScriptOp] {
+        [.size, .encodeMinimally(0x20), .equalVerify, .hash160, .pushBytes(h), .equal]
+    }
+
+    public var description: String {
+        "hash160(\(h.hex))"
+    }
+}
+
+/// Semantics: `(X and Y) or Z`; Miniscript: `andor(X,Y,Z)`; BitcoinScript: `[X] NOTIF [Z] ELSE [Y] ENDIF`.
+public struct AndOr<X: ExpB, Y: ExpBKV, Z: ExpBKV>: ExpBKV {
+    private init(x: X, y: Y, z: Z) { self.x = x; self.y = y; self.z = z }
+
+    let x: X; let y: Y; let z: Z
+
+    public var compiled: [ScriptOp] {
+        x.compiled + [.notIf] + z.compiled + [.else] + y.compiled + [.endIf]
+    }
+
+    public var description: String {
+        "andor(\(x),\(y),\(z))"
+    }
+}
+
+extension AndOr: ExpB where Y: ExpB, Z: ExpB {
+    public init(_ x: X, _ y: Y, _ z: Z) { self.init(x: x, y: y, z: z) }
+}
+
+extension AndOr: ExpK where Y: ExpK, Z: ExpK {
+    public init(_ x: X, _ y: Y, _ z: Z) { self.init(x: x, y: y, z: z) }
+}
+
+extension AndOr: ExpV where Y: ExpV, Z: ExpV {
+    public init(_ x: X, _ y: Y, _ z: Z) { self.init(x: x, y: y, z: z) }
+}
+
+extension AndOr: ModZ where X: ModZ, Y: ModZ, Z: ModZ { }
+extension AndOr: ModO where X: ModZ, Y: ModO, Z: ModO { }
+// TODO: Work around conflicting conformances :(
+// extension AndOr: ModO where X: ModO, Y: ModZ, Z: ModZ { }
+extension AndOr: ModU where Y: ModU, Z: ModU { }
+extension AndOr: ModD where Z: ModD { }
+
+/// Semantics: `X and Y`; Miniscript: `and_v(X,Y)`; Bitcoin Script: `[X] [Y]`.
+public struct AndV<X: ExpV, Y: ExpBKV>: ExpBKV {
+    public init(_ x: X, _ y: Y) { self.x = x; self.y = y }
+    let x: X, y: Y
+
+    public var compiled: [ScriptOp] {
+        x.compiled + y.compiled
+    }
+
+    public var description: String {
+        "and_v(\(x),\(y))"
+    }
+}
+
+extension AndV: ExpB where Y: ExpB { }
+extension AndV: ExpK where Y: ExpK { }
+extension AndV: ExpV where Y: ExpV { }
+
+extension AndV: ModZ where X: ModZ, Y: ModZ { }
+extension AndV: ModO where X: ModZ, Y: ModO { }
+// TODO: Work around conflicting conformances :(
+// extension AndV: ModO where X: ModO, Y: ModZ { }
+extension AndV: ModN where X: ModN { }
+// TODO: Work around conflicting conformances :(
+// extension AndV: ModN where X: ModZ, Y: ModN { }
+extension AndV: ModU where Y: ModU { }
+
+/// Semantics: `X and Y`; Miniscript: `and_b(X,Y)`; Bitcoin Script: `[X] [Y] BOOLAND`.
+public struct AndB<X: ExpB, Y: ExpW>: ExpB, ModU {
+    public init(_ x: X, _ y: Y) { self.x = x; self.y = y }
+    let x: X, y: Y
+
+    public var compiled: [ScriptOp] {
+        x.compiled + y.compiled + [.boolAnd]
+    }
+
+    public var description: String {
+        "and_b(\(x),\(y))"
+    }
+}
+
+extension AndB: ModZ where X: ModZ, Y: ModZ { }
+extension AndB: ModO where X: ModZ, Y: ModO { }
+// TODO: Work around conflicting conformances :(
+// extension AndB: ModO where X: ModO, Y: ModZ { }
+extension AndB: ModN where X: ModN { }
+// TODO: Work around conflicting conformances :(
+// extension AndB: ModN where X: ModZ, Y: ModN { }
+extension AndB: ModD where X: ModD, Y: ModD { }
+
+/// Semantics: `X and Y`; Miniscript: `and_n(X,Y) = andor(X,Y,0)`; Bitcoin Script: `[X] NOTIF 0 ELSE [Y] ENDIF`.
+public struct AndN<X: ExpB, Y: ExpB>: ExpB {
+    public init(_ x: X, _ y: Y) { self.x = x; self.y = y }
+    let x: X, y: Y
+    public var compiled: [ScriptOp] { AndOr(x, y, Zero()).compiled }
+
+    public var description: String {
+        "and_n(\(x),\(y))"
+    }
+}
+
+/// Semantics: `X or Z`; Miniscript: `or_b(X,Z)`; BitcoinScript: `[X] [Z] BOOLOR`.
+public struct OrB<X: ExpB & ModD, X_: ExpB & ModD_, Z: ExpW & ModD, Z_: ExpW & ModD_>: ExpB, ModD, ModU {
+
+    public init(_ x: X, _ z: Z, _ dummyX: X_? = Never?.none, _ dummyZ: Z_? = Never?.none) {
+        precondition(dummyX == nil)
+        precondition(dummyZ == nil)
+        self._x = x
+        self._z = z
+    }
+
+    public init(_ x: X_, _ z: Z, _ dummyX: X? = Never?.none, _ dummyZ: Z_? = Never?.none) {
+        precondition(dummyX == nil)
+        precondition(dummyZ == nil)
+        self.__x = x
+        self._z = z
+    }
+
+    public init(_ x: X, _ z: Z_, _ dummyX: X_? = Never?.none, _ dummyZ: Z? = Never?.none) {
+        precondition(dummyX == nil)
+        precondition(dummyZ == nil)
+        self._x = x
+        self.__z = z
+    }
+
+    public init(_ x: X_, _ z: Z_, _ dummyX: X? = Never?.none, _ dummyZ: Z? = Never?.none) {
+        precondition(dummyX == nil)
+        precondition(dummyZ == nil)
+        self.__x = x
+        self.__z = z
+    }
+
+    private var _x: X? = nil
+    private var __x: X_? = nil
+    private var _z: Z? = nil
+    private var __z: Z_? = nil
+
+    var x: ExpB { _x ?? __x! }
+    var z: ExpW { _z ?? __z! }
+
+    public var compiled: [ScriptOp] {
+        x.compiled + z.compiled + [.boolOr]
+    }
+
+    public var description: String {
+        "or_b(\(x),\(z))"
+    }
+}
+
+extension OrB: ModZ where X: ModZ, Z: ModZ { }
+extension OrB: ModO where X: ModZ, Z: ModO { }
+// TODO: Work around conflicting conformances :(
+// extension OrB: ModO where X: ModO, Z: ModZ { }
+
+/// Semantics: `X or Z`; Miniscript: `or_c(X,Z)`; BitcoinScript: `[X] NOTIF [Z] ENDIF`.
+public struct OrC<X: ExpB, Z: ExpV>: ExpV {
+    public init(_ x: X, _ z: Z) { self.x = x; self.z = z }
+    let x: X, z: Z
+
+    public var compiled: [ScriptOp] {
+        x.compiled + [.notIf] + z.compiled + [.endIf]
+    }
+
+    public var description: String {
+        "or_c(\(x),\(z))"
+    }
+}
+
+extension OrC: ModZ where X: ModZ, Z: ModZ { }
+extension OrC: ModO where X: ModO, Z: ModZ { }
+
+/// Semantics: `X or Z`; Miniscript: `or_d(X,Z)`; BitcoinScript: `[X] IFDUP NOTIF [Z] ENDIF`.
+public struct OrD<X: ExpB, Z: ExpB>: ExpB {
+    public init(_ x: X, _ z: Z) { self.x = x; self.z = z }
+    let x: X, z: Z
+
+    public var compiled: [ScriptOp] {
+        x.compiled + [.ifDup, .notIf] + z.compiled + [.endIf]
+    }
+
+    public var description: String {
+        "or_d(\(x),\(z))"
+    }
+}
+
+extension OrD: ModZ where X: ModZ, Z: ModZ { }
+extension OrD: ModO where X: ModO, Z: ModZ { }
+extension OrD: ModD where Z: ModD { }
+extension OrD: ModU where Z: ModU { }
+
+/// Semantics: `X or Z`; Miniscript: `or_i(X,Z)`; BitcoinScript: `IF [X] ELSE [Z] ENDIF`.
+public struct OrI<X: ExpBKV, Z: ExpBKV>: ExpBKV {
+
+    private init(x: X, z: Z) {
+        self.x = x
+        self.z = z
+    }
+
+    let x: X, z: Z
+
+    public var compiled: [ScriptOp] {
+        [.if] + x.compiled + [.else] + z.compiled + [.endIf]
+    }
+
+    public var description: String {
+        "or_i(\(x),\(z))"
+    }
+}
+
+extension OrI: ExpB where X: ExpB, Z: ExpB {
+    public init(_ x: X, _ z: Z) { self.init(x: x, z: z) }
+}
+
+extension OrI: ExpK where X: ExpK, Z: ExpK {
+    public init(_ x: X, _ z: Z) { self.init(x: x, z: z) }
+}
+
+extension OrI: ExpV where X: ExpV, Z: ExpV {
+    public init(_ x: X, _ z: Z) { self.init(x: x, z: z) }
+}
+
+extension OrI: ModO where X: ModZ, Z: ModZ { }
+extension OrI: ModU where X: ModU, Z: ModU { }
+extension OrI: ModD where X: ModD { }
+// TODO: Work around conflicting conformances :(
+extension OrI: ModD_ where Z: ModD { }
+
+/// Semantics: `X1 + ... + Xn = k`; Miniscript: `thresh(k,X1,...,Xn)`; BitcoinScript: `[X1] [X2] ADD ... [Xn] ADD ... <k> EQUAL`.
+public struct Thresh<X0: ExpB, X1: ExpW, X2: ExpW, X3: ExpW>: ExpB, ModD, ModU {
+    // TODO: Use paremeter packs!
+
+    public init(_ k: Int, _ x0: X0, _ x1: X1, _ x2: X2, _ x3: X3) {
+        precondition(k >= 1 && k <= 4)
+        self.k = k
+        self.x0 = x0
+        self.x1 = x1
+        self.x2 = x2
+        self.x3 = x3
+    }
+
+    let k: Int
+    let x0: X0
+    let x1: X1, x2: X2, x3: X3
+
+    public var compiled: [ScriptOp] {
+        let k = UInt8(k)
+        return x0.compiled + x1.compiled + [.add] + x2.compiled + [.add] + x3.compiled + [.add] + [.constant(k), .equal]
+    }
+
+    public var description: String {
+        "thresh(\(k),\(x0),\(x1),\(x2),\(x3))"
+    }
+}
+
+extension Thresh: ModZ where X0: ModZ, X1: ModZ, X2: ModZ, X3: ModZ { }
+// TODO: Figure out conformance for ModO when _all are z except one is o_.
+
+/// Semantics: `check(key1) + ... + check(keyn) = k (P2WSH only)`; Miniscript: `multi(k,key1,...,keyn)`; BitcoinScript: `<k> <key1> ... <keyn> <n> CHECKMULTISIG`.
+public struct Multi: ExpB, ModN, ModD, ModU {
+
+    public init(_ k: Int, _ keys: PubKey...) {
+        precondition(keys.count >= 1 && keys.count <= UInt8.max)
+        precondition(k >= 1)
+        precondition(k <= keys.count)
+        self.k = k
+        self.keys = keys
+    }
+
+    let k: Int
+    let keys: [PubKey]
+
+    public var compiled: [ScriptOp] {
+        let k = UInt8(k)
+        let n = UInt8(keys.count)
+        let keysPushBytes = keys
+            .map {
+                guard let keyData = $0.compressedData else { preconditionFailure() }
+                return keyData
+            }
+            .map { ScriptOp.pushBytes($0) }
+        return [.constant(k)] + keysPushBytes + [.constant(n), .checkMultiSig]
+    }
+
+    public var description: String {
+        let keysHex = keys.map(\.compressedData!).map(\.hex).joined(separator: ",")
+        return "multi(\(k),\(keysHex))"
+    }
+}
+
+/// Semantics: `check(key1) + ... + check(keyn) = k (Tapscript only)`; Miniscript: `multi_a(k,key1,...,keyn)`; BitcoinScript: `<key1> CHECKSIG <key2> CHECKSIGADD ... <keyn> CHECKSIGADD <k> NUMEQUAL`.
+public struct MultiA: ExpB, ModD, ModU {
+
+    public init(_ k: Int, _ keys: PubKey...) {
+        precondition(keys.count >= 1 && keys.count <= UInt8.max)
+        precondition(k >= 1)
+        precondition(k <= keys.count)
+        self.k = k
+        self.keys = keys
+    }
+
+    let k: Int
+    let keys: [PubKey]
+
+    public var compiled: [ScriptOp] {
+        let k = UInt8(k)
+        let keysPushBytes = keys.dropFirst()
+            .map(\.xOnlyData)
+            .flatMap {
+                [ScriptOp.pushBytes($0), .checkSigAdd]
+            }
+        return [.pushBytes(keys[0].xOnlyData), .checkSig] + keysPushBytes + [.checkSigAdd, .constant(k), .numEqual]
+    }
+
+    public var description: String {
+        let keysHex = keys.map(\.xOnlyData).map(\.hex).joined(separator: ",")
+        return "multi_a(\(k),\(keysHex))"
+    }
+}
+
+/// Semantics: `X (identities)`; Miniscript: `a:X`; BitcoinScript: `TOALTSTACK [X] FROMALTSTACK`.
+public struct Ax<X: ExpB>: ExpW {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        [.toAltStack] + x.compiled + [.fromAltStack]
+    }
+
+    public var description: String {
+        "a:\(x)"
+    }
+}
+
+extension Ax: ModD where X: ModD { }
+extension Ax: ModU where X: ModU { }
+
+/// Semantics: `X (identities)`; Miniscript: `s:X`; BitcoinScript: `SWAP [X]`.
+public struct Sx<X: ExpB>: ExpW {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        [.swap] + x.compiled
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "s\(xDescription)"
+        } else {
+            return "s:\(xDescription)"
+        }
+    }
+}
+
+extension Sx: ModD where X: ModD { }
+extension Sx: ModU where X: ModU { }
+
+/// Semantics: `X (identities)`; Miniscript: `t:X = and_v(X,1)`; BitcoinScript: `[X] 1`.
+public struct Tx<X: ExpV>: ExpB, ModD, ModU {
+    public init(_ x: X) { self.x = x }
+    let x: X
+    public var compiled: [ScriptOp] { AndV(x, One()).compiled }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "t\(xDescription)"
+        } else {
+            return "t:\(xDescription)"
+        }
+    }
+
+}
+
+extension Tx: ModZ where X: ModZ { }
+extension Tx: ModO where X: ModO { }
+extension Tx: ModN where X: ModN { }
+
+/// Semantics: `X (identities)`; Miniscript: `c:X`; BitcoinScript: `[X] CHECKSIG`.
+public struct Cx<X: ExpK>: ExpB, ModU {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        x.compiled + [.checkSig]
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "c\(xDescription)"
+        } else {
+            return "c:\(xDescription)"
+        }
+    }
+
+}
+
+extension Cx: ModO where X: ModO { }
+extension Cx: ModN where X: ModN { }
+extension Cx: ModD where X: ModD { }
+
+/// Semantics: `X (identities)`; Miniscript: `d:X`; BitcoinScript: `DUP IF [X] ENDIF`.
+public struct Dx<X: ExpV>: ExpB, ModO, ModN, ModD, ModU {
+    // TODO: ModU conformance should be tapscript only. Potential solution: duplicate struct definition?
+
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        [.dup, .if] + x.compiled + [.endIf]
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "d\(xDescription)"
+        } else {
+            return "d:\(xDescription)"
+        }
+    }
+
+}
+
+/// Semantics: `X (identities)`; Miniscript: `v:X`; BitcoinScript: `[X] VERIFY (or VERIFY version of last opcode in [X])`.
+public struct Vx<X: ExpB>: ExpV {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        var xCompiled = x.compiled
+        if let lastOp = xCompiled.popLast() {
+            switch lastOp {
+            case .checkSig:
+                return xCompiled + [.checkSigVerify]
+            case .checkMultiSig:
+                return xCompiled + [.checkMultiSigVerify]
+            case .equal:
+                return xCompiled + [.equalVerify]
+            case .numEqual:
+                return xCompiled + [.numEqualVerify]
+            default:
+                return xCompiled + [lastOp, .verify]
+            }
+        } else {
+            return [.verify]
+        }
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "v\(xDescription)"
+        } else {
+            return "v:\(xDescription)"
+        }
+    }
+}
+
+extension Vx: ModZ where X: ModZ { }
+extension Vx: ModO where X: ModO { }
+extension Vx: ModN where X: ModN { }
+
+/// Semantics: `X (identities)`; Miniscript: `j:X`; BitcoinScript: `SIZE 0NOTEQUAL IF [X] ENDIF`.
+public struct Jx<X: ExpB>: ExpB, ModN, ModD {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        [.size, .zeroNotEqual, .if] + x.compiled + [.endIf]
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "j\(xDescription)"
+        } else {
+            return "j:\(xDescription)"
+        }
+    }
+
+}
+
+extension Jx: ModO where X: ModO { }
+extension Jx: ModU where X: ModU { }
+
+/// Semantics: `X (identities)`; Miniscript: `n:X`; BitcoinScript: `[X] 0NOTEQUAL`.
+public struct Nx<X: ExpB>: ExpB, ModU {
+    public init(_ x: X) { self.x = x }
+    let x: X
+
+    public var compiled: [ScriptOp] {
+        x.compiled + [.zeroNotEqual]
+    }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "n\(xDescription)"
+        } else {
+            return "n:\(xDescription)"
+        }
+    }
+}
+
+extension Nx: ModZ where X: ModZ { }
+extension Nx: ModO where X: ModO { }
+extension Nx: ModN where X: ModN { }
+extension Nx: ModD where X: ModD { }
+
+/// Semantics: `X (identities)`; Miniscript: `l:X = or_i(0,X)`; BitcoinScript: `IF 0 ELSE [X] ENDIF`.
+public struct Lx<X: ExpB>: ExpB, ModD {
+    public init(_ x: X) { self.x = x }
+    let x: X
+    public var compiled: [ScriptOp] { OrI(Zero(), x).compiled }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "l\(xDescription)"
+        } else {
+            return "l:\(xDescription)"
+        }
+    }
+
+}
+
+extension Lx: ModO where X: ModZ { }
+extension Lx: ModU where X: ModU { }
+
+/// Semantics: `X (identities)`; Miniscript: `u:X = or_i(X,0)`; BitcoinScript: `IF [X] ELSE 0 ENDIF`.
+public struct Ux<X: ExpB>: ExpB, ModD {
+    public init(_ x: X) { self.x = x }
+    let x: X
+    public var compiled: [ScriptOp] { OrI(x, Zero()).compiled }
+
+    public var description: String {
+        let xDescription = x.description
+        if let _ = try? /[astcdvjnlu]*\:/.prefixMatch(in: xDescription) {
+            return "u\(xDescription)"
+        } else {
+            return "u:\(xDescription)"
+        }
+    }
+
+}
+
+extension Ux: ModO where X: ModZ { }
+extension Ux: ModU where X: ModU { }

--- a/src/bitcoin-node/Documentation.docc/BitcoinNode.md
+++ b/src/bitcoin-node/Documentation.docc/BitcoinNode.md
@@ -30,7 +30,9 @@ Use `--help` to find out about other subcommands and general usage.
 - [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
 - [Crypto Library][crypto]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Blockchain Library][blockchain]
 - [Transport Library][transport]
 - [RPC Library][rpc]
@@ -41,7 +43,9 @@ Use `--help` to find out about other subcommands and general usage.
 [swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
 [crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
 [transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/

--- a/src/bitcoin-psbt/Documentation.docc/BitcoinPSBT.md
+++ b/src/bitcoin-psbt/Documentation.docc/BitcoinPSBT.md
@@ -1,0 +1,77 @@
+# ``BitcoinPSBT``
+
+@Metadata {
+    @DisplayName("Bitcoin PSBT")
+    @TitleHeading("Swift Bitcoin Library")
+}
+
+Bitcoin PSBT (Partially Signed Bitcoin Transaction) corresponds to the implementation of BIP174, BIP370 and others.
+
+## Overview
+
+_BitcoinPSBT_ example:
+
+```swift
+import BitcoinPSBT
+
+// Declare a PSBT with proprietary info. Serialize and parse again to see that all the information is in fact preserved.
+
+let proprietaryInfo = [
+    "satoshi".data(using: .utf8)! : [
+        ProprietaryKey(type: 0, data: .init([0])) : Data([0, 0, 0]),
+        ProprietaryKey(type: .max, data: .init([1, 2, 3])) : Data([1, 2, 3, 4, 5, 6])
+    ],
+    "hal".data(using: .utf8)! : [
+        ProprietaryKey(type: 101, data: .init([0, 0 , 0])) : Data([1, 0, 1]),
+        ProprietaryKey(type: 1, data: .init([1, 1, 1, 1])) : Data([2, 3, 4, 5, 6])
+    ]
+]
+let fund0 = BitcoinTx(ins: [.init(outpoint: .coinbase)], outs: [.init(value: 3)])
+let fund1 = BitcoinTx(ins: [.init(outpoint: .coinbase)], outs: [.init(value: 2), .init(value: 5)])
+let tx = BitcoinTx(ins: [
+    .init(outpoint: fund0.outpoint(0)),
+    .init(outpoint: fund1.outpoint(1))
+], outs: [
+    .init(value: 1),
+    .init(value: 2),
+    .init(value: 4)
+])
+let psbt = PartiallySignedTx(tx: tx, proprietaryInfo: proprietaryInfo, ins: [
+    .init(
+        prevoutTx: fund0, proprietaryInfo: proprietaryInfo
+    ), .init(
+        prevoutTx: fund1, proprietaryInfo: proprietaryInfo
+    )
+], outs: [
+    .init(proprietaryInfo: proprietaryInfo), .init(proprietaryInfo: proprietaryInfo), .init(proprietaryInfo: proprietaryInfo)
+])
+let psbtData = psbt.binaryData
+let psbt2 = try PartiallySignedTx(binaryData: psbtData)
+#expect(psbt == psbt2)
+```
+
+## See Also
+
+- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
+- [Crypto Library][crypto]
+- [Base Library][base]
+- [Miniscript Library][miniscript]
+- [Wallet Library][wallet]
+- [PSBT Library][psbt]
+- [Blockchain Library][blockchain]
+- [Transport Library][transport]
+- [Bitcoin Utility (bcutil) Command][bcutil]
+- [Bitcoin Node (bcnode) Command][bcnode]
+
+<!-- links -->
+
+[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
+[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
+[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
+[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
+[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
+[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
+[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
+[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/

--- a/src/bitcoin-transport/Documentation.docc/BitcoinTransport.md
+++ b/src/bitcoin-transport/Documentation.docc/BitcoinTransport.md
@@ -79,7 +79,9 @@ await halChain.stop()
 - [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
 - [Crypto Library][crypto]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Blockchain Library][blockchain]
 - [Bitcoin Utility (bcutil) Command][bcutil]
 - [RPC Library][rpc]
@@ -90,7 +92,9 @@ await halChain.stop()
 [swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
 [crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
 [bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/

--- a/src/bitcoin-utility/Documentation.docc/BitcoinUtility.md
+++ b/src/bitcoin-utility/Documentation.docc/BitcoinUtility.md
@@ -158,7 +158,9 @@ Use `--help` to find out about other subcommands and general usage.
 - [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
 - [Crypto Library][crypto]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Blockchain Library][blockchain]
 - [Transport Library][transport]
 - [RPC Library][rpc]
@@ -169,7 +171,9 @@ Use `--help` to find out about other subcommands and general usage.
 [swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
 [crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
 [transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/

--- a/src/bitcoin/Documentation.docc/Bitcoin.md
+++ b/src/bitcoin/Documentation.docc/Bitcoin.md
@@ -28,7 +28,9 @@ The Swift Bitcoin package contains:
 
 - [Crypto Library][crypto]
 - [Base Library][base]
+- [Miniscript Library][miniscript]
 - [Wallet Library][wallet]
+- [PSBT Library][psbt]
 - [Blockchain Library][blockchain]
 - [Transport Library][transport]
 - [RPC Library][rpc]
@@ -39,7 +41,9 @@ The Swift Bitcoin package contains:
 
 [crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
 [base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
+[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
 [wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
+[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
 [blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
 [transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
 [rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/

--- a/src/bitcoin/Documentation.docc/header.html
+++ b/src/bitcoin/Documentation.docc/header.html
@@ -19,7 +19,9 @@ a:hover {
     <a href="/docs/documentation/bitcoin/">Docs</a><span> :</span>
     <a href="/docs/crypto/documentation/bitcoincrypto/">.Crypto</a><span> : </span>
     <a href="/docs/base/documentation/bitcoinbase/">.Base</a><span> :</span>
+    <a href="/docs/miniscript/documentation/bitcoinminiscript/">.Miniscript</a><span> :</span>
     <a href="/docs/wallet/documentation/bitcoinwallet/">.Wallet</a><span> :</span>
+    <a href="/docs/psbt/documentation/bitcoinpsbt/">.PSBT</a><span> :</span>
     <a href="/docs/blockchain/documentation/bitcoinblockchain/">.Blockchain</a><span> :</span>
     <a href="/docs/transport/documentation/bitcointransport/">.Transport</a><span> :</span>
     <a href="/docs/rpc/documentation/bitcoinrpc/">.RPC</a><span> :</span>

--- a/src/bitcoin/Exports.swift
+++ b/src/bitcoin/Exports.swift
@@ -1,6 +1,8 @@
 @_exported import BitcoinTransport
 @_exported import BitcoinBlockchain
+@_exported import BitcoinPSBT
 @_exported import BitcoinWallet
+@_exported import BitcoinMiniscript
 @_exported import BitcoinBase
 @_exported import BitcoinCrypto
 // @_exported import BitcoinRPC

--- a/test/bitcoin-miniscript/Miniscript.swift
+++ b/test/bitcoin-miniscript/Miniscript.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+import BitcoinBase
+import BitcoinCrypto
+import BitcoinMiniscript
+
+struct Miniscript {
+
+    let key1 = PubKey(compressed: Data([0x03, 0x70, 0x0d, 0xa8, 0x3d, 0x6c, 0x7e, 0x20, 0xc8, 0xa7, 0x99, 0x65, 0xa6, 0xb1, 0xc3, 0x5b, 0x97, 0x6a, 0x02, 0x5a, 0x85, 0x0f, 0x72, 0xdd, 0x95, 0x36, 0x37, 0x4d, 0x10, 0x7b, 0x58, 0xbe, 0x4a]))!
+    let key2 = PubKey(compressed: Data([0x02, 0x79, 0xe2, 0x1d, 0x05, 0x07, 0xe0, 0xcf, 0x26, 0x56, 0xfd, 0x73, 0xbe, 0xab, 0xf7, 0xc7, 0x48, 0x7b, 0xc0, 0x31, 0xda, 0x1d, 0x45, 0x81, 0x2d, 0x61, 0xe9, 0x6a, 0xa4, 0x01, 0xdf, 0x14, 0xab]))!
+    let key3 = PubKey(compressed: Data([0x02, 0xe3, 0x07, 0x34, 0xde, 0xd7, 0xff, 0x76, 0x5f, 0x5c, 0x11, 0x15, 0x31, 0x55, 0xfb, 0x38, 0x6c, 0x75, 0xbb, 0x6b, 0x38, 0x99, 0xd4, 0xa5, 0x0f, 0x90, 0xe3, 0xe1, 0xbe, 0xc3, 0x2a, 0xb2, 0x43]))!
+    let key1Hex = "03700da83d6c7e20c8a79965a6b1c35b976a025a850f72dd9536374d107b58be4a"
+    let key2Hex = "0279e21d0507e0cf2656fd73beabf7c7487bc031da1d45812d61e96aa401df14ab"
+    let key3Hex = "02e30734ded7ff765f5c11153155fb386c75bb6b3899d4a50f90e3e1bec32ab243"
+    let key2Hash = "bfebfddcc81414d6997cd3c12872006d64604b07"
+
+    @Test("A single key") func singleKey() {
+        print(SecretKey().pubkey.compressedData!.hex)
+        // The Miniscript
+        let exp = PK(key1)
+
+        #expect(exp.description == "pk(\(key1Hex))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG ")
+    }
+
+    @Test("One of two keys (equally likely)") func oneOfTwoLikely() {
+        // The Miniscript
+        let exp = OrB(PK(key1), Sx(PK(key2)))
+
+        #expect(exp.description == "or_b(pk(\(key1Hex)),s:pk(\(key2Hex)))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_SWAP \(key2Hex) OP_CHECKSIG OP_BOOLOR ")
+    }
+
+    @Test("One of two keys (one likely, one unlikely)") func oneOfTwoUnlikely() {
+        // The Miniscript
+        let exp = OrD(PK(key1),PKH(key2))
+
+        #expect(exp.description == "or_d(pk(\(key1Hex)),pkh(\(key2Hex)))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_IFDUP OP_NOTIF OP_DUP OP_HASH160 \(key2Hash) OP_EQUALVERIFY OP_CHECKSIG OP_ENDIF ")
+    }
+
+    @Test("A user and a 2FA service need to sign off, but after 90 days the user alone is enough") func userPlu2FA() {
+        // The Miniscript
+        let exp = AndV(Vx(PK(key1)), OrD(PK(key2), Older(12960)))
+
+        #expect(exp.description == "and_v(v:pk(\(key1Hex)),or_d(pk(\(key2Hex)),older(12960)))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIGVERIFY \(key2Hex) OP_CHECKSIG OP_IFDUP OP_NOTIF a032 OP_CHECKSEQUENCEVERIFY OP_ENDIF ")
+    }
+
+    @Test("A 3-of-3 that turns into a 2-of-3 after 90 days") func threeOfThree() {
+        // The Miniscript
+        let exp = Thresh(3, PK(key1), Sx(PK(key2)), Sx(PK(key3)), Sx(Lx(Nx(Older(12960)))))
+
+        #expect(exp.description == "thresh(3,pk(\(key1Hex)),s:pk(\(key2Hex)),s:pk(\(key3Hex)),sln:older(12960))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_SWAP \(key2Hex) OP_CHECKSIG OP_ADD OP_SWAP \(key3Hex) OP_CHECKSIG OP_ADD OP_SWAP OP_IF 0 OP_ELSE a032 OP_CHECKSEQUENCEVERIFY OP_0NOTEQUAL OP_ENDIF OP_ADD OP_3 OP_EQUAL ") // "3" swapped for "OP_3"
+    }
+
+    @Test("The BOLT #3 to_local policy") func boltToLocalPolicy() {
+        // The Miniscript
+        let exp = AndOr(PK(key1), Older(1008), PK(key2)) // key1: local; key2: revokation
+
+        #expect(exp.description == "andor(pk(\(key1Hex)),older(1008),pk(\(key2Hex)))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_NOTIF \(key2Hex) OP_CHECKSIG OP_ELSE f003 OP_CHECKSEQUENCEVERIFY OP_ENDIF ")
+    }
+
+    @Test("The BOLT #3 offered HTLC policy") func boltOfferedHTLC() {
+        let key2HashData = Data([0xff, 0xeb, 0xfd, 0xdc, 0xc8, 0x14, 0x14, 0xd6, 0x99, 0x7c, 0xd3, 0xc1, 0x28, 0x72, 0x00, 0x6d, 0x64, 0x60, 0x4b, 0x07])
+
+        // key_revocation = key1
+        // key_remote = key2
+        // key_local = key3
+        // H = hash key2
+
+        // The Miniscript
+        let exp = Tx(OrC(PK(key1), AndV(Vx(PK(key2)), OrC(PK(key3), Vx(Hash160(key2HashData))))))
+
+        #expect(exp.description == "t:or_c(pk(\(key1Hex)),and_v(v:pk(\(key2Hex)),or_c(pk(\(key3Hex)),v:hash160(\(key2HashData.hex)))))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_NOTIF \(key2Hex) OP_CHECKSIGVERIFY \(key3Hex) OP_CHECKSIG OP_NOTIF OP_SIZE 20 OP_EQUALVERIFY OP_HASH160 \(key2HashData.hex) OP_EQUALVERIFY OP_ENDIF OP_ENDIF OP_1 ")
+    }
+
+    @Test("The BOLT #3 received HTLC policy") func boltReceivedHTLC() {
+        let key2HashData = Data([0xbf, 0xeb, 0xfd, 0xdc, 0xc8, 0x14, 0x14, 0xd6, 0x99, 0x7c, 0xd3, 0xc1, 0x28, 0x72, 0x00, 0x6d, 0x64, 0x60, 0x4b, 0x07])
+
+        // The Miniscript
+        let exp = AndOr(PK(key1), OrI(AndV(Vx(PKH(key2)), Hash160(key2HashData)), Older(1008)), PK(key3))
+        // remote key: key1; local key: key2; revocation:key3
+
+        #expect(exp.description == "andor(pk(\(key1Hex)),or_i(and_v(v:pkh(\(key2Hex)),hash160(\(key2Hash))),older(1008)),pk(\(key3Hex)))")
+        let asm = BitcoinScript(exp.compiled).asm()
+        #expect(asm == "\(key1Hex) OP_CHECKSIG OP_NOTIF \(key3Hex) OP_CHECKSIG OP_ELSE OP_IF OP_DUP OP_HASH160 \(key2Hash) OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_SIZE 20 OP_EQUALVERIFY OP_HASH160 \(key2Hash) OP_EQUAL OP_ELSE f003 OP_CHECKSEQUENCEVERIFY OP_ENDIF OP_ENDIF ")
+    }
+}

--- a/tools/generate-docs.sh
+++ b/tools/generate-docs.sh
@@ -1,46 +1,64 @@
 #!/bin/bash
 
 rm -f src/bitcoin-crypto/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-base/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-wallet/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-blockchain/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-transport/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-rpc/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-node/Documentation.docc/theme-settings.json
-rm -f src/bitcoin-utility/Documentation.docc/theme-settings.json
-
 cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-crypto/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-base/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-wallet/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-blockchain/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-transport/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-rpc/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-node/Documentation.docc/
-cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-utility/Documentation.docc/
-
 rm -f src/bitcoin-crypto/Documentation.docc/header.html
-rm -f src/bitcoin-base/Documentation.docc/header.html
-rm -f src/bitcoin-wallet/Documentation.docc/header.html
-rm -f src/bitcoin-blockchain/Documentation.docc/header.html
-rm -f src/bitcoin-transport/Documentation.docc/header.html
-rm -f src/bitcoin-rpc/Documentation.docc/header.html
-rm -f src/bitcoin-node/Documentation.docc/header.html
-rm -f src/bitcoin-utility/Documentation.docc/header.html
-
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-crypto/Documentation.docc/
+
+rm -f src/bitcoin-base/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-base/Documentation.docc/
+rm -f src/bitcoin-base/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-base/Documentation.docc/
+
+rm -f src/bitcoin-miniscript/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-miniscript/Documentation.docc/
+rm -f src/bitcoin-miniscript/Documentation.docc/header.html
+ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-miniscript/Documentation.docc/
+
+rm -f src/bitcoin-wallet/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-wallet/Documentation.docc/
+rm -f src/bitcoin-wallet/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-wallet/Documentation.docc/
+
+rm -f src/bitcoin-psbt/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-psbt/Documentation.docc/
+rm -f src/bitcoin-psbt/Documentation.docc/header.html
+ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-psbt/Documentation.docc/
+
+rm -f src/bitcoin-blockchain/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-blockchain/Documentation.docc/
+rm -f src/bitcoin-blockchain/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-blockchain/Documentation.docc/
+
+rm -f src/bitcoin-transport/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-transport/Documentation.docc/
+rm -f src/bitcoin-transport/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-transport/Documentation.docc/
+
+rm -f src/bitcoin-rpc/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-rpc/Documentation.docc/
+rm -f src/bitcoin-rpc/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-rpc/Documentation.docc/
+
+rm -f src/bitcoin-node/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-node/Documentation.docc/
+rm -f src/bitcoin-node/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-node/Documentation.docc/
+
+rm -f src/bitcoin-utility/Documentation.docc/theme-settings.json
+cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-utility/Documentation.docc/
+rm -f src/bitcoin-utility/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-utility/Documentation.docc/
 
 swift package --allow-writing-to-directory .build generate-documentation --target BitcoinCrypto --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/crypto --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
 swift package --allow-writing-to-directory .build generate-documentation --target BitcoinBase --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/base --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
+swift package --allow-writing-to-directory .build generate-documentation --target BitcoinMiniscript --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/miniscript --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+
 swift package --allow-writing-to-directory .build generate-documentation --target BitcoinWallet --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/wallet --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+
+swift package --allow-writing-to-directory .build generate-documentation --target BitcoinPSBT --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/psbt --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
 swift package --allow-writing-to-directory .build generate-documentation --target BitcoinBlockchain --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/blockchain --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
@@ -52,32 +70,46 @@ swift package --allow-writing-to-directory .build generate-documentation --targe
 
 swift package --allow-writing-to-directory .build generate-documentation --target BitcoinNode --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/bcnode --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
-swift package --allow-writing-to-directory .build generate-documentation --target Bitcoin --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --dependency .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinUtility.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinNode.doccarchive --hosting-base-path docs --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-rm src/bitcoin-crypto/Documentation.docc/theme-settings.json
-rm src/bitcoin-base/Documentation.docc/theme-settings.json
-rm src/bitcoin-wallet/Documentation.docc/theme-settings.json
-rm src/bitcoin-blockchain/Documentation.docc/theme-settings.json
-rm src/bitcoin-transport/Documentation.docc/theme-settings.json
-rm src/bitcoin-rpc/Documentation.docc/theme-settings.json
-rm src/bitcoin-node/Documentation.docc/theme-settings.json
-rm src/bitcoin-utility/Documentation.docc/theme-settings.json
+swift package --allow-writing-to-directory .build generate-documentation --target Bitcoin --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --dependency .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinMiniscript.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinPSBT.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinUtility.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinNode.doccarchive --hosting-base-path docs --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
 rm src/bitcoin-crypto/Documentation.docc/header.html
+rm src/bitcoin-crypto/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-base/Documentation.docc/header.html
+rm src/bitcoin-base/Documentation.docc/theme-settings.json
+
+rm src/bitcoin-miniscript/Documentation.docc/header.html
+rm src/bitcoin-miniscript/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-wallet/Documentation.docc/header.html
+rm src/bitcoin-wallet/Documentation.docc/theme-settings.json
+
+rm src/bitcoin-psbt/Documentation.docc/header.html
+rm src/bitcoin-psbt/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-blockchain/Documentation.docc/header.html
+rm src/bitcoin-blockchain/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-transport/Documentation.docc/header.html
+rm src/bitcoin-transport/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-rpc/Documentation.docc/header.html
+rm src/bitcoin-rpc/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-node/Documentation.docc/header.html
+rm src/bitcoin-node/Documentation.docc/theme-settings.json
+
 rm src/bitcoin-utility/Documentation.docc/header.html
+rm src/bitcoin-utility/Documentation.docc/theme-settings.json
 
 rm -rf $WWW_ROOT
 mkdir -p $WWW_ROOT
 
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive/. $WWW_ROOT/crypto
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive/. $WWW_ROOT/base
+cp -rp .build/plugins/Swift-DocC/outputs/BitcoinMiniscript.doccarchive/. $WWW_ROOT/miniscript
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive/. $WWW_ROOT/wallet
+cp -rp .build/plugins/Swift-DocC/outputs/BitcoinPSBT.doccarchive/. $WWW_ROOT/psbt
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive/. $WWW_ROOT/blockchain
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive/. $WWW_ROOT/transport
 cp -rp .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive/. $WWW_ROOT/rpc


### PR DESCRIPTION
Documentation updated.
Documentation also updated for PSBT #355

```swift
let miniscript = AndOr(PK(key1), OrI(AndV(Vx(PKH(key2)), Hash160(key2HashData)), Older(1008)), PK(key3))
// The script is checked fully on compile time!

// Run on Bitcoin directly. No parsing required!
context.run(miniscript.compiled)
```