### PR TITLE
Added -f (forced) argument to cp command

### DIFF
--- a/plugin/copy-config-sources/CopyConfigSources.swift
+++ b/plugin/copy-config-sources/CopyConfigSources.swift
@@ -28,7 +28,7 @@ struct CopyConfigSources: BuildToolPlugin {
             displayName: "",
             // executable: context.tool(named: "/bin/cp").url,
             executable: URL(fileURLWithPath: "/bin/cp"),
-            arguments: [sourceFile.relativePath, destinationFile.relativePath],
+            arguments: ["-f", sourceFile.relativePath, destinationFile.relativePath],
             environment: [:],
             outputFilesDirectory: context.pluginWorkDirectoryURL)
 


### PR DESCRIPTION
This will prevent access denied when running off package checkout sources (when used as dependency)

Fixes #480