### PR TITLE
Fixed interpretation of block version field.

### DIFF
--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -369,11 +369,10 @@ public actor BlockchainService: Sendable {
         return headers
     }
 
+    /// Validates the block header.
+    ///
+    /// This function contains similar logic to `ContextualCheckBlockHeader()` in Bitcoin Core's `validation.cpp`.
     private func checkHeader(_ header: Block) async throws(Error) {
-        // TODO: Disabling until BIP9 (version bits) is integrated (BIP34, BIP65 and BIP66 need to also be considered
-        /*guard header.version == 0x20000000 else {
-            throw .unsupportedBlockVersion
-        }*/
 
         guard await lastBlockID == header.previous else {
             // TODO: Check for all ancestors
@@ -405,6 +404,13 @@ public actor BlockchainService: Sendable {
                     throw .timewarpAttack
                 }
             }
+        }
+
+        // Reject blocks with outdated version
+        if header.version < 2 && height >= params.heightInCoinbaseHeight ||
+            (header.version < 3 && height >= params.strictDERSignatureHeight) ||
+            (header.version < 4 && height >= params.cltvHeight) {
+            throw .unsupportedBlockVersion
         }
     }
 
@@ -760,7 +766,6 @@ public actor BlockchainService: Sendable {
         var block: Block
         repeat {
             block = .init(
-                version: 0x20000000,
                 previous: previousBlockHash,
                 merkleRoot: merkleRoot,
                 time: blockTime,

--- a/src/bitcoin-blockchain/ConsensusParams.swift
+++ b/src/bitcoin-blockchain/ConsensusParams.swift
@@ -18,8 +18,8 @@ public struct ConsensusParams: Sendable {
     }
 
     public init(
-        chain: String,
-        magicBytes: Int,
+        chain: String = "mainnet",
+        magicBytes: Int = 0xd9b4bef9,
         powLimit: Data = Data([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
         powTargetTimespan: Int = 14 * 24 * 60 * 60, // two weeks
         powTargetSpacing: Int = 10 * 60,
@@ -30,13 +30,19 @@ public struct ConsensusParams: Sendable {
         genesisMessage: String = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks",
         genesisScript: Script = [.pushBytes(PublicKey.satoshi.uncompressedData!), .checkSig],
         genesisReward: Amount = 5_000_000_000,
-        genesisBlockTime: Int,
-        genesisBlockNonce: Int,
-        genesisBlockTarget: Int,
-        minChainwork: [UInt8] = .init(repeating: 0, count: 32),
-        chainData: ChainData = .init(),
+        genesisBlockTime: Int = 1231006505,
+        genesisBlockNonce: Int = 2083236893,
+        genesisBlockTarget: Int = 0x1d00ffff,
+        minChainwork: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0xe1, 0x86, 0xb7, 0x0e, 0x08, 0x62, 0xc1, 0x93, 0xec, 0x44, 0xd6],
+        /// Data from RPC: getchaintxstats 4096 000000000000000000011c5890365bdbe5d25b97ce0057589acaef4f1a57263f
+        chainData: ChainData = .init(time: 1723649144, txCount: 1059312821, txRate: 6.721086701157182),
         coinbaseMaturity: Int = Self.defaultCoinbaseMaturity,
-        subsidyHalvingInterval: Int = 210_000
+        subsidyHalvingInterval: Int = 210_000,
+        heightInCoinbaseHeight: Int = 227931,
+        cltvHeight: Int = 388381,
+        strictDERSignatureHeight: Int = 363725,
+        csvHeight: Int = 419328,
+        segwitHeight: Int = 481824
     ) {
         precondition(minChainwork.count == 32)
         self.chain = chain
@@ -58,6 +64,11 @@ public struct ConsensusParams: Sendable {
         self.chainData = chainData
         self.subsidyHalvingInterval = subsidyHalvingInterval
         self.coinbaseMaturity = coinbaseMaturity
+        self.heightInCoinbaseHeight = heightInCoinbaseHeight
+        self.cltvHeight = cltvHeight
+        self.strictDERSignatureHeight = strictDERSignatureHeight
+        self.csvHeight = csvHeight
+        self.segwitHeight = segwitHeight
     }
 
     /// The chain identifier: mainnet, testnet, signet, regtest
@@ -99,6 +110,21 @@ public struct ConsensusParams: Sendable {
     // consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
     // consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
 
+    /// BIP34 Height in Coinbase
+    public let heightInCoinbaseHeight: Int
+
+    /// BIP65 `OP_CHECKLOCKTIMEVERIFY`
+    public let cltvHeight: Int
+
+    /// BIP66 Strict DER signatures
+    public let strictDERSignatureHeight: Int
+
+    /// BIP68 Relative lock-time, BIP112 `CHECKSEQUENCEVERIFY`, BIP113 Median time-past
+    public let csvHeight: Int
+
+    /// BIP141 Segregated Witness, BIP143, BIP147 `NULLDUMMY`
+    public let segwitHeight: Int
+
     public var difficultyAdjustmentInterval: Int {
         powTargetTimespan / powTargetSpacing
     }
@@ -111,18 +137,7 @@ public struct ConsensusParams: Sendable {
         )
     }
 
-    public static let mainnet = Self(
-        chain: "mainnet",
-        magicBytes: 0xd9b4bef9,
-        genesisBlockTime: 1231006505,
-        genesisBlockNonce: 2083236893,
-        genesisBlockTarget: 0x1d00ffff,
-
-        minChainwork: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0xe1, 0x86, 0xb7, 0x0e, 0x08, 0x62, 0xc1, 0x93, 0xec, 0x44, 0xd6],
-
-        /// Data from RPC: getchaintxstats 4096 000000000000000000011c5890365bdbe5d25b97ce0057589acaef4f1a57263f
-        chainData: .init(time: 1723649144, txCount: 1059312821, txRate: 6.721086701157182)
-    )
+    public static let mainnet = Self()
 
     /// Testnet (v4)
     /// BIP94
@@ -139,7 +154,12 @@ public struct ConsensusParams: Sendable {
         minChainwork: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xd6, 0xdc, 0xe8, 0x65, 0x1b, 0x60, 0x94, 0xe4, 0xc1],
 
         /// Data from RPC: getchaintxstats 4096 0000000000003ed4f08dbdf6f7d6b271a6bcffce25675cb40aa9fa43179a89f3
-        chainData: .init(time: 1741070246, txCount: 7653966, txRate: 1.239174414591965)
+        chainData: .init(time: 1741070246, txCount: 7653966, txRate: 1.239174414591965),
+        heightInCoinbaseHeight: 1,
+        cltvHeight: 1,
+        strictDERSignatureHeight: 1,
+        csvHeight: 1,
+        segwitHeight: 1
     )
 
     public static let regtest = Self(
@@ -153,7 +173,14 @@ public struct ConsensusParams: Sendable {
         genesisBlockTime: 1296688602,
         genesisBlockNonce: 2,
         genesisBlockTarget: 0x207fffff,
-        subsidyHalvingInterval: 150
+        minChainwork: .init(repeating: 0, count: 32),
+        chainData: .init(),
+        subsidyHalvingInterval: 150,
+        heightInCoinbaseHeight: 1,
+        cltvHeight: 1,
+        strictDERSignatureHeight: 1,
+        csvHeight: 1,
+        segwitHeight: 0
     )
 
     package static let swiftTesting = Self( // Similar to regtest
@@ -167,8 +194,15 @@ public struct ConsensusParams: Sendable {
         genesisBlockTime: 1296688602,
         genesisBlockNonce: 2,
         genesisBlockTarget: 0x207fffff,
+        minChainwork: .init(repeating: 0, count: 32),
+        chainData: .init(),
         coinbaseMaturity: 1,
-        subsidyHalvingInterval: 150
+        subsidyHalvingInterval: 150,
+        heightInCoinbaseHeight: 1,
+        cltvHeight: 1,
+        strictDERSignatureHeight: 1,
+        csvHeight: 1,
+        segwitHeight: 0
     )
 
     // TODO: Define testnet params with magicBytes 0x0709110b

--- a/src/bitcoin-blockchain/block/Block.swift
+++ b/src/bitcoin-blockchain/block/Block.swift
@@ -9,7 +9,7 @@ public struct Block: Equatable, Sendable {
 
     // MARK: - Initializers
 
-    public init(version: Int = 2, previous: Data, merkleRoot: Data, time: Date = .now, target: Int, nonce: Int = 0, txs: [Transaction] = []) {
+    public init(version: Int = Self.versionBitsTopBits, previous: Data, merkleRoot: Data, time: Date = .now, target: Int, nonce: Int = 0, txs: [Transaction] = []) {
         self.version = version
         self.previous = previous
         self.merkleRoot = merkleRoot
@@ -67,6 +67,9 @@ public struct Block: Equatable, Sendable {
 
     public static let idLength = Hash256.Digest.byteCount
     public static let nullParent = Block.ID(count: 32)
+
+    /// BIP9 version bits prefix `0b001…`
+    public static let versionBitsTopBits = 0x20000000
 
     // MARK: - Type Methods
 

--- a/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
@@ -8,7 +8,7 @@ actor PersistentBlockIndex: BlockIndex {
 
     init(path: FilePath, logger: Logger) {
         self.logger = logger
-        env = try! Environment(at: URL(filePath: path.appending("block-index").string), maxDBs: 2, options: [.noSubDir])
+        env = try! Environment(at: URL(filePath: path.appending("block-index").string), maxDBs: 2, pages: 7_000, options: [.noSubDir])
         try! env.createDB(byID)
         height = try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey])) { _, byHeight in
             try byHeight.count - 1

--- a/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
@@ -13,7 +13,7 @@ actor PersistentCoinsIndex: CoinsIndex {
 
     init(path: FilePath, logger: Logger) {
         self.logger = logger
-        env = try! Environment(at: URL(filePath: path.appending("coins").string), maxDBs: 1, options: [.noSubDir])
+        env = try! Environment(at: URL(filePath: path.appending("coins").string), maxDBs: 1, pages: 2_000, options: [.noSubDir])
         try! env.createDB(byID)
     }
 

--- a/src/bitcoin-blockchain/headers/PersistentHeadersIndex.swift
+++ b/src/bitcoin-blockchain/headers/PersistentHeadersIndex.swift
@@ -8,7 +8,7 @@ actor PersistentHeadersIndex: HeadersIndex {
 
     init(path: FilePath, logger: Logger) {
         self.logger = logger
-        env = try! Environment(at: URL(filePath: path.appending("headers").string), maxDBs: 2, options: [.noSubDir])
+        env = try! Environment(at: URL(filePath: path.appending("headers").string), maxDBs: 2, pages: 3_000, options: [.noSubDir])
         try! env.createDB(byID)
         try! env.withTransaction(db: .init(byPositionName, options: [.create, .integerKey])) { _, _ in }
     }

--- a/src/bitcoin-transport/NodeService.swift
+++ b/src/bitcoin-transport/NodeService.swift
@@ -110,7 +110,7 @@ public actor NodeService: Sendable {
                         if peer.prefersHeaders {
                             await self.send(.headers, payload: headersMessage.data, to: id)
                         } else {
-                            let inventoryMessage = InventoryMessage(items: [.init(type: .witnessBlock, hash:  block.id)]
+                            let inventoryMessage = InventoryMessage(items: [.init(type: .block, hash:  block.id)]
                             )
                             await self.send(.inv, payload: inventoryMessage.data, to: id)
                         }

--- a/src/bitcoin/Documentation.docc/Testnet.md
+++ b/src/bitcoin/Documentation.docc/Testnet.md
@@ -98,6 +98,8 @@ We are also disabling version 2 transport as Swift Bitcoin does not support it.
 
 After this we can connect Carol's node to Alice's as usual with `bitcoin-cli addnode alice onetry`. 
 
+To connect from a dockerized Bitcoin Core instance to a local Swift Bitcoin instance instead, ` bitcoin-cli addnode host.docker.internal onetry` can be used.
+
 To check that the synchronization was successful check Alice's blockchain information:
 
 `swift run bcutil -n testnet get-blockchain-info`

--- a/src/lmdb/Environment.swift
+++ b/src/lmdb/Environment.swift
@@ -3,7 +3,10 @@ import Foundation
 
 package struct Environment: ~Copyable {
 
-    package init(at location: URL, maxDBs: Int = 32, maxReaders: Int = 126, mapSize: Int = 10485760, options: Options = []) throws(InitError) {
+    package init(at location: URL, maxDBs: Int = 32, maxReaders: Int = 126, pages: Int = 1_000, options: Options = []) throws(InitError) {
+
+        let pageSize = Int(getpagesize()) // On Apple Sillicon macOS 16_384 bytes
+        let mapSize = pages * pageSize
 
         var handle: OpaquePointer?
         var status = mdb_env_create(&handle)
@@ -22,7 +25,7 @@ package struct Environment: ~Copyable {
             throw .maxReadersIssue
         }
 
-        // Set the size of the memory map.
+        // Set the size of the memory map. Default mapSize: 10_485_760 bytes
         status = mdb_env_set_mapsize(handle, mapSize)
         guard status == MDB_SUCCESS else {
             throw .mapSizeIssue


### PR DESCRIPTION
Using BIP9 version bits prefix by default.
Added BIP9 buried deployments heights.

Increased map size for LMDB environments. Using OS page size with a multiple.

Fixed issue with block announcements being sent with the wrong inv type.

Checking minimum block version on incoming headers.

Fixes #407 as BIP9 deployments have now been deprecated