### PR TITLE
Swift toolchain bumped to minimum 6.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Swift
+        uses: vapor/swiftly-action@v0.2
+        with:
+            toolchain: 6.2
         # uses: sersoft-gmbh/swifty-linux-action@v3
         # with:
             # release-version: 6.1.2
-        uses: vapor/swiftly-action@v0.2
-        with:
-            toolchain: 6.1.2
         # uses: swift-actions/setup-swift@v2
         # with:
             # swift-version: 6.1

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ccdb6e2c32b3ac0b73feb79a961e043bb1484e412621139344f8cebcc73a0c7d",
+  "originHash" : "1914c2583d139bb8de98bf2e7ded8e99bc1c05d5be81698729106af1a07af6e4",
   "pins" : [
     {
       "identity" : "secp256k1",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "20c451f1ad8e344e61ddbb34ef196653d4b73ea6",
-        "version" : "1.13.0"
+        "revision" : "4b092f15164144c24554e0a75e080a960c5190a6",
+        "version" : "1.14.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "385f5bd783ffbfff46b246a7db7be8e4f04c53bd",
-        "version" : "2.33.0"
+        "revision" : "737e550e607d82bf15bdfddf158ec61652ce836f",
+        "version" : "2.34.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
-        "version" : "1.6.2"
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(
     name: "swift-bitcoin",
     platforms: [
-        .macOS(.v15),
-        .iOS(.v18),
-        .watchOS(.v11),
-        .tvOS(.v18),
-        .visionOS(.v2)
+        .macOS(.v26),
+        .iOS(.v26),
+        .tvOS(.v26),
+        .visionOS(.v26),
+        //.watchOS(.v26),
     ],
     products: [
         .library(name: "Bitcoin", targets: ["Bitcoin"]),

--- a/src/bitcoin-crypto/ecc/eccSigningContext.swift
+++ b/src/bitcoin-crypto/ecc/eccSigningContext.swift
@@ -2,9 +2,7 @@ import Foundation
 import LibSECP256k1
 import ECCHelper
 
-extension OpaquePointer: @unchecked @retroactive Sendable { } // TODO: Remove conformance in Swift 6.2
-
-let eccSigningContext: OpaquePointer = {
+nonisolated(unsafe) let eccSigningContext: OpaquePointer = {
     guard let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_NONE)) else {
         preconditionFailure()
     }

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,11 +1,13 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM swift:6.1.2 AS builder
+# Get the latest Static Linux `swift sdk install` command from https://www.swift.org/install/linux/#swift-sdk-bundles
+
+FROM --platform=$BUILDPLATFORM swift:6.2 AS builder
 ARG TARGETARCH
 COPY . /opt/swift-bitcoin
 WORKDIR /opt/swift-bitcoin
 RUN \
-    swift sdk install https://download.swift.org/swift-6.1.2-release/static-sdk/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum df0b40b9b582598e7e3d70c82ab503fd6fbfdff71fd17e7f1ab37115a0665b3b && \
+    swift sdk install https://download.swift.org/swift-6.2-release/static-sdk/swift-6.2-RELEASE/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378 && \
     if [  $TARGETARCH = arm64 ]; then export ARCH=aarch64; elif [ $TARGETARCH = amd64 ]; then export ARCH=x86_64; else export ARCH=$TARGETARCH; fi && \
     swift build -c release --swift-sdk $ARCH-swift-linux-musl && \
     mv /opt/swift-bitcoin/.build/$ARCH-swift-linux-musl /opt/swift-bitcoin/.build/swift-linux-musl


### PR DESCRIPTION
Minimum Apple platforms requirement of v26.
Fixed warning about making OpaquePointer sendable. Updated GH Actions workflow.
Updated Dockerfile to use latest Static Linux SDK. Updated dependencies (nio-ssl, swift-system)

Issues with release configuration were automatically resolved.
