### PR TITLE
Block undo information now kept

### DIFF
--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -20,6 +20,7 @@ public actor BlockchainService: Sendable {
 
         let dataLocation: DataLocation
 
+        /// Maximum number of attempts to hit the difficulty target when generating blocks.
         public static let defaultMaxTries = 1_000_000
     }
 
@@ -44,7 +45,12 @@ public actor BlockchainService: Sendable {
 
     private var blockStorage: BlockStorage!
     private var blockIndex: BlockIndex!
-    public private(set) var chainTip: Block.ID! = nil
+
+    public var chainTip: Block.ID! {
+        bestBlock?.header.id
+    }
+
+    private(set) var bestBlock: BlockRef! = nil
 
     public private(set) var mempool = [Transaction]()
 
@@ -62,6 +68,7 @@ public actor BlockchainService: Sendable {
     private var finishedIDB = ManagedAtomic<Bool>(false)
 
     public init(params: ConsensusParams = .regtest, config: Config = .init(), logger: Logger = .init(label: "blockchain")) {
+        // TODO: Consider making this init `async throws` and maybe get rid of the life cycle (aka `start()`)
         self.params = params
         self.config = config
         switch config.dataLocation {
@@ -83,7 +90,7 @@ public actor BlockchainService: Sendable {
         self.logger = logger
     }
 
-    public func start() async { // TODO: Throw!
+    public func start() async { // TODO: This needs to throw. Also consider moving logic back to init.
         status = .starting
         defer { status = .running }
 
@@ -109,11 +116,10 @@ public actor BlockchainService: Sendable {
 
         if await blockIndex.height == -1 {
             let genesisBlock = Block.genesis(params)
-            let locator = try! await blockStorage.store(genesisBlock) // TODO: Throw
-            try! await blockIndex.add(genesisBlock, locator: locator, status: .header)
-            chainTip = genesisBlock.id
+            let locator = try! await blockStorage.store(genesisBlock, undo: BlockUndo(spentCoins: [])) // TODO: Throw
+            bestBlock = try! await blockIndex.add(genesisBlock, locator: locator, status: .full)
         } else {
-            chainTip = await blockIndex.chainTip
+            bestBlock = await blockIndex.bestBlock
         }
     }
 
@@ -131,30 +137,24 @@ public actor BlockchainService: Sendable {
     public var genesisBlock: Block {
         get async {
             let locator = await blockIndex.get(at: 0).locator!
-            return try! await blockStorage.retrieve(locator)!
+            let (block, _) = try! await blockStorage.retrieve(locator)!
+            return block
         }
     }
 
     // TODO: Cache this.
     public var synchronized: Bool {
         get async {
-            let height = await blockIndex.height
-            return await validatedHeight == height
+            await blockIndex.height == validatedHeight
         }
     }
 
     public var tipTime: Date {
-        get async {
-            precondition(status == .running)
-            return await blockIndex.get(chainTip).header.time
-        }
+        bestBlock.header.time
     }
 
     public var tipDifficulty: Double {
-        get async {
-            precondition(status == .running)
-            return await blockIndex.get(chainTip).difficulty
-        }
+        bestBlock.difficulty
     }
 
     public var medianTime: Date {
@@ -181,7 +181,7 @@ public actor BlockchainService: Sendable {
     public var chainwork: Data {
         get async {
             precondition(status == .running)
-            return Data(await blockIndex.get(chainTip).chainwork.data.reversed())
+            return Data(bestBlock.chainwork.data.reversed())
         }
     }
 
@@ -194,7 +194,7 @@ public actor BlockchainService: Sendable {
 
     /// Gets a fully validated block by height complete with transactions.
     public func getBlockID(at height: Int) async -> Block.ID? {
-        guard height >= 0, await validatedHeight >= height else {
+        guard height >= 0, validatedHeight >= height else {
             return nil
         }
         return await blockIndex.get(at: height).header.id
@@ -211,14 +211,16 @@ public actor BlockchainService: Sendable {
 
     /// Gets a fully validated block by height complete with transactions.
     public func getBlock(at height: Int) async -> Block? {
-        guard height >= 0, await validatedHeight >= height else {
+        guard height >= 0, validatedHeight >= height else {
             return nil
         }
         let blockRef = await blockIndex.get(at: height)
         guard let locator = blockRef.locator else {
             return nil
         }
-        return try? await blockStorage.retrieve(locator)
+        return if let (block, _) = try? await blockStorage.retrieve(locator) {
+            block
+        } else { nil }
     }
 
     /// Gets a fully validated block by ID complete with transactions.
@@ -227,10 +229,12 @@ public actor BlockchainService: Sendable {
             return nil
         }
         let blockRef = await blockIndex.get(id)
-        guard let locator = blockRef.locator, await validatedHeight >= blockRef.height else {
+        guard let locator = blockRef.locator, validatedHeight >= blockRef.height else {
             return nil
         }
-        return try? await blockStorage.retrieve(locator)
+        return if let (block, _) = try? await blockStorage.retrieve(locator) {
+            block
+        } else { nil }
     }
 
     /// Gets a fully validated block by ID complete with transactions.
@@ -247,7 +251,6 @@ public actor BlockchainService: Sendable {
             return nil
         }
         let ref = await blockIndex.get(id)
-        let validatedHeight = await validatedHeight
         let refNext = if ref.height < validatedHeight {
             await blockIndex.get(at: ref.height + 1)
         } else {
@@ -348,7 +351,7 @@ public actor BlockchainService: Sendable {
             }
         }
         guard let hitHeight else { return [] }
-        let maxHeight = await validatedHeight
+        let maxHeight = validatedHeight
         var heightTo = maxHeight
         let heightFrom = hitHeight + 1
         guard heightFrom <= heightTo else { return [] }
@@ -358,15 +361,7 @@ public actor BlockchainService: Sendable {
         var headers = [Block]()
         for height in heightFrom ... heightTo {
             let blockRef = await blockIndex.get(at: height)
-            let block = if let locator = blockRef.locator {
-                try! await blockStorage.retrieve(locator)!
-                // TODO: handle error properly
-            } else if let header = headers.first(where: { $0.id == blockRef.header.id }) {
-                header
-            } else {
-                preconditionFailure("Could not find header or block.")
-            }
-            headers.append(block.header)
+            headers.append(blockRef.header)
         }
         return headers
     }
@@ -431,7 +426,7 @@ public actor BlockchainService: Sendable {
 
     /// Returns the IDs of the headers missing transactions up to a maximum defined by the function argument.
     public func getNextMissingBlocks(_ numberOfBlocks: Int) async -> [Data] {
-        let startHeight = await validatedHeight + 1
+        let startHeight = validatedHeight + 1
         let maxHeight = await height
         guard startHeight <= maxHeight else { return [] }
         let delta = maxHeight - startHeight + 1
@@ -455,7 +450,7 @@ public actor BlockchainService: Sendable {
             guard let locator = blockRef.locator, blockRef.status == .full else {
                 continue
             }
-            guard let block = try? await blockStorage.retrieve(locator) else {
+            guard let (block, _) = try? await blockStorage.retrieve(locator) else {
                 continue
             }
             ret.append(block)
@@ -464,9 +459,7 @@ public actor BlockchainService: Sendable {
     }
 
     public var validatedHeight: Int {
-        get async {
-            await blockIndex.get(chainTip).height
-        }
+        bestBlock.height
     }
 
     /// The height of the most recent header.
@@ -495,14 +488,14 @@ public actor BlockchainService: Sendable {
         precondition(!tx.isCoinbase)
 
         let valueIn: Amount
-        let nextHeight = await validatedHeight + 1
+        let nextHeight = validatedHeight + 1
 
         var valueInAcc = Amount(0)
         for input in tx.ins {
             let outpoint = input.outpoint
 
             // are the actual inputs available?
-            guard let coin = await coins.get(outpoint) ?? auxCoins[outpoint], !exclude.contains(outpoint) else {
+            guard let coin = try! await coins.get(outpoint) ?? auxCoins[outpoint], !exclude.contains(outpoint) else {
                 throw .inputMissingOrSpent
             }
             guard !coin.isCoinbase || nextHeight - coin.height >= params.coinbaseMaturity else {
@@ -537,7 +530,7 @@ public actor BlockchainService: Sendable {
         for input in tx.ins {
             let outpoint = input.outpoint
 
-            guard let coin = await coins.get(outpoint) ?? auxCoins[outpoint] else {
+            guard let coin = try! await coins.get(outpoint) ?? auxCoins[outpoint] else {
                 preconditionFailure()
             }
             valueIn += coin.out.value
@@ -562,7 +555,7 @@ public actor BlockchainService: Sendable {
             throw .transactionCheckError(error)
         }
 
-        let blockHeight = await validatedHeight + 1
+        let blockHeight = validatedHeight + 1
 
         // TODO: Enforce BIP113 (Median Time Past) for block validation only (not mempool acceptance)
         // let enforceLocktimeMedianTimePast = deploymentActiveAfter(blocks[tip], chainman, Consensus.deploymentCSV)
@@ -578,7 +571,7 @@ public actor BlockchainService: Sendable {
         if !tx.isCoinbase {
             var prevouts = [TransactionOutput]()
             for input in tx.ins {
-                guard let coin = await coins.get(input.outpoint) ?? auxCoins[input.outpoint] else {
+                guard let coin = try! await coins.get(input.outpoint) ?? auxCoins[input.outpoint] else {
                     preconditionFailure() // Already checked in checkTransactionInputs
                 }
                 prevouts.append(coin.out)
@@ -595,33 +588,50 @@ public actor BlockchainService: Sendable {
         }
     }
 
+    /// If we have a header in our index it updates it's validation. If not it adds the block to the index. Adds the block to storage along with undo information and updates coins (chainstate).
     private func connectBlock(_ block: Block) async {
         // TODO: This function does not yet support paralell block download
 
+        let previousRef: BlockRef?
+        if block.previous == Block.nullParent {
+            previousRef = nil
+        } else if await blockIndex.has(block.previous) {
+            previousRef = await blockIndex.get(block.previous)
+        } else {
+            logger.error("Could not connect block because parent is missing from index.")
+            return
+        }
+
+        let newBlockHeight = if let previousRef { previousRef.height + 1} else { 0 }
+
+        var outpointsToRemove = [Outpoint]()
+        for tx in block.txs {
+            for input in tx.ins {
+                outpointsToRemove.append(input.outpoint)
+            }
+        }
+        var newCoins = [Outpoint : UnspentOutput]()
+        for tx in block.txs {
+            for (i, out) in tx.outs.enumerated() {
+                let outpoint = Outpoint(tx: tx.id, out: i)
+                if outpointsToRemove.contains(outpoint) {
+                    continue // Spend from the same block
+                }
+                newCoins[outpoint] = .init(out, height: newBlockHeight, isCoinbase: tx.isCoinbase)
+            }
+        }
+        let spentCoins = try! await coins.update(remove: outpointsToRemove, add: newCoins)
+        let blockUndo = BlockUndo(spentCoins: spentCoins)
+
         // Add block
-        let locator = try! await blockStorage.store(block) // TODO: throw
-        let blockRef: BlockRef
-        if await blockIndex.has(block.id) {
-            blockRef = await blockIndex.get(block.id)
+        let locator = try! await blockStorage.store(block, undo: blockUndo) // TODO: throw
+        bestBlock = if await blockIndex.has(block.id) {
             await blockIndex.update(block.id, locator: locator, status: .full)
         } else {
             /// We can use `try!` because the header has already been verified to have an existing parent in our chain.
-            blockRef = try! await blockIndex.add(block, locator: locator, status: .full)
+            try! await blockIndex.add(block, locator: locator, status: .full)
         }
-        chainTip = block.id
         logger.info("New tip \(block.idHex)")
-
-        // Remove available coins
-        for tx in block.txs {
-            // Remove coins
-            for input in tx.ins {
-                try! await coins.remove(input.outpoint)
-            }
-            // Add coins
-            for (i, out) in tx.outs.enumerated() {
-                await coins.add(.init(out, height: blockRef.height, isCoinbase: tx.isCoinbase), for: .init(tx: tx.id, out: i))
-            }
-        }
 
         let blockCopy = block
         // Notify other nodes of new tip
@@ -637,9 +647,7 @@ public actor BlockchainService: Sendable {
     }
 
     public func processBlock(_ block: Block) async throws(Error) {
-
-        let chainTipRef = await blockIndex.get(chainTip)
-        let nextTipHeight = chainTipRef.height + 1
+        let nextTipHeight = bestBlock.height + 1
 
         let synchronized = await synchronized
         if !synchronized {
@@ -647,12 +655,7 @@ public actor BlockchainService: Sendable {
             if block.id != fistNonBlockHeader.header.id {
                 // New block does not match pre-existing header for block:
                 // Replace block entirely and mark all subsequent blocks as stale
-                let removed = await blockIndex.removeAll(from: nextTipHeight)
-                for r in removed {
-                    if let locator = r.locator {
-                        await blockStorage.remove(locator) // Will only remove from cache, not storage
-                    }
-                }
+                await blockIndex.removeAll(from: nextTipHeight)
             }
         }
 
@@ -702,7 +705,7 @@ public actor BlockchainService: Sendable {
         }
 
         // Check coinbase
-        let nextHeight = await validatedHeight + 1
+        let nextHeight = validatedHeight + 1
         let blockReward = getBlockSubsidy(nextHeight) + fees
         // We allow for a portion of the block reward to be left unclaimed.
         guard blockReward >= coinbaseTx.valueOut else {
@@ -741,6 +744,34 @@ public actor BlockchainService: Sendable {
         mempoolCoins = mpCoins
     }
 
+    public func undoLastBlock() async throws  {
+        guard await synchronized else {
+            return
+        }
+        guard let locator = bestBlock.locator else {
+            preconditionFailure("The chain tip block must have a disk locator")
+        }
+        guard let (block, undo) = try await blockStorage.retrieve(locator) else {
+            preconditionFailure("The chain tip block must exist on disk along with undo information")
+        }
+        var outpointsToRemove = [Outpoint]()
+        var newCoins = [Outpoint : UnspentOutput]()
+        var undoIndex = 0
+        for tx in block.txs {
+            for input in tx.ins {
+                if let coin = undo.spentCoins[undoIndex] {
+                    newCoins[input.outpoint] = coin
+                }
+                undoIndex += 1
+            }
+            for i in tx.outs.indices {
+                outpointsToRemove.append(.init(tx: tx.id, out: i))
+            }
+        }
+        try await coins.update(remove: outpointsToRemove, add: newCoins)
+        bestBlock = await blockIndex.undoLastBlock()
+    }
+
     @discardableResult public func generateToScript(_ script: Script, blocks: Int = 1, maxTries: Int = Config.defaultMaxTries, blockTime: Date? = nil) async -> [Block.ID] {
         var ids = [Block.ID]()
         for _ in 0 ..< blocks {
@@ -766,7 +797,6 @@ public actor BlockchainService: Sendable {
             // Waiting for pending block transactions for known headers
             preconditionFailure("Chain cannot contain unvalidated blocks.")
         }
-        let chainTipRef = await blockIndex.get(chainTip)
         let witnessMerkleRoot = calculateWitnessMerkleRoot(mempool)
 
         let mempoolTxs = mempool
@@ -778,13 +808,13 @@ public actor BlockchainService: Sendable {
         }
 
         let blockReward = params.blockSubsidy + totalFees
-        let coinbaseTx = Transaction.coinbase(version: txVersion, blockHeight: chainTipRef.height + 1, out: .init(value: blockReward, script: script), witnessMerkleRoot: witnessMerkleRoot, tag: tag)
+        let coinbaseTx = Transaction.coinbase(version: txVersion, blockHeight: bestBlock.height + 1, out: .init(value: blockReward, script: script), witnessMerkleRoot: witnessMerkleRoot, tag: tag)
 
-        let previousBlockHash = chainTip!
+        let previousBlockHash = bestBlock.header.id
         let txs = [coinbaseTx] + mempoolTxs
         let merkleRoot = calculateMerkleRoot(txs)
 
-        let target = await getNextWorkRequired(lastHeader: chainTipRef, newBlockTime: blockTime, params: params)
+        let target = await getNextWorkRequired(lastHeader: bestBlock, newBlockTime: blockTime, params: params)
 
         var nonce = initialNonce
         var tries = maxTries
@@ -824,7 +854,7 @@ public actor BlockchainService: Sendable {
             }
         }
         for locator in await blockIndex.locators {
-            guard let block = try? await blockStorage.retrieve(locator) else {
+            guard let (block, _) = try? await blockStorage.retrieve(locator) else {
                 continue
             }
             for tx in block.txs {
@@ -842,25 +872,30 @@ public actor BlockchainService: Sendable {
 
     /// Gets a transaction by ID looking into mempool and blocks.
     public func getTransaction(_ id: Transaction.ID) async -> Transaction? {
-        await getTransactions([id]).first
+        for tx in mempool {
+            if id == tx.id {
+                return tx
+            }
+        }
+        for locator in await blockIndex.locators {
+            guard let (block, _) = try! await blockStorage.retrieve(locator) else {
+                continue
+            }
+            for tx in block.txs {
+                if id == tx.id {
+                    return tx
+                }
+            }
+        }
+        return nil
     }
 
-    /// Finds transactions in mempool and blocks which match any of the provided IDs.
+    /// Finds transactions in mempool which match any of the provided IDs.
     public func getTransactions(_ ids: [Transaction.ID]) async -> [Transaction] {
         var ret = [Transaction]()
         for tx in mempool {
             if ids.contains(tx.id) {
                 ret.append(tx)
-            }
-        }
-        for locator in await blockIndex.locators {
-            guard let block = try? await blockStorage.retrieve(locator) else {
-                continue
-            }
-            for tx in block.txs {
-                if ids.contains(tx.id) {
-                    ret.append(tx)
-                }
             }
         }
         return ret
@@ -876,6 +911,10 @@ public actor BlockchainService: Sendable {
             }
             return mempool[i]
         }
+    }
+
+    public func currentUTXOSet() async -> [Outpoint : UnspentOutput] {
+        await coins.all
     }
 
     private func getNextWorkRequired(lastHeader: BlockRef, newBlockTime: Date, params: ConsensusParams) async -> Int {
@@ -961,7 +1000,7 @@ public actor BlockchainService: Sendable {
     }
 
     private func getMedianTimePast(at height: Int? = nil) async -> Date {
-        let maxHeight = await blockIndex.get(chainTip).height
+        let maxHeight = bestBlock.height
         let height = height ?? maxHeight
         precondition(height >= 0 && height <= maxHeight)
         let startHeight = max(height - 11, 0)
@@ -972,7 +1011,7 @@ public actor BlockchainService: Sendable {
     }
 
     private func guessVerificationProgress(for height: Int? = nil) async -> Double {
-        let maxHeight = await blockIndex.get(chainTip).height
+        let maxHeight = bestBlock.height
         let height = height ?? maxHeight
         precondition(height >= 0 && height <= maxHeight)
 
@@ -1000,15 +1039,13 @@ public actor BlockchainService: Sendable {
         if await blockStorage.status == .starting { return true }
 
         // This is for the active chain only.
-        if chainTip == nil { return true }
+        if bestBlock == nil { return true }
 
-        let blockRef = await blockIndex.get(chainTip)
-
-        if try! DifficultyTarget(params.minChainwork.reversed()) > blockRef.chainwork { return true }
+        if try! DifficultyTarget(params.minChainwork.reversed()) > bestBlock.chainwork { return true }
 
         let maxTipAge = TimeInterval(24 * 60 * 60) // 24 hours
         let maxTipTime = Date(timeIntervalSince1970: nowSeconds() - maxTipAge)
-        if (blockRef.header.time < maxTipTime ) { return true }
+        if (bestBlock.header.time < maxTipTime ) { return true }
 
         logger.info("Leaving InitialBlockDownload (latching to false)")
         finishedIDB.store(true, ordering: .relaxed)
@@ -1023,7 +1060,7 @@ public actor BlockchainService: Sendable {
         // evaluated is what is used.
         // Thus if we want to know if a transaction can be part of the
         // *next* block, we need to use one more than chainActive.Height()
-        let nextBlockHeight = await blockIndex.get(chainTip).height + 1
+        let nextBlockHeight = bestBlock.height + 1
         var heights = [Int]()
         // pcoinsTip contains the UTXO set for chainActive.Tip()
         for input in tx.ins {

--- a/src/bitcoin-blockchain/UnspentOutput.swift
+++ b/src/bitcoin-blockchain/UnspentOutput.swift
@@ -3,13 +3,13 @@ import BitcoinCrypto
 import BitcoinBase
 
 /// A reference to an unspent transaction output (aka _UTXO_).
-struct UnspentOutput: Equatable, Sendable {
+public struct UnspentOutput: Equatable, Sendable {
 
     let out: TransactionOutput
     let height: Int
     let isCoinbase: Bool
 
-    init(_ out: TransactionOutput, height: Int = Self.mempoolHeight, isCoinbase: Bool = false) {
+    public init(_ out: TransactionOutput, height: Int = Self.mempoolHeight, isCoinbase: Bool = false) {
         precondition(height > 0 && height <= Self.mempoolHeight && !(isCoinbase && height == Self.mempoolHeight))
         self.out = out
         self.height = height
@@ -19,26 +19,53 @@ struct UnspentOutput: Equatable, Sendable {
     var isMempool: Bool {
         height == Self.mempoolHeight
     }
-    static let mempoolHeight = 0x7fffffff
+    public static let mempoolHeight = 0x7fffffff
 }
 
 extension UnspentOutput: BinaryCodable {
 
-    init(from decoder: inout BinaryDecoder) throws {
+    public init(from decoder: inout BinaryDecoder) throws {
         out = try decoder.decode()
         height = try decoder.decode()
         isCoinbase = try decoder.decode()
     }
     
-    func encode(to encoder: inout BinaryEncoder) {
+    public func encode(to encoder: inout BinaryEncoder) {
         encoder.encode(out)
         encoder.encode(height)
         encoder.encode(isCoinbase)
     }
     
-    func encodingSize(_ counter: inout BinaryEncodingSizeCounter) {
+    public func encodingSize(_ counter: inout BinaryEncodingSizeCounter) {
         counter.count(out)
         counter.count(Int.self)
         counter.count(Bool.self)
+    }
+}
+
+extension Optional: BinaryCodable where Wrapped == UnspentOutput {
+    public init(from decoder: inout BinaryDecoder) throws {
+        let intData = decoder.peek(MemoryLayout<Int>.size)
+        if intData == Data([UInt8](repeating: 0xff, count: MemoryLayout<Int>.size)) {
+            self = nil
+        } else {
+            self = try UnspentOutput(from: &decoder)
+        }
+    }
+
+    public func encode(to encoder: inout BinaryEncoder) {
+        if let self {
+            encoder.encode(self)
+        } else {
+            encoder.encode(-1)
+        }
+    }
+
+    public func encodingSize(_ counter: inout BinaryEncodingSizeCounter) {
+        if let self {
+            counter.count(self)
+        } else {
+            counter.count(Int.self)
+        }
     }
 }

--- a/src/bitcoin-blockchain/block/Block.swift
+++ b/src/bitcoin-blockchain/block/Block.swift
@@ -160,7 +160,7 @@ extension Block: CustomBinaryCodable {
             let magic = Int(try decoder.decode() as UInt32)
             guard magic == magicBytes else { throw BinaryDecodingError.limitExceeded } // TODO: Replace error for something appropriate
             let length = Int(try decoder.decode() as UInt32)
-            decoder.setLimit(length)
+            decoder.setLimit(length - MemoryLayout<UInt32>.size * 2)
             try self.init(from: &decoder)
             decoder.resetLimit()
         }
@@ -180,7 +180,7 @@ extension Block: CustomBinaryCodable {
             }
         case .file(let magicBytes):
             encoder.encode(UInt32(magicBytes))
-            encoder.encode(UInt32(dataSize))
+            encoder.encode(UInt32(dataSize(encoding: encoding)))
             encode(to: &encoder)
         }
     }

--- a/src/bitcoin-blockchain/block/BlockUndo.swift
+++ b/src/bitcoin-blockchain/block/BlockUndo.swift
@@ -1,0 +1,32 @@
+import Foundation
+import BitcoinCrypto
+import BitcoinBase
+
+struct BlockUndo: Equatable, Sendable {
+
+    init(spentCoins: [UnspentOutput?]) {
+        self.spentCoins = spentCoins
+    }
+
+    let spentCoins: [UnspentOutput?]
+}
+
+extension BlockUndo: CustomBinaryCodable {
+
+    public init(from decoder: inout BinaryDecoder, encoding: Never?) throws {
+        let length = Int(try decoder.decode() as UInt32)
+        decoder.setLimit(length - MemoryLayout<UInt32>.size)
+        spentCoins = try decoder.decode()
+        decoder.resetLimit()
+    }
+
+    public func encode(to encoder: inout BinaryEncoder, encoding: Never?) {
+        encoder.encode(UInt32(dataSize))
+        encoder.encode(spentCoins)
+    }
+
+    public func encodingSize(_ counter: inout BinaryEncodingSizeCounter, encoding: Encoding?) {
+        counter.count(UInt32.self)
+        counter.count(spentCoins)
+    }
+}

--- a/src/bitcoin-blockchain/block/index/BlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/BlockIndex.swift
@@ -7,13 +7,19 @@ protocol BlockIndex: Sendable {
     /// Locators in reverse height order
     var locators: [BlockStorageLocator] { get async }
     var lastHeaderID: Block.ID { get async }
-    var chainTip: Block.ID { get async }
+    var bestBlock: BlockRef { get async }
 
     @discardableResult
     func add(_ block: Block, locator: BlockStorageLocator? /* = nil */, status: BlockRef.ValidationStatus /* = .header */) async throws(BlockIndexError) -> BlockRef
+
     func add(_ blockRef: BlockRef) async
-    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) async
-    func update(_ id: Block.ID, status: BlockRef.ValidationStatus) async
+
+    @discardableResult
+    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) async -> BlockRef
+
+    @discardableResult
+    func update(_ id: Block.ID, status: BlockRef.ValidationStatus)  async -> BlockRef
+
     func has(_ id: Block.ID) async -> Bool
     func get(_ id: Block.ID) async -> BlockRef // TODO: Probably throws and return value nil-able
 
@@ -23,6 +29,8 @@ protocol BlockIndex: Sendable {
     func getParent(for childID: Block.ID) async -> BlockRef?
 
     /// Either removes (if header-only) or marks block as stale
-    func removeAll(from height: Int) async -> [BlockRef]
+    func removeAll(from height: Int) async
     func calculateMissingBlocks(_ ids: [Block.ID]) async -> [Block.ID]
+
+    func undoLastBlock() async -> BlockRef
 }

--- a/src/bitcoin-blockchain/block/index/BlockRef.swift
+++ b/src/bitcoin-blockchain/block/index/BlockRef.swift
@@ -75,10 +75,8 @@ extension BlockRef: BinaryCodable {
         chainwork = try decoder.decode()
         chainTxCount = try decoder.decode()
         status = try decoder.decode()
-        let hasLocator: Bool = try decoder.decode()
-        if hasLocator {
-            locator = try decoder.decode()
-        }
+        let locator: BlockStorageLocator = try decoder.decode()
+        self.locator = locator == .placeholder ? nil : locator
     }
 
     func encode(to encoder: inout BinaryEncoder) {
@@ -89,10 +87,9 @@ extension BlockRef: BinaryCodable {
         encoder.encode(chainTxCount)
         encoder.encode(status)
         if let locator {
-            encoder.encode(true)
             encoder.encode(locator)
         } else {
-            encoder.encode(false)
+            encoder.encode(BlockStorageLocator.placeholder)
         }
     }
     
@@ -103,9 +100,6 @@ extension BlockRef: BinaryCodable {
         counter.count(chainwork)
         counter.count(chainTxCount)
         counter.count(status)
-        counter.count(Bool.self)
-        if let locator {
-            counter.count(locator)
-        }
+        counter.count(BlockStorageLocator.placeholder)
     }
 }

--- a/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
@@ -44,14 +44,14 @@ actor PersistentBlockIndex: BlockIndex {
         }
     }
 
-    var chainTip: Block.ID {
+    var bestBlock: BlockRef {
         try! env.withTransaction(db: byID, byHeight, options: .readOnly) { [height] _, byID, byHeight in
             for i in 0 ... height {
                 let h = height - i
                 let blockID = try byHeight.get(h)!
                 let ref = try BlockRef(try byID.get(blockID)!)
                 if ref.status == .full {
-                    return blockID
+                    return ref
                 }
             }
             preconditionFailure("No fully validated blocks exist")
@@ -90,19 +90,18 @@ actor PersistentBlockIndex: BlockIndex {
         height += 1
     }
 
-    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) {
+    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) -> BlockRef {
         update(id: id, locator: locator, status: status)
     }
 
-    func update(_ id: Block.ID, status: BlockRef.ValidationStatus) {
+    func update(_ id: Block.ID, status: BlockRef.ValidationStatus) -> BlockRef  {
         update(id: id, locator: nil, status: status)
     }
 
-    private func update(id: Block.ID, locator: BlockStorageLocator?, status: BlockRef.ValidationStatus) {
+    private func update(id: Block.ID, locator: BlockStorageLocator?, status: BlockRef.ValidationStatus) -> BlockRef {
         let data = try! env.withTransaction(db: byID, options: [.readOnly]) { _, byID in
-            try byID.get(id)
+            try byID.get(id)!
         }
-        guard let data else { return }
         var blockRef = try! BlockRef(data)
         if let locator {
             blockRef.locator = locator
@@ -112,6 +111,7 @@ actor PersistentBlockIndex: BlockIndex {
             try byID.put(blockRef.data, key: blockRef.header.id)
             try byHeight.put(blockRef.header.id, key: blockRef.height)
         }
+        return blockRef
     }
 
     func has(_ id: Block.ID) -> Bool {
@@ -159,8 +159,8 @@ actor PersistentBlockIndex: BlockIndex {
     }
 
     /// Either removes (if header-only) or marks block as stale
-    func removeAll(from height: Int) -> [BlockRef] {
-        let (totalRemoved, refs) = try! env.withTransaction(db: byID, byHeight) { _, byID, byHeight in
+    func removeAll(from height: Int) {
+        let totalRemoved = try! env.withTransaction(db: byID, byHeight) { _, byID, byHeight in
         var refs = [BlockRef]()
             for h in height ... self.height {
                 let blockID = try byHeight.get(h)!
@@ -181,10 +181,9 @@ actor PersistentBlockIndex: BlockIndex {
             for h in height ... self.height {
                 try! byHeight.delete(h)
             }
-            return (previousCount - height, refs)
+            return previousCount - height
         }
         self.height -= totalRemoved
-        return refs
     }
 
     func calculateMissingBlocks(_ ids: [Block.ID]) -> [Block.ID] {
@@ -197,6 +196,25 @@ actor PersistentBlockIndex: BlockIndex {
             }
         }
         return missing
+    }
+
+    func undoLastBlock() -> BlockRef {
+        let blockID = try! env.withTransaction(db: byHeight, options: .readOnly) { [height] _, byHeight in
+            guard let blockID = try byHeight.get(height) else {
+                fatalError("Could not find last block ID, throwing")
+            }
+            return blockID
+        }
+        return try! env.withTransaction(db: byID) { _, byID in
+            guard let data = try byID.get(blockID) else {
+                fatalError("Could not find last block reference")
+            }
+            var ref = try BlockRef(data)
+            ref.status = .stale
+            try byID.put(blockID, key: ref.data)
+            let previousData = try byID.get(ref.previous)!
+            return try BlockRef(previousData)
+        }
     }
 }
 

--- a/src/bitcoin-blockchain/block/index/TransientBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/TransientBlockIndex.swift
@@ -27,10 +27,13 @@ actor TransientBlockIndex: BlockIndex {
         return byHeight.last!
     }
 
-    var chainTip: Block.ID {
+    var bestBlock: BlockRef {
         for id in byHeight.reversed() {
-            if byID[id]!.status == .full {
-                return id
+            guard let ref = byID[id] else {
+                fatalError("Missing block ref")
+            }
+            if ref.status == .full {
+                return ref
             }
         }
         preconditionFailure("No fully validated blocks exist")
@@ -60,14 +63,17 @@ actor TransientBlockIndex: BlockIndex {
         height += 1
     }
 
-    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) {
+    func update(_ id: Block.ID, locator: BlockStorageLocator, status: BlockRef.ValidationStatus) -> BlockRef {
         byID[id]!.locator = locator
         byID[id]!.status = status
+        return byID[id]!
     }
 
-    func update(_ id: Block.ID, status: BlockRef.ValidationStatus) {
+    @discardableResult
+    func update(_ id: Block.ID, status: BlockRef.ValidationStatus) -> BlockRef {
         // TODO: deal with duplication of the different `update()` funcs.
         byID[id]!.status = status
+        return byID[id]!
     }
 
     func has(_ id: Block.ID) -> Bool {
@@ -96,7 +102,7 @@ actor TransientBlockIndex: BlockIndex {
     }
 
     /// Either removes (if header-only) or marks block as stale
-    func removeAll(from height: Int) -> [BlockRef] {
+    func removeAll(from height: Int) {
         var refs = [BlockRef]()
         for h in height ... self.height {
             refs.append(get(at: h))
@@ -104,7 +110,6 @@ actor TransientBlockIndex: BlockIndex {
         for ref in refs {
             if ref.status < .full {
                 byID[ref.header.id] = nil
-
             } else {
                 update(ref.header.id, status: .stale)
             }
@@ -112,7 +117,6 @@ actor TransientBlockIndex: BlockIndex {
         let totalRemoved = byHeight.count - height
         byHeight.removeLast(totalRemoved)
         self.height -= totalRemoved
-        return refs
     }
 
     func calculateMissingBlocks(_ ids: [Block.ID]) -> [Block.ID] {
@@ -123,5 +127,15 @@ actor TransientBlockIndex: BlockIndex {
             }
         }
         return missing
+    }
+
+    func undoLastBlock() -> BlockRef {
+        let id = byHeight[height]
+        // TODO: Once we support parallel block download: `guard id == chainTip else {`
+        guard let ref = byID[id], ref.status == .full else {
+            preconditionFailure("Chain must be fully sync'ed to undo the last block")
+        }
+        byID[id]!.status = .stale
+        return byID[byID[id]!.previous]!
     }
 }

--- a/src/bitcoin-blockchain/block/storage/BlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/BlockStorage.swift
@@ -7,9 +7,8 @@ protocol BlockStorage: Sendable {
 
     func start() async throws(BlockStorageError)
     func stop() async
-    func store(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator
-    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> Block?
-    func remove(_ locator: BlockStorageLocator) async
+    func store(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator
+    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> (Block, BlockUndo)?
 
     static var cacheSize: Int { get }
 }

--- a/src/bitcoin-blockchain/block/storage/BlockStorageLocator.swift
+++ b/src/bitcoin-blockchain/block/storage/BlockStorageLocator.swift
@@ -4,20 +4,26 @@ import BitcoinCrypto
 struct BlockStorageLocator: Hashable {
     let file: Int
     let offset: Int
+    let undoOffset: Int
+
+    static let placeholder = Self(file: -1, offset: -1, undoOffset: -1)
 }
 
 extension BlockStorageLocator: BinaryCodable {
     init(from decoder: inout BinaryDecoder) throws {
         file = try decoder.decode()
         offset = try decoder.decode()
+        undoOffset = try decoder.decode()
     }
 
     func encode(to encoder: inout BinaryEncoder) {
         encoder.encode(file)
         encoder.encode(offset)
+        encoder.encode(undoOffset)
     }
 
     func encodingSize(_ counter: inout BinaryEncodingSizeCounter) {
+        counter.count(Int.self)
         counter.count(Int.self)
         counter.count(Int.self)
     }

--- a/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
@@ -18,7 +18,7 @@ actor PersistentBlockStorage: BlockStorage {
     private var blocksDir = FilePath?.none
     private var fileNumber = -1
 
-    private var cache = OrderedDictionary<BlockStorageLocator, Block>()
+    private var cache = OrderedDictionary<BlockStorageLocator, (Block, BlockUndo)>()
 
     internal private(set) var sizeOnDisk = 0
 
@@ -46,7 +46,9 @@ actor PersistentBlockStorage: BlockStorage {
         // Save the path to the blocks dir.
         self.blocksDir = blocksDir
 
-        // Find the last file.
+        // Find the last file. Careful: the value of `digits` needs to be in the regex as a literal
+        let regex = /blk(\d{5})/
+
         let initialFileNumber = fileNumber // Will be -1
         let maxNumber: Int
         let totalFiles: Int
@@ -60,19 +62,17 @@ actor PersistentBlockStorage: BlockStorage {
                     logger.debug("\(file.path)")
                     let name = file.name
                     let stem = name.stem
-                    let digits = /\d{8}/
-                    let match = try digits.wholeMatch(in: stem)
-                    guard file.type == .regular, let ext = name.extension, ext == "dat", match != nil, let number = Int(stem) else {
-                        logger.debug("skiping \(name)")
+                    guard file.type == .regular, let ext = name.extension, ext == "dat", let match = try regex.wholeMatch(in: stem), let number = Int(match.output.1) else {
+                        logger.trace("skiping \(name)")
                         continue
                     }
                     guard let info = try? await fs.info(forFileAt: file.path) else {
-                        logger.error("Could not find the file at \(file.path.string).")
+                        logger.error("Could not find the block file at \(file.path.string).")
                         throw BlockStorageError.dataLocationIssue
                     }
                     totalSize += Int(info.size)
 
-                    logger.debug("Evaluating \(name)")
+                    logger.trace("Evaluating \(name)")
                     maxNumber = max(number, maxNumber)
                     totalFiles += 1
 
@@ -106,12 +106,12 @@ actor PersistentBlockStorage: BlockStorage {
         try await fileInfo(for: fileNumber)
     } }
 
-    private func fileInfo(for number: Int) async throws(BlockStorageError) -> FileInfo? {
+    private func fileInfo(for number: Int, undo: Bool = false) async throws(BlockStorageError) -> FileInfo? {
         guard number >= 0 else { return nil }
         let fs = FileSystem.shared
-        let filePath = filePath(for: number)
+        let filePath = filePath(for: number, undo: undo)
         guard let fileInfo = try? await fs.info(forFileAt: filePath) else {
-            logger.error("Could not find the file at \(filePath.string).")
+            logger.error("Could not get info for file at \(filePath.string).")
             throw .dataLocationIssue
         }
         return fileInfo
@@ -123,20 +123,20 @@ actor PersistentBlockStorage: BlockStorage {
         status = .stopped
     }
 
-    func store(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator {
-        let locator = try await storeToDisk(block)
+    func store(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator {
+        let locator = try await storeToDisk(block, undo)
         if cache.count == Self.cacheSize - 1 {
             cache.removeFirst()
         }
-        cache[locator] = block
+        cache[locator] = (block, undo)
         return locator
     }
 
-    private func storeToDisk(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator {
+    private func storeToDisk(_ block: Block, _ undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator {
         let fs = FileSystem.shared
         let maxSize = Int64(config.maxFileSize) // Accounts for magic bytes header and block length prefix
-        let encoding = Block.Encoding.file(magicBytes: config.magic)
 
+        let encoding = Block.Encoding.file(magicBytes: config.magic)
         let serializedBlock = block.data(encoding: encoding)
 
         var offset: Int64
@@ -160,37 +160,63 @@ actor PersistentBlockStorage: BlockStorage {
             throw offset == 0 ? .blockFileCreateIssue : .blockFileWriteIssue
         }
 
-        sizeOnDisk += serializedBlock.count
+        // Block's undo data (revert file)
+        let serializedUndoBlock = undo.data
+        let undoOffset: Int64
+        if offset == 0 {
+            undoOffset = 0
+        } else {
+            guard let undoInfo = try await fileInfo(for: fileNumber, undo: true) else {
+                preconditionFailure("file must exist as offset is not 0")
+            }
+            precondition(undoInfo.size + Int64(serializedUndoBlock.count) <= maxSize, "Undo file cannot be smaller than block file")
+            undoOffset = undoInfo.size
+        }
+
+        let undoPath = filePath(for: fileNumber, undo: true)
+        do {
+            _ = try await fs.withFileHandle(
+                forWritingAt: undoPath,
+                options: undoOffset == 0 ? .newFile(replaceExisting: false) : .modifyFile(createIfNecessary: false)
+            ) { handle in
+                try await handle.write(contentsOf: serializedUndoBlock, toAbsoluteOffset: undoOffset)
+            }
+        } catch {
+            logger.error("Could not open block undo data file for writing.")
+            throw undoOffset == 0 ? .blockFileCreateIssue : .blockFileWriteIssue
+        }
+
+        sizeOnDisk += serializedBlock.count + serializedUndoBlock.count
 
         // Sanity check
         if let info = try await lastFileInfo {
             logger.debug("Written file \(filePath(for: fileNumber).string) as offset \(offset), file size: \(info.size)")
         }
-        return .init(file: fileNumber, offset: Int(offset))
+        return .init(file: fileNumber, offset: Int(offset), undoOffset: Int(undoOffset))
     }
 
-    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> Block? {
+    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> (Block, BlockUndo)? {
         if let block = cache[locator] {
             return block
         }
         return try await retrieveFromDisk(locator)
     }
 
-    private func retrieveFromDisk(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> Block? {
+    private func retrieveFromDisk(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> (Block, BlockUndo)? {
         let fs = FileSystem.shared
         let maxBlockSize = Int64(config.maxBlock + MemoryLayout<UInt32>.size * 2) // Accounts for magic bytes header and block length prefix
         let encoding = Block.Encoding.file(magicBytes: config.magic)
 
-        // TODO: Make 99999999 dependant on the digits of the number portion of the file name currently 8.
-        guard locator.file >= 0, locator.file <= 99999999 else {
+        let maxSuffix = Int(pow(Double(10), Double(digits))) - 1 // 99999
+        guard locator.file >= 0, locator.file <= maxSuffix else {
             logger.error("Invalid file reference.")
             throw .invalidFileRef
         }
 
-        guard let info = try await fileInfo(for: locator.file) else {
+        guard let info = try await fileInfo(for: locator.file), let undoInfo = try await fileInfo(for: locator.file, undo: true) else {
             throw .invalidFileRef
         }
-        logger.trace("Located file \(locator.file) as offset \(locator.offset), file size: \(info.size)")
+        logger.trace("Located block and revert files \(locator.file) as offsets \(locator.offset) (block) and \(locator.undoOffset) revert, file sizes: \(info.size), \(undoInfo.size)")
 
         let blockData: [UInt8]
         do {
@@ -198,35 +224,60 @@ actor PersistentBlockStorage: BlockStorage {
                 var reader = handle.bufferedReader(startingAtAbsoluteOffset: Int64(locator.offset), capacity: .bytes(maxBlockSize))
                 var buffer = try await reader.read(.bytes(maxBlockSize))
 
-                let lengthBytes = buffer.viewBytes(at: MemoryLayout<UInt32>.size, length: MemoryLayout<UInt32>.size)!
+                let lengthBytes = buffer.viewBytes(at: MemoryLayout<UInt32>.size, length: MemoryLayout<UInt32>.size)! // `at:` value accounts for network magic bytes
                 let length = lengthBytes.withUnsafeBytes {
                     $0.loadUnaligned(as: UInt32.self)
                 }
-                return buffer.readBytes(length: MemoryLayout<UInt32>.size * 2 + Int(length))!
+                return buffer.readBytes(length: Int(length))!
                 // `Int(length +  MemoryLayout<UInt32>.size * 2)` could also be `newFileInfo.size - offset` which will be higher.
             }
         } catch {
             logger.error("There was an issue reading the file or attempting to decode block from file's data.")
             throw .corruptedBlockData // TODO: Differenciate from not being able to open the file for reading.
         }
+
+        let blockUndoData: [UInt8]
         do {
-            return try Block(blockData, encoding: encoding)
+            blockUndoData = try await fs.withFileHandle(forReadingAt: filePath(for: locator.file, undo: true)) { handle in
+                var reader = handle.bufferedReader(startingAtAbsoluteOffset: Int64(locator.undoOffset), capacity: .bytes(maxBlockSize))
+                var buffer = try await reader.read(.bytes(maxBlockSize))
+                let lengthBytes = buffer.viewBytes(at: 0, length: MemoryLayout<UInt32>.size)!
+                let length = lengthBytes.withUnsafeBytes {
+                    $0.loadUnaligned(as: UInt32.self)
+                }
+                return buffer.readBytes(length: Int(length))!
+            }
         } catch {
-            logger.error("There was an issue attempting to decode block from file's data.")
+            logger.error("There was an issue reading the file or attempting to decode block from file's data.")
+            throw .corruptedBlockData // TODO: Differenciate from not being able to open the file for reading.
+        }
+
+        let block: Block
+        do {
+            block = try Block(blockData, encoding: encoding)
+        } catch {
+            logger.error("There was an issue attempting to decode block from file's contents.")
             throw .corruptedBlockData
         }
+        let blockUndo: BlockUndo
+        do {
+            blockUndo = try BlockUndo(blockUndoData)
+        } catch {
+            logger.error("There was an issue attempting to decode block revert information from file's contents.")
+            throw .corruptedBlockData
+        }
+        return (block, blockUndo)
     }
 
-    func remove(_ locator: BlockStorageLocator) {
-        // We don't remove blocks from actual storage. The index will get marked as stale outside of this actor. We will just remove from the cache.
-        cache.removeValue(forKey: locator)
-    }
-
-    private func filePath(for number: Int) -> FilePath {
+    private func filePath(for number: Int, undo: Bool = false) -> FilePath {
         guard let blocksDir else { preconditionFailure() }
-        let formatted = String(format: "%08d", number)
-        return blocksDir.appending("\(formatted).dat")
+        let formatted = String(format: "%0\(digits)d", number)
+        return blocksDir.appending("\(undo ? undoFilePrefix : blockFilePrefix)\(formatted).dat")
     }
 
     static let cacheSize = 3
 }
+
+private let blockFilePrefix = "blk"
+private let undoFilePrefix = "rev"
+private let digits = 5 // Warning: If this value changes, also must the `regex` local variable

--- a/src/bitcoin-blockchain/block/storage/TransientBlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/TransientBlockStorage.swift
@@ -11,8 +11,9 @@ actor TransientBlockStorage: BlockStorage {
     let config: BlockStorageConfig
     internal private(set) var status = BlockStorageStatus.idle
 
-    private var cache = OrderedDictionary<BlockStorageLocator, Block>()
+    private var cache = OrderedDictionary<BlockStorageLocator, (Block, BlockUndo)>()
     private var blocks = [Block]()
+    private var blockUndos = [BlockUndo]()
 
     internal private(set) var sizeOnDisk = 0
 
@@ -27,26 +28,22 @@ actor TransientBlockStorage: BlockStorage {
         status = .stopped
     }
 
-    func store(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator {
-        let locator: BlockStorageLocator = .init(file: -1, offset: blocks.endIndex)
+    func store(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator {
+        let locator: BlockStorageLocator = .init(file: blocks.endIndex, offset: -1, undoOffset: -1)
         blocks.append(block)
+        blockUndos.append(undo)
         if cache.count == Self.cacheSize - 1 {
             cache.removeFirst()
         }
-        cache[locator] = block
+        cache[locator] = (block, undo)
         return locator
     }
 
-    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> Block? {
+    func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> (Block, BlockUndo)? {
         if let block = cache[locator] {
             return block
         }
-        return blocks[locator.offset]
-    }
-
-    func remove(_ locator: BlockStorageLocator) {
-        // We don't remove blocks from actual storage. The index will get marked as stale outside of this actor. We will just remove from the cache.
-        cache.removeValue(forKey: locator)
+        return (blocks[locator.file], blockUndos[locator.file])
     }
 
     static let cacheSize = 3

--- a/src/bitcoin-blockchain/coins/CoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/CoinsIndex.swift
@@ -1,7 +1,30 @@
 import BitcoinBase
 
+/// Coins index, also known as chain state.
+///
+/// A list of unspent outputs (coins) indexed by outpoint (transaction ID plus offset).
 protocol CoinsIndex: Sendable {
+
+    var all: [Outpoint : UnspentOutput] { get async }
+    func get(_ outpoint: Outpoint) async throws(CoinsError) -> UnspentOutput?
+
+    /// Removes spent coins and adds new unspent ones.
+    /// - Parameters:
+    ///   - remove: A list of outpoints to remove.
+    ///   - add: A map of outpoints to coins.
+    /// - Returns: A list of removed coins with "holes" which are the coins that could not be removed because they were not found.
+    @discardableResult mutating func update(remove: [Outpoint], add: [Outpoint : UnspentOutput]) async throws(CoinsError) -> [UnspentOutput?]
+
     mutating func add(_ coin: UnspentOutput, for outpoint: Outpoint) async
-    func get(_ outpoint: Outpoint) async -> UnspentOutput?
     mutating func remove(_ outpoint: Outpoint) async throws
+}
+
+enum CoinsError: Error {
+
+    /// When trying to remove spent coins, no unspent output was found for at least on of the provided outpoints.
+    case spentCoinNotFound
+
+    case corruptedCoinData
+
+    case databaseError(Error)
 }

--- a/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
@@ -20,20 +20,86 @@ actor PersistentCoinsIndex: CoinsIndex {
     let logger: Logger
     private let env: Environment
 
+    var all: [Outpoint : UnspentOutput] { get {
+        var unordered = [Outpoint : UnspentOutput]()
+        do {
+            try env.withTransaction(db: byID, options: .readOnly) { _, byID in
+                try byID.withCursor(readOnly: true) { cursor in
+                    var maybeKv = try cursor.getKeyValue()
+                    while let kv = maybeKv {
+                        let (outpointData, coinData) = kv
+                        let outpoint = try Outpoint(outpointData)
+                        let coin = try UnspentOutput(coinData)
+                        unordered[outpoint] = coin
+                        maybeKv = try cursor.getKeyValue(.next)
+                    }
+                }
+            }
+        } catch {
+            return [ : ]
+        }
+        return unordered
+    } }
+
+    func get(_ outpoint: Outpoint) throws(CoinsError) -> UnspentOutput? {
+        let result: UnspentOutput?
+        do {
+            result = try env.withTransaction(db: byID, options: .readOnly) { _, byID  throws(CoinsError) in
+                try _get(outpoint, byID: byID)
+            }
+        } catch {
+            switch error {
+            case let .handlerIssue(nestedError):
+                throw nestedError
+            default:
+                throw .databaseError(error)
+            }
+        }
+        return result
+    }
+
+    func update(remove outpointsToRemove: [Outpoint], add coinsToAdd: [Outpoint : UnspentOutput]) throws(CoinsError) -> [UnspentOutput?] {
+        var removedCoins = [UnspentOutput?]()
+        do {
+            try env.withTransaction(db: byID) { _, byID throws(CoinsError) in
+                for outpoint in outpointsToRemove {
+                    guard let coin = try _get(outpoint, byID: byID) else {
+                        removedCoins.append(nil)
+                        continue // Some coins may be spends from within the block
+                    }
+                    removedCoins.append(coin)
+                    let deleted: Bool
+                    do {
+                        deleted = try byID.delete(outpoint.data)
+                    } catch {
+                        throw CoinsError.databaseError(error)
+                    }
+                    if !deleted {
+                        throw CoinsError.spentCoinNotFound
+                    }
+                }
+                for (outpoint, coin) in coinsToAdd {
+                    do {
+                        try byID.put(coin.data, key: outpoint.data)
+                    } catch {
+                        throw CoinsError.databaseError(error)
+                    }
+                }
+            }
+        } catch {
+            switch error {
+            case let .handlerIssue(nestedError):
+                throw nestedError
+            default:
+                throw .databaseError(error)
+            }
+        }
+        return removedCoins
+    }
+
     func add(_ coin: UnspentOutput, for outpoint: Outpoint) {
         try! env.withTransaction(db: byID) { _, byID in
             try byID.put(coin.data, key: outpoint.data)
-        }
-    }
-
-    func get(_ outpoint: Outpoint) -> UnspentOutput? { // TODO: Probably should throw
-        try! env.withTransaction(db: byID, options: .readOnly) { _, byID in
-            let data = try byID.get(outpoint.data)
-            if let data {
-                return try! UnspentOutput(data)
-            } else {
-                return nil
-            }
         }
     }
 
@@ -50,3 +116,20 @@ actor PersistentCoinsIndex: CoinsIndex {
 }
 
 private let byID = Database.Descriptor("by-id")
+
+    private func _get(_ outpoint: Outpoint, byID: borrowing LMDB.Database) throws(CoinsError) -> UnspentOutput? {
+        let data: Data?
+        do {
+            data = try byID.get(outpoint.data)
+        } catch {
+            throw .databaseError(error)
+        }
+        guard let data else {
+            return nil
+        }
+        do {
+            return try UnspentOutput(data)
+        } catch {
+            throw .corruptedCoinData
+        }
+    }

--- a/src/bitcoin-blockchain/coins/TransientCoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/TransientCoinsIndex.swift
@@ -7,12 +7,36 @@ struct TransientCoinsIndex: CoinsIndex {
 
     private var coins = OrderedDictionary<Outpoint, UnspentOutput>()
 
-    mutating func add(_ coin: UnspentOutput, for outpoint: Outpoint) async {
-        coins[outpoint] = coin
+    var all: [Outpoint : UnspentOutput] { get async {
+        var unordered = [Outpoint : UnspentOutput]()
+        for (k, v) in coins {
+            unordered[k] = v
+        }
+        return unordered
+    } }
+
+    func get(_ outpoint: Outpoint) -> UnspentOutput? {
+        coins[outpoint]
     }
 
-    func get(_ outpoint: Outpoint) async -> UnspentOutput? { // TODO: Probably should throw
-        coins[outpoint]
+    mutating func update(remove outpointsToRemove: [Outpoint], add coinsToAdd: [Outpoint : UnspentOutput]) async throws(CoinsError) -> [UnspentOutput?] {
+        var removedCoins = [UnspentOutput?]()
+        for outpoint in outpointsToRemove {
+            guard let coin = coins[outpoint] else {
+                removedCoins.append(nil)
+                continue // Some coins may be spends from within the block
+            }
+            removedCoins.append(coin)
+            coins[outpoint] = nil
+        }
+        for (outpoint, coin) in coinsToAdd {
+            coins[outpoint] = coin
+        }
+        return removedCoins
+    }
+
+    mutating func add(_ coin: UnspentOutput, for outpoint: Outpoint) async {
+        coins[outpoint] = coin
     }
 
     mutating func remove(_ outpoint: Outpoint) async {

--- a/src/bitcoin-crypto/codec/Binary/BinaryDecoder.swift
+++ b/src/bitcoin-crypto/codec/Binary/BinaryDecoder.swift
@@ -9,9 +9,28 @@ public struct BinaryDecoder {
 
     private var data: Data
     private var offset = 0
-    private var limit = Int?.none
+    private var limits = [Int]()
     private var checkpoint = Int?.none
     private var checkpointLimit = Int?.none
+
+    private var limit: Int? {
+        get {
+            limits.last
+        }
+        set {
+            if let newValue {
+                if limits.isEmpty {
+                    limits.append(newValue)
+                } else {
+                    limits[limits.endIndex - 1] = newValue
+                }
+            } else {
+                if !limits.isEmpty {
+                    limits.removeLast()
+                }
+            }
+        }
+    }
 
     /// Decodes data which may appear prefixed by its length as a variable integer.
     public mutating func decode(variable: Bool, byteSwapped: Bool = false) throws -> Data {
@@ -30,8 +49,11 @@ public struct BinaryDecoder {
                     else { remaining }
 
         if let limit {
-            if count <= limit { self.limit = limit - count }
-            else { throw BinaryDecodingError.limitExceeded }
+            if count <= limit {
+                self.limit = limit - count
+            } else {
+                throw BinaryDecodingError.limitExceeded
+            }
         }
 
         let nextOffset = offset + count
@@ -98,12 +120,12 @@ public struct BinaryDecoder {
 
     /// Sets a limit on the number of bytes to decode before issuing a ``BinaryDecodingError/limitExceeded``.
     public mutating func setLimit(_ limit: Int) {
-        self.limit = limit
+        limits.append(limit)
     }
 
     /// Resets the limit to none.
     public mutating func resetLimit() {
-        limit = nil
+        limits.removeLast()
     }
 
     /// Sets a checkpoint to which we might want to revert if something fails.
@@ -130,7 +152,8 @@ public struct BinaryDecoder {
 
     /// Peeks into the next _n_ bytes to be decoded without advancing the internal offset.
     public func peek(_ count: Int) -> Data {
-        Data(data[offset ..< offset + 2])
+        let min = min(data.endIndex, offset + count)
+        return Data(data[offset ..< min])
     }
 
     public func peek() -> UInt8? {

--- a/src/lmdb/Cursor.swift
+++ b/src/lmdb/Cursor.swift
@@ -13,7 +13,7 @@ package struct Cursor: ~Copyable {
         }
         self.handle = handle!
     }
-    
+
     let txHandle: OpaquePointer
     let dbHandle: MDB_dbi
     let handle: OpaquePointer
@@ -23,7 +23,7 @@ package struct Cursor: ~Copyable {
         var keyVal = MDB_val()
         var dataVal = MDB_val()
         let operation: MDB_cursor_op = operation.value
-        
+
         let status = mdb_cursor_get(handle, &keyVal, &dataVal, operation)
         if status == MDB_NOTFOUND {
             return nil
@@ -33,6 +33,24 @@ package struct Cursor: ~Copyable {
         }
         let data = Data(bytes: dataVal.mv_data, count: dataVal.mv_size)
         return data
+    }
+
+    @discardableResult
+    package func getKeyValue(_ operation:  Operation = .first) throws(Database.AccessError) -> (Data, Data)? {
+        var keyVal = MDB_val()
+        var dataVal = MDB_val()
+        let operation: MDB_cursor_op = operation.value
+
+        let status = mdb_cursor_get(handle, &keyVal, &dataVal, operation)
+        if status == MDB_NOTFOUND {
+            return nil
+        }
+        guard status == MDB_SUCCESS else {
+            throw .getIssue
+        }
+        let keyData = Data(bytes: keyVal.mv_data, count: keyVal.mv_size)
+        let valueData = Data(bytes: dataVal.mv_data, count: dataVal.mv_size)
+        return (keyData, valueData)
     }
 
     package func delete() throws(Database.AccessError) {

--- a/src/lmdb/Environment.swift
+++ b/src/lmdb/Environment.swift
@@ -43,44 +43,49 @@ package struct Environment: ~Copyable {
 
     private let handle: OpaquePointer
 
-    package func createDB(_ db: Database.Descriptor) throws(Transaction.InitError) {
+    package func createDB(_ db: Database.Descriptor) throws(Transaction.InitError<Never>) {
         var db = db
         db.options.insert(.create)
-        try withTransaction(db: db) { _, _ in }
+        try withTransaction(db: db) { _, _ throws(Never) in }
     }
 
-    package func stats(for db: Database.Descriptor) throws(Transaction.InitError) -> Database.Statistics {
-        try withTransaction(db: db) { _, db in
+    package func stats(for db: Database.Descriptor) throws(Transaction.InitError<Database.AccessError>) -> Database.Statistics {
+        try withTransaction(db: db) { _, db throws(Database.AccessError) in
             try db.stats
         }
     }
 
-    package func put(_ value: Data, key: Data, db: Database.Descriptor = nil, options: Database.PutOptions = [])  throws(Transaction.InitError) {
-        try withTransaction(db: db) { tx, db in
+    package func put(_ value: Data, key: Data, db: Database.Descriptor = nil, options: Database.PutOptions = [])  throws(Transaction.InitError<Database.AccessError>) {
+        try withTransaction(db: db) { tx, db throws(Database.AccessError) in
             try db.put(value, key: key, options: options)
         }
     }
 
-    package func get(_ key: Data, db: Database.Descriptor = nil) throws(Transaction.InitError) -> Data? {
+    package func get(_ key: Data, db: Database.Descriptor = nil) throws(Transaction.InitError<Database.AccessError>) -> Data? {
         var value = Data?.none
-        try withTransaction(db: db, options: [.readOnly]) { tx, db in
+        try withTransaction(db: db, options: [.readOnly]) { tx, db throws(Database.AccessError) in
             value = try db.get(key)
         }
         return value
     }
 
     @discardableResult
-    package func withTransaction<T>(db: Database.Descriptor, options: Transaction.Options = [], handler: @escaping (borrowing Transaction, borrowing Database) throws(any Error) -> T) throws(Transaction.InitError) -> T {
+    package func withTransaction<T, E: Error>(db: Database.Descriptor, options: Transaction.Options = [], handler: @escaping (borrowing Transaction, borrowing Database) throws(E) -> T) throws(Transaction.InitError<E>) -> T {
         try withTransaction(db: db, nil, options: options, handler: handler, handler2: nil)
     }
 
     @discardableResult
-    package func withTransaction<T>(db: Database.Descriptor, _ anotherDB: Database.Descriptor, options: Transaction.Options = [], handler: @escaping (borrowing Transaction, borrowing Database, borrowing Database) throws(any Error) -> T) throws(Transaction.InitError) -> T {
+    package func withTransaction<T, E: Error>(db: Database.Descriptor, _ anotherDB: Database.Descriptor, options: Transaction.Options = [], handler: @escaping (borrowing Transaction, borrowing Database, borrowing Database) throws(E) -> T) throws(Transaction.InitError<E>) -> T {
         try withTransaction(db: db, anotherDB, options: options, handler: nil, handler2: handler)
     }
 
-    private func withTransaction<T>(db: Database.Descriptor, _ anotherDB: Database.Descriptor?, options: Transaction.Options = [], handler: TransactionHandler<T>?, handler2: TransactionHandler2<T>?) throws(Transaction.InitError) -> T {
-        let tx = try Transaction(env: handle, options: options)
+    private func withTransaction<T, E: Error>(db: Database.Descriptor, _ anotherDB: Database.Descriptor?, options: Transaction.Options = [], handler: TransactionHandler<T, E>?, handler2: TransactionHandler2<T, E>?) throws(Transaction.InitError<E>) -> T {
+        let tx: Transaction
+        do {
+            tx = try Transaction(env: handle, options: options)
+        } catch {
+            throw .beginIssue
+        }
         guard let db = tx.database(db) else {
             throw .databaseIssue
         }
@@ -94,7 +99,7 @@ package struct Environment: ~Copyable {
             db2 = nil
         }
         let result: T
-        do {
+        do throws(E) {
             result = if let db2, let handler2 {
                 try handler2(tx, db, db2)
             } else if let handler {
@@ -123,6 +128,6 @@ package struct Environment: ~Copyable {
     }
 }
 
-private typealias TransactionHandler<T> = (borrowing Transaction, borrowing Database) throws(any Error) -> T
+private typealias TransactionHandler<T, E: Error> = (borrowing Transaction, borrowing Database) throws(E) -> T
 
-private typealias TransactionHandler2<T> = (borrowing Transaction, borrowing Database, borrowing Database) throws(any Error) -> T
+private typealias TransactionHandler2<T, E: Error> = (borrowing Transaction, borrowing Database, borrowing Database) throws(E) -> T

--- a/src/lmdb/Transaction+Error.swift
+++ b/src/lmdb/Transaction+Error.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension Transaction {
 
-    package enum InitError: Error {
-        case beginIssue, databaseIssue, commitIssue, handlerIssue(Error)
+    package enum InitError<E: Error>: Error {
+        case beginIssue, databaseIssue, commitIssue, handlerIssue(E)
     }
 
     package enum CommitError: Error {

--- a/src/lmdb/Transaction.swift
+++ b/src/lmdb/Transaction.swift
@@ -2,7 +2,7 @@ import CLMDB
 
 package struct Transaction: ~Copyable {
 
-    init(env: OpaquePointer, options: Options = []) throws(InitError) {
+    init(env: OpaquePointer, options: Options = []) throws(InitError<Never>) {
         var handle = OpaquePointer?.none
         let status = mdb_txn_begin(env, nil, options.unsigned, &handle)
         guard status == MDB_SUCCESS else {

--- a/test/bitcoin/BlockchainIntegrationTests.swift
+++ b/test/bitcoin/BlockchainIntegrationTests.swift
@@ -122,4 +122,95 @@ struct BlockchainIntegrationTests {
         await alice.stop()
         await bob.stop()
     }
+
+    @Test func blockUndo() async throws {
+        let blockchain = BlockchainService(params: .swiftTesting)
+        await blockchain.start()
+
+        let aliceKey = SecretKey()
+        let alicePK = aliceKey.pubkey
+
+        let block = try #require(await blockchain.generateTo(alicePK))
+        let coinbaseTx1 = block.txs[0]
+
+        let utxoSet1 = await blockchain.currentUTXOSet()
+
+        let expectedUTXOSet1 = [
+            coinbaseTx1.outpoint(0): UnspentOutput(coinbaseTx1.outs[0], height: 1, isCoinbase: true),
+            coinbaseTx1.outpoint(1): UnspentOutput(coinbaseTx1.outs[1], height: 1, isCoinbase: true)
+        ]
+
+        #expect(utxoSet1 == expectedUTXOSet1)
+
+        let outs1 = [
+            TransactionOutput(value: 100_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 200_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 300_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 400_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 500_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 3_499_999_999, script: .payToPubkeyHash(alicePK))
+        ]
+        var tx1 = Transaction(
+            ins: [.init(outpoint: coinbaseTx1.outpoint(0))],
+            outs: outs1)
+
+        var signer = TransactionSigner(tx: tx1, prevouts: [coinbaseTx1.outs[0]])
+        signer.sign(input: 0, with: aliceKey)
+        tx1 = signer.tx
+
+        try await blockchain.addTransaction(tx1)
+
+        var tx2 = Transaction(
+            ins: [.init(outpoint: tx1.outpoint(5))],
+            outs: [
+            TransactionOutput(value: 600_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 700_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 800_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 900_000_000, script: .payToPubkeyHash(alicePK)),
+            .init(value: 499_999_999, script: .payToPubkeyHash(alicePK))
+        ])
+
+        var signer2 = TransactionSigner(tx: tx2, prevouts: [tx1.outs[5]])
+        signer2.sign(input: 0, with: aliceKey)
+        tx2 = signer2.tx
+
+        try await blockchain.addTransaction(tx2)
+
+
+        let block2 = try #require(await blockchain.generateTo(alicePK))
+        let coinbaseTx2 = block2.txs[0]
+
+        let utxoSet2 = await blockchain.currentUTXOSet()
+
+        let expectedUTXOSet2 = [
+            coinbaseTx1.outpoint(1): UnspentOutput(coinbaseTx1.outs[1], height: 1, isCoinbase: true),
+            coinbaseTx2.outpoint(0): UnspentOutput(coinbaseTx2.outs[0], height: 2, isCoinbase: true),
+            coinbaseTx2.outpoint(1): UnspentOutput(coinbaseTx2.outs[1], height: 2, isCoinbase: true),
+            tx1.outpoint(0): UnspentOutput(tx1.outs[0], height: 2),
+            tx1.outpoint(1): UnspentOutput(tx1.outs[1], height: 2),
+            tx1.outpoint(2): UnspentOutput(tx1.outs[2], height: 2),
+            tx1.outpoint(3): UnspentOutput(tx1.outs[3], height: 2),
+            tx1.outpoint(4): UnspentOutput(tx1.outs[4], height: 2),
+            tx2.outpoint(0): UnspentOutput(tx2.outs[0], height: 2),
+            tx2.outpoint(1): UnspentOutput(tx2.outs[1], height: 2),
+            tx2.outpoint(2): UnspentOutput(tx2.outs[2], height: 2),
+            tx2.outpoint(3): UnspentOutput(tx2.outs[3], height: 2),
+            tx2.outpoint(4): UnspentOutput(tx2.outs[4], height: 2)
+        ]
+
+        #expect(utxoSet2.count == expectedUTXOSet2.count)
+        #expect(utxoSet2 == expectedUTXOSet2)
+
+        #expect(await blockchain.validatedHeight == 2)
+
+        try await blockchain.undoLastBlock()
+
+        let utxoSet1_ = await blockchain.currentUTXOSet()
+        #expect(utxoSet1_.count == expectedUTXOSet1.count)
+        #expect(utxoSet1_ == expectedUTXOSet1)
+
+        #expect(await blockchain.validatedHeight == 1)
+
+        await blockchain.stop()
+    }
 }

--- a/test/lmdb/LMDBTests.swift
+++ b/test/lmdb/LMDBTests.swift
@@ -261,6 +261,7 @@ struct LMDBTests {
                     let value = try cursor.get(i == 0 ? .first : .next)
                     #expect(value == values[i])
                 }
+                #expect(try cursor.get(.next) == nil)
                 //let key = String(data: k, encoding: .utf8)!
             }
         }


### PR DESCRIPTION
Function and Test for reverting the last block
Refactored blockchain chainTip (best block hash) into bestBlock ref (indexed block which includes header and metadata)

Nested data limits support in binary decoding
LMDB wrapper now allows getting key and value from cursor Better "rethrows" in DB transaction handlers with throw types and generics

Fixed issue with coins spent in the same block were still added to UTXO set

Fixed issue with file block encoding whereby the length field was incorrect

Also fixed issue and optimized finding transactions in mempool and scanning available block storage