### PR TITLE
Combined documentation, navigation and content tweaks

### DIFF
--- a/src/bitcoin-base/Documentation.docc/BitcoinBase.md
+++ b/src/bitcoin-base/Documentation.docc/BitcoinBase.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Base")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Basic elements of the Bitcoin protocol, namely transactions and scripts.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | Base | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinBase_ basic usage:
 
@@ -50,24 +52,16 @@ let sighash = SignatureHash(tx: unsignedTx, input: 0, sighashType: .all, scriptC
 - ``SigVersion``
 - ``SighashType``
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Wallet Library][wallet]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-base/scriptOperations/ScriptRuntime+ControlOps.swift
+++ b/src/bitcoin-base/scriptOperations/ScriptRuntime+ControlOps.swift
@@ -65,7 +65,7 @@ extension ScriptRuntime {
         stack.append(ScriptBool(first == second).data)
     }
 
-    /// Same as ``opEqual`` (`OP_EQUAL`), but runs  ``opVerify`` (`OP_VERIFY`) afterward.
+    /// Same as ``opEqual()`` (`OP_EQUAL`), but runs  ``opVerify()`` (`OP_VERIFY`) afterward.
     mutating func opEqualVerify() throws {
         try opEqual()
         try opVerify()

--- a/src/bitcoin-base/transaction/Transaction+check.swift
+++ b/src/bitcoin-base/transaction/Transaction+check.swift
@@ -93,7 +93,7 @@ extension Transaction {
     /// which the transaction will be considered final in the context of BIP 68.
     /// Also removes from the vector of input heights any entries which did not
     /// correspond to sequence locked inputs as they do not affect the calculation.
-    /// Called from ``sequenceLocks()``.
+    /// Called from ``sequenceLocks(verifyLockTimeSequence:previousHeights:blockHeight:previousBlockMedianTimePast:)``.
     package func calculateSequenceLocks(verifyLockTimeSequence: Bool, previousHeights: inout [Int], blockHeight: Int) -> (Int, Int) {
 
         precondition(previousHeights.count == ins.count);
@@ -152,7 +152,7 @@ extension Transaction {
         return (minHeight, minTime)
     }
 
-    /// BIP68 - Untested. Called by ``BlockchainService/checkSequenceLocks(verifyLockTimeSequence:coins:previousBlockMedianTimePast:)`` and ``Transaction/sequenceLocks(verifyLockTimeSequence:previousHeights:blockHeight:previousBlockMedianTimePast:)``.
+    /// BIP68 - Untested. Called by  ``/BitcoinBlockchain/BlockchainService/checkSequenceLocks(verifyLockTimeSequence:coins:previousBlockMedianTimePast:)`` and ``Transaction/sequenceLocks(verifyLockTimeSequence:previousHeights:blockHeight:previousBlockMedianTimePast:)``.
     package func evaluateSequenceLocks(blockHeight: Int, previousBlockMedianTimePast: Int, lockPair: (Int, Int)) throws {
         if lockPair.0 >= blockHeight || lockPair.1 >= previousBlockMedianTimePast {
             throw ValidationError.futureLockTime

--- a/src/bitcoin-blockchain/Documentation.docc/BitcoinBlockchain.md
+++ b/src/bitcoin-blockchain/Documentation.docc/BitcoinBlockchain.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Blockchain")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Bitcoin service layer namely transaction blocks, block headers, transaction memory pool (_mempool_) and coins (UTXO set). 
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | Blockchain | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinBlockchain_ usage example:
 
@@ -58,29 +60,16 @@ let lastBlock = await blockchain.txs.last!
 - ``ConsensusParams``
 - <doc:Design>
 
-
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-crypto/Documentation.docc/BitcoinCrypto.md
+++ b/src/bitcoin-crypto/Documentation.docc/BitcoinCrypto.md
@@ -1,13 +1,15 @@
 # ``BitcoinCrypto``
 
 @Metadata {
-    @DisplayName("BitcoinCrypto")
-    @TitleHeading("Swift Bitcoin Library")
+    @DisplayName("Bitcoin Crypto")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Elliptic curve cryptography, hash function library and Bitcoin-specific coders.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | Crypto | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 Use BitcoinCrypto to perform Bitcoin-related cryptographic operations:
 
@@ -48,28 +50,16 @@ Encode and decode binary data into and from strings using Base58 or Bech32 encod
 - ``Base16Encoder``
 - ``Base16Decoder``
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-miniscript/Documentation.docc/BitcoinMiniscript.md
+++ b/src/bitcoin-miniscript/Documentation.docc/BitcoinMiniscript.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Miniscript")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 _Miniscript_ is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more. Bitcoin Miniscript provides a DSL with all the checks and guarantees of Miniscript performed at compile-time.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | Miniscript | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinMiniscript_ example:
 
@@ -29,28 +31,16 @@ let asm = BitcoinScript(exp.compiled).asm()
 
 ```
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-node/Documentation.docc/BitcoinNode.md
+++ b/src/bitcoin-node/Documentation.docc/BitcoinNode.md
@@ -2,14 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Node (bcnode)")
-    @TitleHeading("Swift Bitcoin Tool")
+    @TitleHeading("Swift Bitcoin tool")
 }
 
 Use the `bcnode` command to start a new Bitcoin node instance.
 
 ## Overview
 
-> Swift Bitcoin: This tool is part of the [Swift Bitcoin](https://swiftbitcoin.org/docs/documentation/bitcoin/) suite.
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | Node (bcnode)
 
 To launch a Bitcoin RPC server instance use the `start` subcommand.
 
@@ -25,28 +25,16 @@ Use `--help` to find out about other subcommands and general usage.
 
 - ``Start``
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-psbt/Documentation.docc/BitcoinPSBT.md
+++ b/src/bitcoin-psbt/Documentation.docc/BitcoinPSBT.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin PSBT")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Bitcoin PSBT (Partially Signed Bitcoin Transaction) corresponds to the implementation of BIP174, BIP370 and others.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | PSBT | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinPSBT_ example:
 
@@ -62,28 +64,16 @@ psbt.finalize()
 let tx = psbt.extractTx()
 ```
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-rpc/Documentation.docc/BitcoinRPC.md
+++ b/src/bitcoin-rpc/Documentation.docc/BitcoinRPC.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin RPC")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Bitcoin RPC (Remote Procedure Call) contains the basic JSON-RPC types along with implementations for the various commands.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | RPC | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinRPC_ example:
 
@@ -23,28 +25,16 @@ print(blockchainInfo)
 // {"blocks": 2, "hashes": ["0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",    "23b822b7912cf1b96f1ec5bb07fba40fdd0e889b1f650662f2c0336db9220851"],"headers": 2}
 ```
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-transport/Documentation.docc/BitcoinTransport.md
+++ b/src/bitcoin-transport/Documentation.docc/BitcoinTransport.md
@@ -2,12 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Transport")
-    @TitleHeading("Swift Bitcoin Library")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Bitcoin transport layer, also known as the peer-to-peer or _wire_ protocol. Everything from the node service to messages to peer representation.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | Transport | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 _BitcoinTransport_ handshake example:
 
@@ -75,28 +77,16 @@ await halChain.stop()
 - ``MessageCommand``
 - <doc:Design>
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [RPC Library][rpc]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-utility/Documentation.docc/BitcoinUtility.md
+++ b/src/bitcoin-utility/Documentation.docc/BitcoinUtility.md
@@ -2,14 +2,14 @@
 
 @Metadata {
     @DisplayName("Bitcoin Utility (bcutil)")
-    @TitleHeading("Swift Bitcoin Tool")
+    @TitleHeading("Swift Bitcoin tool")
 }
 
 Use the `bcutil` command control a running Bitcoin node instance or perform off-chain operations.
 
 ## Overview
 
-> Swift Bitcoin: This tool is part of the [Swift Bitcoin](https://swiftbitcoin.org/docs/documentation/bitcoin/) suite.
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | Utility (bcutil) | [Node (bcnode)][bcnode]
 
 We can use `bcutil` to perform both offline operations as well as issuing RPC commands to a runing `bcnode`.
 
@@ -153,28 +153,16 @@ Use `--help` to find out about other subcommands and general usage.
 
 - ``Node``
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin-wallet/Documentation.docc/BitcoinWallet.md
+++ b/src/bitcoin-wallet/Documentation.docc/BitcoinWallet.md
@@ -1,13 +1,15 @@
 # ``BitcoinWallet``
 
 @Metadata {
-    @DisplayName("BitcoinWallet")
-    @TitleHeading("Swift Bitcoin Library")
+    @DisplayName("Bitcoin Wallet")
+    @TitleHeading("Swift Bitcoin framework")
 }
 
 Generate and decode Bitcoin addresses. Manage mnemonic seeds and derive Hierarchically Deterministic (HD) keys.
 
 ## Overview
+
+> Swift Bitcoin modules: [Bitcoin (umbrella)][bitcoin] | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | Wallet | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 Use BitcoinWallet to generate addresses from public keys or scripts and to decode either legacy, segregated witness or taproot addresses.
 
@@ -70,24 +72,16 @@ let result = signedTx.verifyScript(prevouts: prevouts)
 
 - ``MnemonicPhrase`` 
 
-## See Also
-
-- [Swift Bitcoin "Umbrella" Library][swiftbitcoin]
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[swiftbitcoin]: https://swiftbitcoin.org/docs/documentation/bitcoin/
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin/Documentation.docc/Bitcoin.md
+++ b/src/bitcoin/Documentation.docc/Bitcoin.md
@@ -1,14 +1,16 @@
 # ``Bitcoin``
 
 @Metadata {
-    @DisplayName("Swift Bitcoin")
-    @TitleHeading("Pure-Swift Bitcoin Toolkit")
+    @DisplayName("Bitcoin")
+    @TitleHeading("Swift Bitcoin framework")
     @CallToAction(url: "https://github.com/swift-bitcoin/swift-bitcoin/archive/refs/heads/develop.zip", purpose: download)
 }
 
 Pure-Swift Bitcoin client implementation with full node capabilities.
 
 ## Overview
+
+> Swift Bitcoin modules: Bitcoin (umbrella) | [Crypto][crypto] | [Base][base] | [Miniscript][miniscript] | [Wallet][wallet] | [PSBT][psbt] | [Blockchain][blockchain] | [Transport][transport] | [RPC][rpc] | [Utility (bcutil)][bcutil] | [Node (bcnode)][bcnode]
 
 The Swift Bitcoin package contains:
 - The _Bitcoin_ Swift umbrella library.
@@ -25,28 +27,16 @@ The Swift Bitcoin package contains:
 - <doc:Running>
 - <doc:Testnet>
 
-## See Also
-
-- [Crypto Library][crypto]
-- [Base Library][base]
-- [Miniscript Library][miniscript]
-- [Wallet Library][wallet]
-- [PSBT Library][psbt]
-- [Blockchain Library][blockchain]
-- [Transport Library][transport]
-- [RPC Library][rpc]
-- [Bitcoin Utility (bcutil) Command][bcutil]
-- [Bitcoin Node (bcnode) Command][bcnode]
-
 <!-- links -->
 
-[crypto]: https://swiftbitcoin.org/docs/crypto/documentation/bitcoincrypto/
-[base]: https://swiftbitcoin.org/docs/base/documentation/bitcoinbase/
-[miniscript]: https://swiftbitcoin.org/docs/miniscript/documentation/bitcoinminiscript/
-[wallet]: https://swiftbitcoin.org/docs/wallet/documentation/bitcoinwallet/
-[psbt]: https://swiftbitcoin.org/docs/psbt/documentation/bitcoinpsbt/
-[blockchain]: https://swiftbitcoin.org/docs/blockchain/documentation/bitcoinblockchain/
-[transport]: https://swiftbitcoin.org/docs/transport/documentation/bitcointransport/
-[rpc]: https://swiftbitcoin.org/docs/rpc/documentation/bitcoinrpc/
-[bcnode]: https://swiftbitcoin.org/docs/bcnode/documentation/bitcoinnode/
-[bcutil]: https://swiftbitcoin.org/docs/bcutil/documentation/bitcoinutility/
+[bitcoin]: /documentation/bitcoin
+[crypto]: /documentation/bitcoincrypto
+[base]: /documentation/bitcoinbase
+[miniscript]: /documentation/bitcoinminiscript
+[wallet]: /documentation/bitcoinwallet
+[psbt]: /documentation/bitcoinpsbt
+[blockchain]: /documentation/bitcoinblockchain
+[transport]: /documentation/bitcointransport
+[rpc]: /documentation/bitcoinrpc
+[bcnode]: /documentation/bitcoinnode
+[bcutil]: /documentation/bitcoinutility

--- a/src/bitcoin/Documentation.docc/header.html
+++ b/src/bitcoin/Documentation.docc/header.html
@@ -16,17 +16,7 @@ a:hover {
 </style>
 <p>
     <a href="/"><strong>Swift Bitcoin</strong></a><span> | </span>
-    <a href="/docs/documentation/bitcoin/">Docs</a><span> :</span>
-    <a href="/docs/crypto/documentation/bitcoincrypto/">.Crypto</a><span> : </span>
-    <a href="/docs/base/documentation/bitcoinbase/">.Base</a><span> :</span>
-    <a href="/docs/miniscript/documentation/bitcoinminiscript/">.Miniscript</a><span> :</span>
-    <a href="/docs/wallet/documentation/bitcoinwallet/">.Wallet</a><span> :</span>
-    <a href="/docs/psbt/documentation/bitcoinpsbt/">.PSBT</a><span> :</span>
-    <a href="/docs/blockchain/documentation/bitcoinblockchain/">.Blockchain</a><span> :</span>
-    <a href="/docs/transport/documentation/bitcointransport/">.Transport</a><span> :</span>
-    <a href="/docs/rpc/documentation/bitcoinrpc/">.RPC</a><span> :</span>
-    <a href="/docs/bcnode/documentation/bitcoinnode/">_bcnode</a><span> :</span>
-    <a href="/docs/bcutil/documentation/bitcoinutility/">_bcutil</a>
-    <span> | </span>
+    <a href="/info"><strong>Info</strong></a><span> | </span>
+    <span> Docs </span><span> | </span>
     <a href="https://github.com/swift-bitcoin/swift-bitcoin">Code</a>
 </p>

--- a/tools/generate-docs.sh
+++ b/tools/generate-docs.sh
@@ -50,27 +50,41 @@ cp src/bitcoin/Documentation.docc/theme-settings.json src/bitcoin-utility/Docume
 rm -f src/bitcoin-utility/Documentation.docc/header.html
 ln -s ../../bitcoin/Documentation.docc/header.html src/bitcoin-utility/Documentation.docc/
 
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinCrypto --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/crypto --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+rm -rf $WWW_ROOT
+mkdir -p $WWW_ROOT
 
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinBase --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/base --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+swift package \
+    --allow-writing-to-directory $WWW_ROOT \
+    generate-documentation \
+    --target Bitcoin \
+    --target BitcoinCrypto \
+    --target BitcoinBase \
+    --target BitcoinBlockchain \
+    --target BitcoinMiniscript \
+    --target BitcoinWallet \
+    --target BitcoinPSBT  \
+    --target BitcoinTransport \
+    --target BitcoinRPC \
+    --target BitcoinNode \
+    --target BitcoinUtility \
+    --disable-indexing \
+    --symbol-graph-minimum-access-level internal \
+    --transform-for-static-hosting \
+    --hosting-base-path docs \
+    --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop \
+    --checkout-path $PWD \
+    --experimental-enable-custom-templates \
+    --enable-experimental-combined-documentation \
+    --output-path $WWW_ROOT
 
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinMiniscript --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/miniscript --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+# Additional options:
+#
+#     --exclude-extended-types
+#     --enable-experimental-external-link-support
 
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinWallet --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/wallet --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinPSBT --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/psbt --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinBlockchain --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/blockchain --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinTransport --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/transport --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinRPC --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/rpc --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinUtility --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/bcutil --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target BitcoinNode --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --hosting-base-path docs/bcnode --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
-
-swift package --allow-writing-to-directory .build generate-documentation --target Bitcoin --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --dependency .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinMiniscript.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinPSBT.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinUtility.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinNode.doccarchive --hosting-base-path docs --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
+# Command line with dependencies:
+#
+# swift package --allow-writing-to-directory .build generate-documentation --target Bitcoin --disable-indexing --transform-for-static-hosting --enable-experimental-external-link-support --dependency .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinMiniscript.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinPSBT.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinUtility.doccarchive --dependency .build/plugins/Swift-DocC/outputs/BitcoinNode.doccarchive --hosting-base-path docs --source-service github --source-service-base-url https://github.com/swift-bitcoin/swift-bitcoin/blob/develop --checkout-path $PWD --experimental-enable-custom-templates
 
 rm src/bitcoin-crypto/Documentation.docc/header.html
 rm src/bitcoin-crypto/Documentation.docc/theme-settings.json
@@ -101,18 +115,3 @@ rm src/bitcoin-node/Documentation.docc/theme-settings.json
 
 rm src/bitcoin-utility/Documentation.docc/header.html
 rm src/bitcoin-utility/Documentation.docc/theme-settings.json
-
-rm -rf $WWW_ROOT
-mkdir -p $WWW_ROOT
-
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinCrypto.doccarchive/. $WWW_ROOT/crypto
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinBase.doccarchive/. $WWW_ROOT/base
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinMiniscript.doccarchive/. $WWW_ROOT/miniscript
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinWallet.doccarchive/. $WWW_ROOT/wallet
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinPSBT.doccarchive/. $WWW_ROOT/psbt
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinBlockchain.doccarchive/. $WWW_ROOT/blockchain
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinTransport.doccarchive/. $WWW_ROOT/transport
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinRPC.doccarchive/. $WWW_ROOT/rpc
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinNode.doccarchive/. $WWW_ROOT/bcnode
-cp -rp .build/plugins/Swift-DocC/outputs/BitcoinUtility.doccarchive/. $WWW_ROOT/bcutil
-cp -rp .build/plugins/Swift-DocC/outputs/Bitcoin.doccarchive/. $WWW_ROOT


### PR DESCRIPTION
Leveraging experimental DocC plugin flag to create a combined documentation archive for all targets

Replaced last section with hard-coded links to other modules with note on overview with relative links There's some issues building the blockchain documentation due to Swift Atomics crashing the compiler

Fixes #438