### PR TITLE
Network message `sendheaders` implemented on both ends.

### DIFF
--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -346,7 +346,8 @@ public actor BlockchainService: Sendable {
             }
         }
         guard let hitHeight else { return [] }
-        var heightTo = await blockIndex.height // TODO: previously `await validatedHeight`. Double check don't need to consider all headers (including ones missing transactions or not yet validated)
+        let maxHeight = await blockIndex.height
+        var heightTo = maxHeight // TODO: previously `await validatedHeight`. Double check don't need to consider all headers (including ones missing transactions or not yet validated)
         let heightFrom = hitHeight + 1
         guard heightFrom <= heightTo else { return [] }
         if heightTo - heightFrom + 1 > 200 {
@@ -369,9 +370,10 @@ public actor BlockchainService: Sendable {
     }
 
     private func checkHeader(_ header: Block) async throws(Error) {
-        guard header.version == 0x20000000 else {
+        // TODO: Disabling until BIP9 (version bits) is integrated (BIP34, BIP65 and BIP66 need to also be considered
+        /*guard header.version == 0x20000000 else {
             throw .unsupportedBlockVersion
-        }
+        }*/
 
         guard await lastBlockID == header.previous else {
             // TODO: Check for all ancestors

--- a/src/bitcoin-rpc/commands/GetBlockchainInfoRPC.swift
+++ b/src/bitcoin-rpc/commands/GetBlockchainInfoRPC.swift
@@ -7,7 +7,7 @@ extension GetBlockchainInfoRPC {
     public func run(blockchain: BlockchainService) async -> Result {
         let chain = await blockchain.params.chain
         let blocks = await blockchain.validatedHeight
-        let headerIDs = await blockchain.headerIDs
+        let headerHeight = await blockchain.height
         let bestBlockHash = await blockchain.chainTip
 
         let formatter = FloatingPointFormatStyle<Double>().notation(.scientific).precision(.fractionLength(15)) // .locale(US)
@@ -24,7 +24,7 @@ extension GetBlockchainInfoRPC {
         return .init(
             chain: chain,
             blocks: blocks,
-            headers: headerIDs.count - 1,
+            headers: headerHeight, // headerIDs.count - 1,
             bestBlockHash: bestBlockHash!.reversed().hex,
             difficulty: formatter.format(difficulty).lowercased(), // To output `4.656542373906925e-1` instead of 4.6565423739069247e-10
             time: Int(time.timeIntervalSince1970),
@@ -32,8 +32,8 @@ extension GetBlockchainInfoRPC {
             verificationProgress: verificationProgress,
             initialBlockDownload: initialBlockDownload,
             chainwork: chainwork.hex,
-            sizeOnDisk: sizeOnDisk,
-            hashes: headerIDs.map { $0.reversed().hex }
+            sizeOnDisk: sizeOnDisk
+            //hashes: headerIDs.map { $0.reversed().hex }
         )
     }
 }

--- a/src/bitcoin-transport/MessageCommand.swift
+++ b/src/bitcoin-transport/MessageCommand.swift
@@ -67,6 +67,10 @@ public enum MessageCommand: String, RawRepresentable, Sendable {
     /// The payload is a serialized ``HeadersMessage``.
     case headers
 
+    /// Indicates that a node prefers to receive new block announcements via a "headers" message rather than an "inv".
+    /// BIP130
+    case sendheaders
+
     /// The payload is a serialized ``FeeFilterMessage``.
     /// BIP133
     case feefilter

--- a/src/bitcoin-transport/NodeService.swift
+++ b/src/bitcoin-transport/NodeService.swift
@@ -107,7 +107,13 @@ public actor NodeService: Sendable {
                         header.txs = []
                         let items = [header]
                         let headersMessage = HeadersMessage(items: items)
-                        await self.send(.headers, payload: headersMessage.data, to: id)
+                        if peer.prefersHeaders {
+                            await self.send(.headers, payload: headersMessage.data, to: id)
+                        } else {
+                            let inventoryMessage = InventoryMessage(items: [.init(type: .witnessBlock, hash:  block.id)]
+                            )
+                            await self.send(.inv, payload: inventoryMessage.data, to: id)
+                        }
                     }
                 }
             }
@@ -346,6 +352,8 @@ public actor NodeService: Sendable {
             try await processGetHeaders(message, from: id)
         case .headers:
             try await processHeaders(message, from: id)
+        case .sendheaders:
+            try await processSendHeaders(message, from: id)
         case .block:
             try await processBlock(message, from: id)
         case .getdata:
@@ -606,6 +614,16 @@ public actor NodeService: Sendable {
         }
 
         await requestNextMissingBlocks(id)
+
+        // BIP130 delaying `sendheaders` until we don't need more headers
+        if !headersMessage.moreItems, state.peers[id]?.sentSendHeaders == false {
+            enqueue(.sendheaders, to: id)
+        }
+    }
+
+    private func processSendHeaders(_ message: NetworkMessage, from id: PeerID) async throws {
+        guard let _ = state.peers[id] else { return }
+        state.peers[id]!.prefersHeaders = true
     }
 
     func processBlock(_ message: NetworkMessage, from id: PeerID) async throws {

--- a/src/bitcoin-transport/PeerState.swift
+++ b/src/bitcoin-transport/PeerState.swift
@@ -22,6 +22,15 @@ public struct PeerState: Sendable {
     // Information from the version message sent by the peer
     var version = VersionMessage?.none
 
+    /// Whether this peer has sent us a `sendheaders` message.
+    ///
+    /// BIP130
+    var prefersHeaders = false
+
+    /// Whether we have sent this peer a `sendheaders` message.
+    /// BIP130
+    var sentSendHeaders = false
+
     /// BIP339
     var witnessRelayPreferenceSent = false
 

--- a/src/json-rpc/Commands/GetBlockchainInfoRPC.swift
+++ b/src/json-rpc/Commands/GetBlockchainInfoRPC.swift
@@ -5,7 +5,7 @@ public struct GetBlockchainInfoRPC: RPCCommand, Sendable {
 
     public struct Result: Codable, Sendable {
 
-        public init(chain: String, blocks: Int, headers: Int, bestBlockHash: String, difficulty: String, time: Int, medianTime: Int, verificationProgress: Double, initialBlockDownload: Bool, chainwork: String, sizeOnDisk: Int, hashes: [String]) {
+        public init(chain: String, blocks: Int, headers: Int, bestBlockHash: String, difficulty: String, time: Int, medianTime: Int, verificationProgress: Double, initialBlockDownload: Bool, chainwork: String, sizeOnDisk: Int/*, hashes: [String]*/) {
             self.chain = chain
             self.blocks = blocks
             self.headers = headers
@@ -17,7 +17,7 @@ public struct GetBlockchainInfoRPC: RPCCommand, Sendable {
             self.initialBlockDownload = initialBlockDownload
             self.chainwork = chainwork
             self.sizeOnDisk = sizeOnDisk
-            self.hashes = hashes
+            //self.hashes = hashes
         }
 
         /// Current network name (main, test, testnet4,, regtest, signet).
@@ -53,7 +53,7 @@ public struct GetBlockchainInfoRPC: RPCCommand, Sendable {
         /// the estimated size of the block and undo files on disk
         public let sizeOnDisk: Int
 
-        public let hashes: [String]
+        //public let hashes: [String]
     }
 
     public init() {}

--- a/test/bitcoin-transport/BlockSyncTests.swift
+++ b/test/bitcoin-transport/BlockSyncTests.swift
@@ -273,6 +273,10 @@ struct BlockSyncTests {
         let bobHeadersAfter = await bobChain.height + 1
         #expect(bobHeadersAfter == bobHeadersBefore)
 
+        // Bob --(sendheaders)->> …
+        let mBA10_sendheaders = try #require(await bob.popMessage(peerA))
+        #expect(mBA10_sendheaders.command == .sendheaders)
+
         // No Response
         #expect(await bob.popMessage(peerA) == nil)
 
@@ -280,17 +284,17 @@ struct BlockSyncTests {
         try await bob.processMessage(mAB10_getdata, from: peerA)
 
         // Bob --(block)->> …
-        let mBA10_block = try #require(await bob.popMessage(peerA))
-        #expect(mBA10_block.command == .block)
-
-        let bobBlock1 = try Block(mBA10_block.payload)
-        #expect(bobBlock1.txs.count == 1)
-
-        // Bob --(block)->> …
         let mBA11_block = try #require(await bob.popMessage(peerA))
         #expect(mBA11_block.command == .block)
 
-        let bobBlock2 = try Block(mBA11_block.payload)
+        let bobBlock1 = try Block(mBA11_block.payload)
+        #expect(bobBlock1.txs.count == 1)
+
+        // Bob --(block)->> …
+        let mBA12_block = try #require(await bob.popMessage(peerA))
+        #expect(mBA12_block.command == .block)
+
+        let bobBlock2 = try Block(mBA12_block.payload)
         #expect(bobBlock2.txs.count == 1)
 
         // No Response
@@ -298,34 +302,44 @@ struct BlockSyncTests {
 
         await #expect(aliceChain.validatedHeight == 0)
 
+        // … --(sendheaders)->> Alice
         // … --(block)->> Alice
         // … --(block)->> Alice
-        try await alice.processMessage(mBA10_block, from: peerB)
-        #expect(await aliceChain.validatedHeight == 1)
+        try await alice.processMessage(mBA10_sendheaders, from: peerB)
 
         try await alice.processMessage(mBA11_block, from: peerB)
+        #expect(await aliceChain.validatedHeight == 1)
+
+        try await alice.processMessage(mBA12_block, from: peerB)
 
         #expect(await aliceChain.validatedHeight == 2)
 
-        // Alice --(getdata)->> …
-        let mAB11_getdata = try #require(await alice.popMessage(peerB))
-        #expect(mAB11_getdata.command == .getdata)
+        // Alice --(sendheaders)->> …
+        let mAB11_sendheaders = try #require(await alice.popMessage(peerB))
+        #expect(mAB11_sendheaders.command == .sendheaders)
 
-        let aliceGetData1 = try #require(GetDataMessage(mAB11_getdata.payload))
+        // Alice --(getdata)->> …
+        let mAB12_getdata = try #require(await alice.popMessage(peerB))
+        #expect(mAB12_getdata.command == .getdata)
+
+        let aliceGetData1 = try #require(GetDataMessage(mAB12_getdata.payload))
         #expect(aliceGetData1.items.count == 1)
 
+        // … --(sendheaders)->> Bob
+        try await bob.processMessage(mAB11_sendheaders, from: peerA)
+
         // … --(getdata)->> Bob
-        try await bob.processMessage(mAB11_getdata, from: peerA)
+        try await bob.processMessage(mAB12_getdata, from: peerA)
 
         // Bob --(block)->> …
-        let mBA12_block = try #require(await bob.popMessage(peerA))
-        #expect(mBA12_block.command == .block)
+        let mBA13_block = try #require(await bob.popMessage(peerA))
+        #expect(mBA13_block.command == .block)
 
-        let bobBlock3 = try Block(mBA12_block.payload)
+        let bobBlock3 = try Block(mBA13_block.payload)
         #expect(bobBlock3.txs.count == 1)
 
         // … --(block)->> Alice
-        try await alice.processMessage(mBA12_block, from: peerB)
+        try await alice.processMessage(mBA13_block, from: peerB)
 
         #expect(await aliceChain.validatedHeight == 3)
 

--- a/test/bitcoin-transport/NodeBootstrapTests.swift
+++ b/test/bitcoin-transport/NodeBootstrapTests.swift
@@ -561,5 +561,7 @@ private func makePeerState(_ incoming: Bool = false, highBandwidth: Bool = true)
     ps.compactBlocksPreferenceSent = true
     ps.compactBlocksVersionLocked = true
     ps.highBandwidthCompactBlocks = highBandwidth
+    ps.prefersHeaders = true
+    ps.sentSendHeaders = true
     return ps
 }

--- a/test/bitcoin-transport/NodeServiceTests.swift
+++ b/test/bitcoin-transport/NodeServiceTests.swift
@@ -306,6 +306,10 @@ struct NodeServiceTests: ~Copyable {
         let halGetData = try #require(GetDataMessage(messageHS9_getdata.payload))
         #expect(halGetData.items.count == 1)
 
+        // Hal --(sendheaders)->> …
+        let messageHS10_sendheaders = try #require(await hal.popMessage(satoshiPeer))
+        #expect(messageHS10_sendheaders.command == .sendheaders)
+
         // … --(pong)->> Satoshi
         try await satoshi.processMessage(messageHS7_pong, from: halPeer)
 
@@ -323,6 +327,16 @@ struct NodeServiceTests: ~Copyable {
         let satoshiHeightAfter = await satoshiChain.height
         #expect(satoshiHeightAfter == satoshiHeightBefore)
 
+        // Satoshi --(sendheaders)->> …
+        let messageSH10_sendheaders = try #require(await satoshi.popMessage(halPeer))
+        #expect(messageSH10_sendheaders.command == .sendheaders)
+
+        // No Response
+        #expect(await satoshi.popMessage(halPeer) == nil)
+
+        // … --(sendheaders)->> Satoshi
+        try await satoshi.processMessage(messageHS10_sendheaders, from: halPeer)
+
         // No Response
         #expect(await satoshi.popMessage(halPeer) == nil)
 
@@ -330,17 +344,23 @@ struct NodeServiceTests: ~Copyable {
         try await satoshi.processMessage(messageHS9_getdata, from: halPeer)
 
         // Satoshi --(block)->> …
-        let messageSH10_block = try #require(await satoshi.popMessage(halPeer))
-        #expect(messageSH10_block.command == .block)
+        let messageSH11_block = try #require(await satoshi.popMessage(halPeer))
+        #expect(messageSH11_block.command == .block)
 
-        let satoshiBlock = try Block(messageSH10_block.payload)
+        let satoshiBlock = try Block(messageSH11_block.payload)
         #expect(satoshiBlock.txs.count == 1)
 
         let halBlocksBefore = await halChain.validatedHeight + 1
         #expect(halBlocksBefore == 1)
 
+        // … --(sendheaders)->> Hal
+        try await hal.processMessage(messageSH10_sendheaders, from: satoshiPeer)
+
+        // No Response
+        #expect(await hal.popMessage(satoshiPeer) == nil)
+
         // … --(block)->> Hal
-        try await hal.processMessage(messageSH10_block, from: satoshiPeer)
+        try await hal.processMessage(messageSH11_block, from: satoshiPeer)
 
         let halBlocksAfter = await halChain.validatedHeight + 1
         #expect(halBlocksAfter == 2)


### PR DESCRIPTION
Tests updated.
Removed hashes from blockchain information RPC.
Commented out outdated block version interpretation until BIP9
