### PR TITLE
Incoming peer disconnection now detected immediately

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
+        "version" : "1.6.2"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
-        "version" : "2.8.0"
+        "revision" : "0fcc4c9c2d58dd98504c06f7308c86de775396ff",
+        "version" : "2.9.0"
       }
     },
     {

--- a/src/bitcoin-blockchain/BlockchainService+Error.swift
+++ b/src/bitcoin-blockchain/BlockchainService+Error.swift
@@ -16,7 +16,7 @@ extension BlockchainService {
         /// A transaction in the block could not be validated.
         case invalidTransactionInBlock(TransactionValidationError)
 
-        case unsupportedBlockVersion, orphanHeader, invalidDifficultyTarget, insuficientProofOfWork, headerTooOld, headerTooNew, headerPartOfInvalidChain, missingCoinbaseTransaction, coinbaseTransactionOverspends, wrongMerkleRoot, blockAlreadyExists, futureLockTime
+        case unsupportedBlockVersion, orphanHeader, invalidDifficultyTarget, insuficientProofOfWork, headerTooOld, headerTooNew, headerPartOfInvalidChain, missingCoinbaseTransaction, coinbaseTransactionOverspends, wrongMerkleRoot, /* blockAlreadyExists, */ futureLockTime
 
         case dataDirIssue, blockFileIssue, receivedCancellation
 

--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -280,19 +280,24 @@ public actor BlockchainService: Sendable {
     public func addTransaction(_ tx: Transaction) async throws(TransactionValidationError) {
 
         guard !mempool.contains(tx) else {
-            logger.warning("Transaction already in mempool")
+            logger.warning("Transaction already in mempool: \(tx.idHex)")
             return
         }
 
         for txIn in tx.ins {
             // TODO: Have the coins index return transaction's inputs' previous coins/heights all at once (when coins not from the mempool coins array)
             guard let _ = try! await coins.get(txIn.outpoint) ?? mempoolCoins[txIn.outpoint], !mempoolExclude.contains(txIn.outpoint) else {
-                logger.warning("Missing UTXO")
+                logger.warning("Missing UTXO in tx \(tx.idHex)")
                 return
             }
         }
 
-        try await mempoolAcceptPreChecks(tx)
+        do {
+            try await mempoolAcceptPreChecks(tx)
+        } catch {
+            logger.warning("Mempool precheck failed for tx \(tx.idHex)")
+            throw error
+        }
 
         // Get a reference to previous block
         guard activeTip.header.previous != Block.nullParent else {
@@ -920,7 +925,7 @@ public actor BlockchainService: Sendable {
 
         // Check that all transactions are finalized
         guard tx.isFinal(blockHeight: blockHeight, blockTime: lockTimeCutoff) else {
-            logger.error("Transaction not final")
+            logger.error("Tx not final: \(tx.idHex)")
             throw .nonFinalTransaction
         }
 
@@ -938,6 +943,19 @@ public actor BlockchainService: Sendable {
                 throw .scriptError
             }
         }
+    }
+
+    /// Checks if a mempool transaction still has all it's inputs available.
+    private func inputsAvailable(_ tx: Transaction, exclude: [Outpoint], auxCoins: [Outpoint : UnspentOutput]) async -> Bool {
+        precondition(!tx.isCoinbase)
+        for input in tx.ins {
+            let outpoint = input.outpoint
+            // are the actual inputs available?
+            guard let _ = try! await coins.get(outpoint) ?? auxCoins[outpoint], !exclude.contains(outpoint) else {
+                return false
+            }
+        }
+        return true
     }
 
     /// Processes a block complete with transactions.
@@ -973,8 +991,9 @@ public actor BlockchainService: Sendable {
         logger.debug("Processing block txs \(block.idHex)")
 
         guard blockRef.status == .header else {
-            logger.warning("Block \(block.idHex) already exist with status \(blockRef.status)")
-            throw .blockAlreadyExists
+            logger.warning("Block \(block.idHex) already exists with status \(blockRef.status)")
+            // throw .blockAlreadyExists
+            return blockRef
         }
 
         logger.debug("Block \(block.idHex) merkle status validated")
@@ -1170,18 +1189,12 @@ public actor BlockchainService: Sendable {
         var mpExclude = [Outpoint]()
         var mpCoins = [Outpoint: UnspentOutput]()
         for tx in mempool {
-            do {
-                // TODO: Revisit this hack, pass along only what's necessary
-                let nextTip = BlockRef(.init(previous: blockRef.header.id, merkleRoot: .init(), time: Date(timeIntervalSince1970: 0), target: 0), height: blockRef.height + 1, chainwork: .init(), chainTxCount: -1)
-
-                try await checkTx(tx, block: nextTip, previous: blockRef, exclude: mpExclude, auxCoins: mpCoins)
-            } catch {
-                logger.warning("Mempool transaction became invalid")
-                continue // Exclude this transaction from the new mempool
+            if await inputsAvailable(tx, exclude: mpExclude, auxCoins: mpCoins) {
+                newMempool.append(tx)
+            } else {
+                logger.debug("Removing tx from mempool: \(tx.idHex)")
+                continue
             }
-
-            newMempool.append(tx)
-
             // Remove coins
             mpExclude += tx.ins.map(\.outpoint)
             // Add coins

--- a/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
@@ -286,10 +286,7 @@ actor PersistentBlockIndex: BlockIndex {
                 precondition(ref.status == .active)
                 ref.status = .stale
                 try byID.put(ref.data, key: id)
-
-                //refs.insert(ref, at: 0)
                 refs.append(ref)
-
                 id = ref.header.previous
             } while id != ancestor.header.id
             return refs

--- a/src/bitcoin-node/services/P2PService.swift
+++ b/src/bitcoin-node/services/P2PService.swift
@@ -155,13 +155,10 @@ actor P2PService: Service {
                     logger.info("P2P server received incoming connection from peer @ \(remoteAddress).")
 
                     await connectionMade()
-
+                    let peerID = await node.addPeer(host: remoteHost, port: remotePort)
                     group.addTask {
                         do {
                             try await connectionChannel.executeThenClose { [logger] inbound, outbound in
-
-                                let peerID = await self.node.addPeer(host: remoteHost, port: remotePort)
-
                                 try await withThrowingDiscardingTaskGroup { group in
                                     group.addTask {
                                         for await message in await self.node.getChannel(for: peerID).cancelOnGracefulShutdown() {
@@ -182,7 +179,7 @@ actor P2PService: Service {
                                                 try await outbound.write(message)
                                             }
                                         }
-                                        // Disconnected
+                                        // Channel was closed
                                         logger.info("Removing incoming peer \(peerID).")
                                         await self.node.removePeer(peerID) // stop sibbling tasks
                                     }
@@ -191,6 +188,7 @@ actor P2PService: Service {
                         } catch {
                             logger.error("An unexpected error has occurred:\n\(error)")
                         }
+                        // Disconnected
                         await self.clientDisconnected()
                     }
                 }

--- a/src/bitcoin-node/services/RPCService.swift
+++ b/src/bitcoin-node/services/RPCService.swift
@@ -225,6 +225,7 @@ actor RPCService: Service {
             throw .init(.internalError, "Maximum P2P client instances reached.")
         }
         await client.connect(host: params.host, port: params.port)
+        // await serviceGroup?.addServiceUnlessShutdown(P2PClient(eventLoopGroup: eventLoopGroup, node: node, logger: logger))
         return UUID().uuidString // FIXME: Find a way to return real peer ID
     }
 }

--- a/src/bitcoin-transport/NodeService.swift
+++ b/src/bitcoin-transport/NodeService.swift
@@ -145,7 +145,7 @@ public actor NodeService: Sendable {
     }
 
     /// Registers a peer with the node. Incoming means we are the listener. Otherwise we are the node initiating the connection.
-    public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) async -> UUID {
+    public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) -> UUID {
         let id = PeerID()
         state.peers[id] = PeerState(address: IPv6Address.fromHost(host), port: port, incoming: incoming)
         peerOuts[id] = .init()
@@ -793,7 +793,11 @@ public actor NodeService: Sendable {
             return
         }
         state.peers[id]!.registerKnownTxs([tx.id])
-        try await blockchain.addTransaction(tx)
+        do {
+            try await blockchain.addTransaction(tx)
+        } catch {
+            logger.warning("tx rejected by mempool: \(tx.idHex)")
+        }
     }
 
     private func processCompactBlock(_ message: NetworkMessage, from id: PeerID) async throws {

--- a/src/bitcoin-transport/PeerState.swift
+++ b/src/bitcoin-transport/PeerState.swift
@@ -91,19 +91,19 @@ public struct PeerState: Sendable {
     }
 
     mutating func registerKnownBlocks(_ ids: [Block.ID]) {
-        knownBlocks = knownBlocks + ids
-        let count = knownBlocks.count
+        let count = knownBlocks.count + ids.count
         if count > maxKnownBlocks {
             knownBlocks.removeFirst(count - maxKnownBlocks)
         }
+        knownBlocks += ids
     }
 
     mutating func registerKnownTxs(_ ids: [Transaction.ID]) {
-        knownTxs = knownTxs + ids
-        let count = knownTxs.count
+        let count = knownTxs.count + ids.count
         if count > maxKnownTxs {
             knownTxs.removeFirst(count - maxKnownTxs)
         }
+        knownTxs += ids
     }
 }
 

--- a/test/bitcoin/BlockchainIntegrationTests.swift
+++ b/test/bitcoin/BlockchainIntegrationTests.swift
@@ -257,34 +257,31 @@ struct BlockchainIntegrationTests {
 
         let fm = FileManager.default
         let disambiguator = UInt.random(in: UInt.min ... UInt.max)
-        let dataDirURL = fm.temporaryDirectory.appendingPathComponent("\(disambiguator)/swift-bitcoin-data")
-        let dataDirURL2 = fm.temporaryDirectory.appendingPathComponent("\(disambiguator)/swift-bitcoin-data2")
-        let dataDirURL3 = fm.temporaryDirectory.appendingPathComponent("\(disambiguator)/swift-bitcoin-data3")
-        let dataDir = FilePath(dataDirURL.relativePath)
-        let dataDir2 = FilePath(dataDirURL3.relativePath)
-        let dataDir3 = FilePath(dataDirURL2.relativePath)
 
-        if persistence {
-            try? fm.removeItem(atPath: dataDir.string)
-            try? fm.removeItem(atPath: dataDir2.string)
-            try? fm.removeItem(atPath: dataDir3.string)
-            try fm.createDirectory(at: dataDirURL, withIntermediateDirectories: true)
-            try fm.createDirectory(at: dataDirURL2, withIntermediateDirectories: true)
-            try fm.createDirectory(at: dataDirURL3, withIntermediateDirectories: true)
+        func dataDir(_ index: Int) throws -> FilePath {
+            let url = fm.temporaryDirectory.appendingPathComponent(disambiguator.description).appendingPathComponent(#fileID).appendingPathComponent(#function).appendingPathComponent(index.description)
+            let path = FilePath(url.relativePath)
+            try? fm.removeItem(atPath: path.string)
+            try fm.createDirectory(at: url, withIntermediateDirectories: true)
+            return path
         }
 
+        let dataPath = persistence ? try dataDir(0) : nil
+        let dataPath1 = persistence ? try dataDir(1) : nil
+        let dataPath2 = persistence ? try dataDir(2) : nil
+
         defer {
-            if persistence {
-                try? fm.removeItem(atPath: dataDir.string)
-                try? fm.removeItem(atPath: dataDir2.string)
-                try? fm.removeItem(atPath: dataDir3.string)
+            if let dataPath, let dataPath1, let dataPath2 {
+                try? fm.removeItem(atPath: dataPath.string)
+                try? fm.removeItem(atPath: dataPath1.string)
+                try? fm.removeItem(atPath: dataPath2.string)
             }
         }
 
-        let satoshi = try await BlockchainService(params: .swiftTesting, config: persistence ? .init(dataLocation: .custom(path: dataDir.string)) : .init())
+        let satoshi = try await BlockchainService(params: .swiftTesting, config: persistence ? .init(dataLocation: .custom(path: dataPath!.string)) : .init())
 
-        let alice = try await BlockchainService(params: .swiftTesting, config: .init(dataLocation: .custom(path: dataDir2.string)))
-        let bob = try await BlockchainService(params: .swiftTesting, config: .init(dataLocation: .custom(path: dataDir3.string)))
+        let alice = try await BlockchainService(params: .swiftTesting, config: persistence ?.init(dataLocation: .custom(path: dataPath1!.string)) : .init())
+        let bob = try await BlockchainService(params: .swiftTesting, config: persistence ? .init(dataLocation: .custom(path: dataPath2!.string)) : .init())
 
         let satoshiKey = SecretKey()
         let satoshiID = satoshiKey.pubkey


### PR DESCRIPTION
peer state cleared #417

Fixed issue where mempool rejection of non final tx resulted in disconnection. Now logged as warning. Mempool transactions now cleared in a more orderly manner after new tip is found. We specifically look for coins that became unavailable.

Receiving a duplicate block now just logged as a warning and otherwise ignored.

Refactored part of reorg test. Refactored blockchain logic for keeping track of recent transactions known by peer.

Deps updated: argument parser, service lifecycle