### PR TITLE
BIP94 rules (block storm and timewarp mitigation) plus testnet3 rules

### DIFF
--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -29,6 +29,9 @@ public actor BlockchainService: Sendable {
 
     public enum Error: Swift.Error {
         case unsupportedBlockVersion, orphanHeader, insuficientProofOfWork, headerTooOld, headerTooNew, missingCoinbaseTransaction, coinbaseTransactionOverspends, wrongMerkleRoot, invalidTransactionInBlock, dataDirIssue
+
+        /// Block's timestamp is too early on diff adjustment block.
+        case timewarpAttack
     }
 
     public let params: ConsensusParams
@@ -385,9 +388,21 @@ public actor BlockchainService: Sendable {
             throw .headerTooNew
         }
 
-        let target = await getNextWorkRequired(forHeight: await height, newBlockTime: header.time, params: params)
+        let height = await height
+        let previousHeader = await blockIndex.get(at: height)
+        let target = await getNextWorkRequired(lastHeader: previousHeader, newBlockTime: header.time, params: params)
         guard DifficultyTarget(compact: header.target) <= DifficultyTarget(compact: target), try! DifficultyTarget(header.id) <= DifficultyTarget(compact: header.target) else {
             throw .insuficientProofOfWork
+        }
+
+        // Testnet4 and regtest only: Check timestamp against prev for difficulty-adjustment blocks to prevent timewarp attacks (see https://github.com/bitcoin/bitcoin/pull/15482).
+        if params.preventBlockStorms {
+            // Check timestamp for the first block of each difficulty adjustment interval, except the genesis block.
+            if (height + 1) % params.difficultyAdjustmentInterval == 0 {
+                guard header.time.timeIntervalSince1970 >= previousHeader.time.timeIntervalSince1970  - ConsensusParams.maxTimewarp else {
+                    throw .timewarpAttack
+                }
+            }
         }
     }
 
@@ -736,7 +751,7 @@ public actor BlockchainService: Sendable {
         let txs = [coinbaseTx] + mempoolTxs
         let merkleRoot = calculateMerkleRoot(txs)
 
-        let target = await getNextWorkRequired(forHeight: chainTipRef.height, newBlockTime: blockTime, params: params)
+        let target = await getNextWorkRequired(lastHeader: chainTipRef, newBlockTime: blockTime, params: params)
 
         var nonce = initialNonce
         var tries = maxTries
@@ -831,9 +846,9 @@ public actor BlockchainService: Sendable {
         }
     }
 
