### PR TITLE
Returning peer ID when connecting manually #349

### DIFF
--- a/src/bitcoin-node/services/P2PClientService.swift
+++ b/src/bitcoin-node/services/P2PClientService.swift
@@ -10,12 +10,14 @@ import Logging
 
 actor P2PClient: Service {
 
-    init(eventLoopGroup: EventLoopGroup, node: NodeService, logger: Logger, host: String, port: Int) {
+    init(eventLoopGroup: EventLoopGroup, node: NodeService, logger: Logger, host: String, port: Int,  onDisconnect: (@Sendable (PeerID) async -> ())? = nil) async {
         self.eventLoopGroup = eventLoopGroup
         self.node = node
         self.logger = logger
         remoteHost = host
         remotePort = port
+        self.onDisconnect = onDisconnect
+        peerID = await node.addPeer(host: remoteHost, port: remotePort, incoming: false)
     }
 
     let eventLoopGroup: EventLoopGroup
@@ -23,21 +25,21 @@ actor P2PClient: Service {
     let logger: Logger
     let remoteHost: String
     let remotePort: Int
+    let onDisconnect: (@Sendable (PeerID) async -> ())?
+    let peerID: Int
 
     // Status
-    private(set) var running = false
     private(set) var connected = false
     private(set) var localPort = Int?.none
 
     private var clientChannel: NIOAsyncChannel<NetworkMessage, NetworkMessage>?
 
     var status: StatusRPC.Result.P2PClient {
-        .init(running: running, connected: connected, remoteHost: remoteHost, remotePort: remotePort, localPort: localPort)
+        .init(peerID: peerID, connected: connected, remoteHost: remoteHost, remotePort: remotePort, localPort: localPort)
     }
 
     /// Runs the stand-by client service but does not attempt to initiate a peer-to-peer connection.
     func run() async throws {
-        running = true
         try await withGracefulShutdownHandler {
             try await connectToPeer()
         } onGracefulShutdown: { [logger] in
@@ -69,23 +71,22 @@ actor P2PClient: Service {
         logger.info("P2P client @\(localPort ?? -1) connected to peer @\(remoteHost):\(remotePort) ( …")
 
         try await clientChannel.executeThenClose { @Sendable [logger] inbound, outbound in
-            let peerID = await node.addPeer(host: remoteHost, port: remotePort, incoming: false)
 
             try await withThrowingDiscardingTaskGroup { [logger] group in
-                group.addTask {
+                group.addTask { [peerID] in
                     await self.node.connect(peerID)
                     while let message = await self.node.popMessage(peerID) {
                         try await outbound.write(message)
                     }
                     logger.info("Connected \(peerID)")
                 }
-                group.addTask {
+                group.addTask { [peerID] in
                     for await message in await self.node.getChannel(for: peerID).cancelOnGracefulShutdown() {
                         try await outbound.write(message)
                     }
                     try? await clientChannel.channel.close()
                 }
-                group.addTask { [logger] in
+                group.addTask { [logger, peerID] in
                     for try await message in inbound.cancelOnGracefulShutdown() {
                         do {
                             try await self.node.processMessage(message, from: peerID)
@@ -105,14 +106,14 @@ actor P2PClient: Service {
                 }
             }
         }
-        peerDisconnected() // Clean up, update status
+        await peerDisconnected() // Clean up, update status
     }
 
-    private func peerDisconnected() {
+    private func peerDisconnected() async {
         logger.info("P2P client @\(localPort ?? -1) disconnected from remote peer @\(remoteHost):\(remotePort)…")
         clientChannel = nil
-        running = false
         connected = false
         localPort = nil
+        await onDisconnect?(peerID)
     }
 }

--- a/src/bitcoin-node/services/RPCService.swift
+++ b/src/bitcoin-node/services/RPCService.swift
@@ -30,7 +30,7 @@ actor RPCService: Service {
     let node: NodeService
     let blockchain: BlockchainService
     let p2pService: P2PService
-    var p2pClients = [P2PClient]()
+    var p2pClients = [PeerID: P2PClient]()
     let logger: Logger
 
     // Status and statistics
@@ -176,15 +176,16 @@ actor RPCService: Service {
 
         // Collect P2P Client Services' statuses in order
         let p2pClientStatus = await withTaskGroup(of: (Int, StatusRPC.Result.P2PClient).self, returning: [StatusRPC.Result.P2PClient].self) { group in
-            for i in p2pClients.indices {
+            for (i, client) in p2pClients {
                 group.addTask {
-                    let status = await self.p2pClients[i].status
+                    let status = await client.status
                     return (i, status)
                 }
             }
+            // Let's sort clients by their ID
             var items = [(Int, StatusRPC.Result.P2PClient)]()
-            for await var result in group {
-                result.1.index = result.0 // Set the index inside the struct
+            for await result in group {
+                // result.1.peerID = result.0 // Set the peerID inside the struct
                 items.append(result)
             }
             return items.sorted(by: { $0.0 < $1.0 }).map(\.1) // Get rid of the tuple index
@@ -212,10 +213,16 @@ actor RPCService: Service {
     }
 
     private func rpcConnect(_ params: ConnectRPC.Params) async throws(JSONRPCResponse.Error) -> ConnectRPC.Result {
-        let service = P2PClient(eventLoopGroup: eventLoopGroup, node: node, logger: logger, host: params.host, port: params.port)
-        p2pClients.append(service)
+        let service = await P2PClient(eventLoopGroup: eventLoopGroup, node: node, logger: logger, host: params.host, port: params.port) { peerID  in
+            await self.clearPeer(peerID)
+        }
+        p2pClients[service.peerID] = service
         let config = ServiceGroupConfiguration.ServiceConfiguration(service: service, successTerminationBehavior: .ignore)
         await serviceGroup?.addServiceUnlessShutdown(config)
-        return UUID().uuidString // FIXME: Find a way to return real peer ID
+        return service.peerID
+    }
+
+    private func clearPeer(_ peerID: Int) {
+        p2pClients[peerID] = nil
     }
 }

--- a/src/bitcoin-rpc/commands/DisconnectPeerRPC.swift
+++ b/src/bitcoin-rpc/commands/DisconnectPeerRPC.swift
@@ -5,6 +5,5 @@ import BitcoinTransport
 extension DisconnectPeerRPC {
     public func run(node: NodeService) async -> Bool {
         await node.removePeer(params.peerID)
-        return true
     }
 }

--- a/src/bitcoin-rpc/commands/GetPeerInfoRPC.swift
+++ b/src/bitcoin-rpc/commands/GetPeerInfoRPC.swift
@@ -10,7 +10,7 @@ extension GetPeerInfoRPC {
 
         return peers.keys.map { id in
             let peer = peers[id]!
-            return ResultItem(id: id.uuidString, connectionType: peer.incoming ? .incoming : .outgoing)
+            return ResultItem(id: id, connectionType: peer.incoming ? .incoming : .outgoing)
         }
     }
 }

--- a/src/bitcoin-transport/NodeService.swift
+++ b/src/bitcoin-transport/NodeService.swift
@@ -5,7 +5,7 @@ import BitcoinBlockchain
 import Logging
 
 /// A peer's unique identifier.
-public typealias PeerID = UUID
+public typealias PeerID = Int
 
 /// Manages connection with state.peers, process incoming messages and sends responses.
 public actor NodeService: Sendable {
@@ -57,7 +57,7 @@ public actor NodeService: Sendable {
     private var port = Int?.none
 
     /// Channel for delivering message to state.peers.
-    private var peerOuts = [UUID : AsyncChannel<NetworkMessage>]()
+    private var peerOuts = [PeerID : AsyncChannel<NetworkMessage>]()
 
     /// The node's randomly generated identifier (nonce). This is sent with `version` messages.
     private let nonce = UInt64.random(in: UInt64.min ... UInt64.max)
@@ -67,6 +67,8 @@ public actor NodeService: Sendable {
 
     /// BIP152
     private var pendingBlockTxs: [Block.ID : [Transaction?]] = [:]
+
+    private var maxPeerID = 0
 
     public func start() async {
         status = .starting
@@ -145,8 +147,9 @@ public actor NodeService: Sendable {
     }
 
     /// Registers a peer with the node. Incoming means we are the listener. Otherwise we are the node initiating the connection.
-    public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) -> UUID {
-        let id = PeerID()
+    public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) -> PeerID {
+        let id = maxPeerID
+        maxPeerID += 1
         state.peers[id] = PeerState(address: IPv6Address.fromHost(host), port: port, incoming: incoming)
         peerOuts[id] = .init()
         return id
@@ -163,12 +166,14 @@ public actor NodeService: Sendable {
     }
 
     /// Deregisters a peer and cleans up outbound channels.
-    public func removePeer(_ id: PeerID) {
+    @discardableResult public func removePeer(_ id: PeerID) -> Bool {
+        guard let _ = state.peers[id] else { return false }
         state.peers[id]?.nextPingTask?.cancel()
         state.peers[id]?.checkPongTask?.cancel()
         peerOuts[id]?.finish()
         peerOuts.removeValue(forKey: id)
         state.peers.removeValue(forKey: id)
+        return true
     }
 
     /// Returns a channel for a given peer's outbox. The caller can be notified of new messages generated for this peer.
@@ -697,7 +702,7 @@ public actor NodeService: Sendable {
         /*
         // Code for requesting blocks from multiple blocks
         var minInTransitBlocks = config.maxInTransitBlocks
-        var selectedPeerID = UUID?.none
+        var selectedPeerID = PeerID?.none
         for (id, peer) in state.peers {
             let inTransitBlocks = peer.inTransitBlocks
             if peer.height > height, inTransitBlocks < minInTransitBlocks {

--- a/src/bitcoin-transport/NodeState.swift
+++ b/src/bitcoin-transport/NodeState.swift
@@ -3,7 +3,7 @@ import BitcoinBase
 
 public struct NodeState: Sendable {
 
-    public init(feeFilterRate: Amount = 1, peers: [UUID : PeerState] = [UUID : PeerState]()) {
+    public init(feeFilterRate: Amount = 1, peers: [PeerID : PeerState] = [:]) {
         self.feeFilterRate = feeFilterRate
         self.peers = peers
     }
@@ -12,7 +12,7 @@ public struct NodeState: Sendable {
     public var feeFilterRate: Amount // TODO: Allow to be changed via RPC command, #189
 
     /// Peer information.
-    public internal(set) var peers = [UUID : PeerState]()
+    public internal(set) var peers = [PeerID : PeerState]()
 
     @usableFromInline static let initial = Self()
 }

--- a/src/bitcoin-utility/commands/Node/DisconnectPeer.swift
+++ b/src/bitcoin-utility/commands/Node/DisconnectPeer.swift
@@ -11,12 +11,9 @@ struct DisconnectPeer: AsyncParsableCommand {
     @OptionGroup var parent: Node
 
     @Argument(help: "The ID of the peer to disconnect.")
-    var peerID: String
+    var peerID: Int
 
     mutating func run() async throws {
-        guard let peerID = UUID(uuidString: peerID) else {
-            throw ValidationError("Invalid argument: peerID must be a valid UUID.")
-        }
         let request = JSONRPCRequest(.disconnectPeer(.init(peerID: peerID)))
         try await sendRPC(host: parent.host, port: parent.resolvedPort, request: request)
     }

--- a/src/json-rpc/Commands/ConnectRPC.swift
+++ b/src/json-rpc/Commands/ConnectRPC.swift
@@ -14,7 +14,7 @@ public struct ConnectRPC: RPCCommand, Sendable {
         public let port: Int
     }
 
-    public typealias Result = String // UUID
+    public typealias Result = Int // PeerID
 
     public init(_ params: Params) {
         self.params = params

--- a/src/json-rpc/Commands/DisconnectPeerRPC.swift
+++ b/src/json-rpc/Commands/DisconnectPeerRPC.swift
@@ -4,11 +4,11 @@ import Foundation
 public struct DisconnectPeerRPC: RPCCommand, Sendable {
 
     public struct Params: Codable, Sendable {
-        public init(peerID: UUID) {
+        public init(peerID: Int /* PeerID */) {
             self.peerID = peerID
         }
 
-        public let peerID: UUID
+        public let peerID: Int /* PeerID */
     }
 
     public typealias Result = Bool

--- a/src/json-rpc/Commands/GetPeerInfoRPC.swift
+++ b/src/json-rpc/Commands/GetPeerInfoRPC.swift
@@ -11,12 +11,12 @@ public struct GetPeerInfoRPC: RPCCommand, Sendable {
 
         public enum ConnectiontType: Codable, Sendable { case outgoing, incoming }
 
-        public init(id: String, connectionType: ConnectiontType) {
+        public init(id: Int, connectionType: ConnectiontType) {
             self.id = id
             self.connectionType = connectionType
         }
 
-        public let id: String
+        public let id: Int
         public let connectionType: ConnectiontType
     }
 

--- a/src/json-rpc/Commands/StatusRPC.swift
+++ b/src/json-rpc/Commands/StatusRPC.swift
@@ -45,16 +45,15 @@ public struct StatusRPC: RPCCommand, Sendable {
 
         public struct P2PClient: Codable, Sendable {
 
-            public init(running: Bool, connected: Bool, remoteHost: String, remotePort: Int, localPort: Int?) {
-                self.running = running
+            public init(peerID: Int /* PeerID */, connected: Bool, remoteHost: String, remotePort: Int, localPort: Int?) {
+                self.peerID = peerID
                 self.connected = connected
                 self.remoteHost = remoteHost
                 self.remotePort = remotePort
                 self.localPort = localPort
             }
 
-            public var index = -1
-            let running: Bool
+            let peerID: Int /* PeerID */
             let connected: Bool
             let remoteHost: String
             let remotePort: Int

--- a/test/bitcoin-transport/BlockSyncTests.swift
+++ b/test/bitcoin-transport/BlockSyncTests.swift
@@ -9,12 +9,12 @@ struct BlockSyncTests {
 
     var aliceChain = BlockchainService?.none
     var alice = NodeService?.none
-    var peerB = UUID?.none
+    var peerB = PeerID?.none
     var aliceToBob = AsyncChannel<NetworkMessage>.Iterator?.none
 
     var bobChain = BlockchainService?.none
     var bob = NodeService?.none
-    var peerA = UUID?.none
+    var peerA = PeerID?.none
     var bobToAlice = AsyncChannel<NetworkMessage>.Iterator?.none
 
     init() async throws {

--- a/test/bitcoin-transport/NodeBootstrapTests.swift
+++ b/test/bitcoin-transport/NodeBootstrapTests.swift
@@ -17,7 +17,7 @@ struct NodeBootstrapTests {
     @Test("Ping Pong")
     func pingPong() async throws {
         // Alice's node
-        let peerB = PeerID()
+        let peerB = 0
         let alice = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -26,7 +26,7 @@ struct NodeBootstrapTests {
         await #expect(alice.state.peers[peerB]!.handshakeComplete)
 
         // Bob's node
-        let peerA = PeerID()
+        let peerA = 0
         let bob = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -77,7 +77,7 @@ struct NodeBootstrapTests {
     @Test("Empty block relay")
     func emptyBlockRelay() async throws {
         // Alices's node
-        let peerB = PeerID()
+        let peerB = 0
         let alice = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -86,13 +86,13 @@ struct NodeBootstrapTests {
         let block0 = try #require(await alice.blockchain.generateTo(pubkey))
 
         // Bob's node
-        let peerA = PeerID()
-        let peerC = PeerID() // Carol on Bob's node
+        let peerA = 0
+        let peerC = 1 // Carol on Bob's node
         let bob = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [peerA : makePeerState(true), peerC : makePeerState()]))
         try await bob.blockchain.processBlock(block0, immediate: true)
 
         // Carol's node
-        let carolPeerB = PeerID() // Bob on Carol's node
+        let carolPeerB = 0 // Bob on Carol's node
         let carol = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [carolPeerB : makePeerState(true)]))
         try await carol.blockchain.processBlock(block0, immediate: true)
 
@@ -142,7 +142,7 @@ struct NodeBootstrapTests {
     @Test("Mempool transaction relay")
     func mempoolTxRelay() async throws {
         // Alice's node
-        let peerB = PeerID()
+        let peerB = 0
         let alice = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -150,12 +150,12 @@ struct NodeBootstrapTests {
         )
 
         // Bob's node
-        let peerA = PeerID()
-        let peerC = PeerID() // Carol on Bob's node
+        let peerA = 0
+        let peerC = 1 // Carol on Bob's node
         let bob = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [peerA : makePeerState(true), peerC : makePeerState()]))
 
         // Carol node
-        let carolPeerB = PeerID() // Bob on Carol's node
+        let carolPeerB = 0 // Bob on Carol's node
         let carol = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [carolPeerB : makePeerState(true)]))
 
         // Setup blockchains
@@ -268,7 +268,7 @@ struct NodeBootstrapTests {
     @Test("Compact block (high bandwidth mode)")
     func  compactBlockHighBandwidth() async throws {
         // Alices's node
-        let peerB = PeerID()
+        let peerB = 0
         let alice = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -277,13 +277,13 @@ struct NodeBootstrapTests {
         let block0 = try #require(await alice.blockchain.generateTo(pubkey))
 
         // Bob's node
-        let peerA = PeerID()
-        let peerC = PeerID() // Carol on Bob's node
+        let peerA = 0
+        let peerC = 1 // Carol on Bob's node
         let bob = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [peerA : makePeerState(true), peerC : makePeerState()]))
         try await bob.blockchain.processBlock(block0, immediate: true)
 
         // Carol's node
-        let carolPeerB = PeerID() // Bob on Carol's node
+        let carolPeerB = 0 // Bob on Carol's node
         let carol = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [carolPeerB : makePeerState(true)]))
         try await carol.blockchain.processBlock(block0, immediate: true)
 
@@ -377,7 +377,7 @@ struct NodeBootstrapTests {
     @Test("Compact block (low bandwidth mode)")
     func  compactBlockLowBandwidth() async throws {
         // Alices's node
-        let peerB = PeerID()
+        let peerB = 0
         let alice = NodeService(
             blockchain: try await .init(params: .swiftTesting),
             config: .init(keepAliveFrequency: nil),
@@ -385,12 +385,12 @@ struct NodeBootstrapTests {
         )
 
         // Bob's node
-        let peerA = PeerID()
-        let peerC = PeerID() // Carol on Bob's node
+        let peerA = 0
+        let peerC = 1 // Carol on Bob's node
         let bob = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [peerA : makePeerState(true), peerC : makePeerState(highBandwidth: false)]))
 
         // Carol's node
-        let carolPeerB = PeerID() // Bob on Carol's node
+        let carolPeerB = 0 // Bob on Carol's node
         let carol = NodeService(blockchain: try await .init(params: .swiftTesting), config: .init(keepAliveFrequency: nil), state: NodeState(peers: [carolPeerB : makePeerState(true)]))
 
         // Setup blockchains

--- a/test/bitcoin-transport/NodeServiceTests.swift
+++ b/test/bitcoin-transport/NodeServiceTests.swift
@@ -9,12 +9,12 @@ struct NodeServiceTests: ~Copyable {
 
     var satoshiChain = BlockchainService?.none
     var satoshi = NodeService?.none
-    var halPeer = UUID?.none
+    var halPeer = PeerID?.none
     var satoshiOut = AsyncChannel<NetworkMessage>.Iterator?.none
 
     var halChain = BlockchainService?.none
     var hal = NodeService?.none
-    var satoshiPeer = UUID?.none
+    var satoshiPeer = PeerID?.none
     var halOut = AsyncChannel<NetworkMessage>.Iterator?.none
 
     init() async throws {


### PR DESCRIPTION
Sequential integer peer IDs
Client services state cleared when outgoing node disconnects via remote or local initiative Attempting to disconnect non existing nodes will result in a false RPC response