-    private func getNextWorkRequired(forHeight heightLast: Int, newBlockTime: Date, params: ConsensusParams) async -> Int {
+    private func getNextWorkRequired(lastHeader: BlockRef, newBlockTime: Date, params: ConsensusParams) async -> Int {
+        let heightLast = lastHeader.height
         precondition(heightLast >= 0)
-        let lastHeader = await blockIndex.get(at: heightLast)
         let powLimitTarget = try! DifficultyTarget(Data(params.powLimit.reversed()))
         let proofOfWorkLimit = powLimitTarget.toCompact()
 
@@ -841,8 +856,7 @@ public actor BlockchainService: Sendable {
         if (heightLast + 1) % params.difficultyAdjustmentInterval != 0 {
             if params.powAllowMinDifficultyBlocks {
                 // Special difficulty rule for testnet:
-                // If the new block's timestamp is more than 2* 10 minutes
-                // then allow mining of a min-difficulty block.
+                // If the new block's timestamp is more than 2 * 10 minutes then allow mining of a min-difficulty block.
                 if Int(newBlockTime.timeIntervalSince1970) > Int(lastHeader.time.timeIntervalSince1970) + params.powTargetSpacing * 2 {
                     return proofOfWorkLimit
                 } else {
@@ -863,10 +877,10 @@ public actor BlockchainService: Sendable {
         let heightFirst = heightLast - (params.difficultyAdjustmentInterval - 1)
         precondition(heightFirst >= 0)
         let firstHeader = await blockIndex.get(at: heightFirst) // pindexLast->GetAncestor(nHeightFirst)
-        return calculateNextWorkRequired(lastHeader: lastHeader, firstBlockTime: firstHeader.time, params: params)
+        return await calculateNextWorkRequired(lastHeader: lastHeader, firstBlockTime: firstHeader.time, params: params)
     }
 
-    private func calculateNextWorkRequired(lastHeader: BlockRef, firstBlockTime: Date, params: ConsensusParams) -> Int {
+    private func calculateNextWorkRequired(lastHeader: BlockRef, firstBlockTime: Date, params: ConsensusParams) async -> Int {
         if params.powNoRetargeting {
             return lastHeader.target
         }
@@ -883,7 +897,15 @@ public actor BlockchainService: Sendable {
         // Retarget
         let powLimitTarget = try! DifficultyTarget(Data(params.powLimit.reversed()))
 
-        var new = DifficultyTarget(compact: lastHeader.target)
+        var new: DifficultyTarget
+        if params.preventBlockStorms {
+            // Here we use the first block of the difficulty period. This way the real difficulty is always preserved in the first block as it is not allowed to use the min-difficulty exception.
+            let heightFirst = lastHeader.height - (params.difficultyAdjustmentInterval - 1)
+            let first = await blockIndex.get(at: heightFirst)
+            new = DifficultyTarget(compact: first.target)
+        } else {
+            new = DifficultyTarget(compact: lastHeader.target)
+        }
         precondition(!new.isZero)
         new *= (UInt32(actualTimespan))
         new /= DifficultyTarget(UInt64(params.powTargetTimespan))

--- a/src/bitcoin-blockchain/ConsensusParams.swift
+++ b/src/bitcoin-blockchain/ConsensusParams.swift
@@ -20,11 +20,12 @@ public struct ConsensusParams: Sendable {
     public init(
         chain: String,
         magicBytes: Int,
-        powLimit: Data,
-        powTargetTimespan: Int,
-        powTargetSpacing: Int,
-        powAllowMinDifficultyBlocks: Bool,
-        powNoRetargeting: Bool,
+        powLimit: Data = Data([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        powTargetTimespan: Int = 14 * 24 * 60 * 60, // two weeks
+        powTargetSpacing: Int = 10 * 60,
+        powAllowMinDifficultyBlocks: Bool = false,
+        powNoRetargeting: Bool = false,
+        preventBlockStorms: Bool = false,
         blockSubsidy: Amount = 5_000_000_000,
         genesisMessage: String = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks",
         genesisScript: Script = [.pushBytes(PublicKey.satoshi.uncompressedData!), .checkSig],
@@ -45,6 +46,7 @@ public struct ConsensusParams: Sendable {
         self.powTargetSpacing = powTargetSpacing
         self.powAllowMinDifficultyBlocks = powAllowMinDifficultyBlocks
         self.powNoRetargeting = powNoRetargeting
+        self.preventBlockStorms = preventBlockStorms
         self.blockSubsidy = blockSubsidy
         self.genesisMessage = genesisMessage
         self.genesisScript = genesisScript
@@ -69,6 +71,12 @@ public struct ConsensusParams: Sendable {
     public let powTargetSpacing: Int
     public let powAllowMinDifficultyBlocks: Bool
     public let powNoRetargeting: Bool
+
+    /// BIP94 rule 2 and 3. Testnet 4's "Block Storm" fix and "Time Warp Attack" mitigation.
+    ///
+    /// This is a new rule to address block storms caused by the testnet 20-minute exception.
+    ///
+    public let preventBlockStorms: Bool
 
     /// The initial block subsidy which defaults to 5 billion satoshis or 50 bitcoins.
     public var blockSubsidy = Amount(5_000_000_000)
@@ -106,11 +114,6 @@ public struct ConsensusParams: Sendable {
     public static let mainnet = Self(
         chain: "mainnet",
         magicBytes: 0xd9b4bef9,
-        powLimit: Data([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        powTargetTimespan: 14 * 24 * 60 * 60, // Wrong
-        powTargetSpacing: 10 * 60, // Wrong
-        powAllowMinDifficultyBlocks: true, // Wrong
-        powNoRetargeting: true, // Wrong
         genesisBlockTime: 1231006505,
         genesisBlockNonce: 2083236893,
         genesisBlockTarget: 0x1d00ffff,
@@ -126,11 +129,8 @@ public struct ConsensusParams: Sendable {
     public static let testnet = Self(
         chain: "testnet4",
         magicBytes: 0x283f161c,
-        powLimit: Data([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        powTargetTimespan: 14 * 24 * 60 * 60, // two weeks
-        powTargetSpacing: 10 * 60,
         powAllowMinDifficultyBlocks: true,
-        powNoRetargeting: false,
+        preventBlockStorms: true,
         genesisMessage: "03/May/2024 000000000000000000001ebd58c244970b3aa9d783bb001011fbe8ea8e98e00e",
         genesisScript: [Script.Operation.pushBytes(Data([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])), .checkSig],
         genesisBlockTime: 1714777860,
@@ -146,10 +146,10 @@ public struct ConsensusParams: Sendable {
         chain: "regtest",
         magicBytes: 0xdab5bffa,
         powLimit: Data([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        powTargetTimespan: 14 * 24 * 60 * 60, // two weeks
-        powTargetSpacing: 10 * 60,
+        powTargetTimespan: 24 * 60 * 60, // one day
         powAllowMinDifficultyBlocks: true,
         powNoRetargeting: true,
+        preventBlockStorms: false, // In Bitcoin Core there is a configuration option / command line parameter to set this to true on regtest (will mitigate timewarp attack).
         genesisBlockTime: 1296688602,
         genesisBlockNonce: 2,
         genesisBlockTarget: 0x207fffff,
@@ -160,7 +160,7 @@ public struct ConsensusParams: Sendable {
         chain: "swift-testing",
         magicBytes: 0xdab5bffa,
         powLimit: Data([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        powTargetTimespan: 14 * 24 * 60 * 60, // two weeks
+        powTargetTimespan: 24 * 60 * 60, // one day
         powTargetSpacing: 10 * 60,
         powAllowMinDifficultyBlocks: true,
         powNoRetargeting: true,
@@ -203,5 +203,5 @@ public struct ConsensusParams: Sendable {
     private static let locktimeVerifySequence = 1 << 0
 
     /// Maximum number of seconds that the timestamp of the first block of a difficulty adjustment period is allowed to be earlier than the last block of the previous period (BIP94).
-    private static let maxTimewarp = 600
+    package static let maxTimewarp = TimeInterval(600)
 }


### PR DESCRIPTION
Some updates to consensus paremeters. Smoke tested by sync'ing testnet4 up to 4174 (arbitrary).

Unit tests pending
