### PR TITLE
Reindex function accessible from RPC, offline utility and API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b3792e710257d99a99d7ba4285ff725d986a227ed4123057cdec39c32150b5fc",
+  "originHash" : "80086d4279fa7cee0fc91b1f880ece70f744bea498e1431e1404b764e6478c80",
   "pins" : [
     {
       "identity" : "secp256k1",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
-        "version" : "1.6.2"
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "40d25bbb2fc5b557a9aa8512210bded327c0f60d",
-        "version" : "1.5.0"
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms",
       "state" : {
-        "revision" : "2773d4125311133a2f705ec374c363a935069d45",
-        "version" : "1.1.0"
+        "revision" : "6c050d5ef8e1aa6342528460db614e9770d7f804",
+        "version" : "1.1.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "66a8512c4e7466582bab21e0e0c333f01974e5b6",
-        "version" : "1.16.0"
+        "revision" : "133a347911b6ad0fc8fe3bf46ca90c66cff97130",
+        "version" : "1.17.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
+        "version" : "1.8.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "3eea09220e07d34ace722221cbda90306f48c86c",
-        "version" : "2.90.1"
+        "revision" : "a1605a3303a28e14d822dec8aaa53da8a9490461",
+        "version" : "2.92.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "7ee281d816fa8e5f3967a2c294035a318ea551c7",
-        "version" : "1.31.0"
+        "revision" : "1c90641b02b6ab47c6d0db2063a12198b04e83e2",
+        "version" : "1.31.2"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-profile-recorder.git",
       "state" : {
-        "revision" : "03c1510ae7375e5dc887e233558af650219fddfe",
-        "version" : "0.3.9"
+        "revision" : "005d4a34371c7ad8ecf2b1cc00de33bea405f903",
+        "version" : "0.3.10"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -148,7 +148,7 @@ let package = Package(
             resources: [.copy("dummy")], plugins: [.plugin(name: "CopyConfigSources")]),
         .executableTarget(
             name: "BitcoinUtility", dependencies: [
-                "BitcoinTransport", "BitcoinBlockchain", "BitcoinWallet", "BitcoinBase", "BitcoinCrypto", "NIOJSONRPC", "JSONRPC",
+                "BitcoinTransport", "BitcoinBlockchain", "BitcoinWallet", "BitcoinBase", "BitcoinCrypto", "NIOJSONRPC", "JSONRPC", "LMDB",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),

--- a/src/bitcoin-blockchain/BlockInfo.swift
+++ b/src/bitcoin-blockchain/BlockInfo.swift
@@ -2,10 +2,12 @@ import Foundation
 
 /// Additional information about a block in the blockchain.
 public struct BlockInfo: Sendable {
-    public init(next: Block.ID?, height: Int, confirmations: Int, difficulty: Double, chainwork: Data, medianTime: Date) {
+
+    public init(next: Block.ID?, height: Int, confirmations: Int, status: ValidationStatus, difficulty: Double, chainwork: Data, medianTime: Date) {
         self.next = next
         self.height = height
         self.confirmations = confirmations
+        self.status = status
         self.difficulty = difficulty
         self.chainwork = chainwork
         self.medianTime = medianTime
@@ -14,6 +16,7 @@ public struct BlockInfo: Sendable {
     public let next: Block.ID?
     public let height: Int
     public let confirmations: Int
+    public let status: ValidationStatus
     public let difficulty: Double
     public let chainwork: Data
     public let medianTime: Date

--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -80,7 +80,7 @@ public actor BlockchainService: Sendable {
         } else {
             logger.debug("No good header, seeding genesis block")
             let genesisBlock = Block.genesis(params)
-            let locator = try! await blockStorage.store(genesisBlock, undo: BlockUndo(spentCoins: [])) // TODO: Throw
+            let locator = try! await blockStorage.storeGenesisBlock(genesisBlock, undo: BlockUndo(spentCoins: [])) // TODO: Throw
             activeTip = try! await blockIndex.addGenesisBlock(genesisBlock, locator: locator)
             bestHeader = activeTip
         }
@@ -142,6 +142,9 @@ public actor BlockchainService: Sendable {
 
     private var currentlyValidating: Block.ID?
     private var validationTask: Task<(), Swift.Error>? = nil // TODO: Use custom error once `Swift.Task` supports typed throws
+
+    private var reindexing = false
+    private var reindexTask: Task<(), Never>? = nil
 
     /// The height of the best, fully validated block.
     public var height: Int {
@@ -234,6 +237,10 @@ public actor BlockchainService: Sendable {
     /// Cancels concurrent tasks and removes all subscriptions to block and transaction updates.
     public func shutdown() async {
 
+        // Cancel reindex task and wait for it to fishish
+        reindexTask?.cancel()
+        _ = await reindexTask?.value
+
         // Cancel validation task and wait for it to fishish
         validationTask?.cancel()
         _ = try? await validationTask?.value
@@ -251,6 +258,10 @@ public actor BlockchainService: Sendable {
     ///
     /// After the merkle root validation the block could be ready for connection to the blockchain. If that's the case, the immediate parameter is used to determine whether the full validation and connection is done on the current `Task` or a new background task.
     public func processBlock(_ block: Block, immediate: Bool = true) async throws(Error) {
+        try await processBlockInternal(block, immediate: immediate, locator: nil)
+    }
+
+    private func processBlockInternal(_ block: Block, immediate: Bool = true, locator: BlockStorageLocator?) async throws(Error) {
 
         knownBlocksCounter.increment()
 
@@ -261,7 +272,7 @@ public actor BlockchainService: Sendable {
         }
 
         switch headerRef.status {
-        case .header: try await checkBlock(block, ref: headerRef)
+        case .header: try await checkBlock(block, ref: headerRef, locator: locator)
         case .merkle: break
         case .active, .stale: return
         case .invalid: throw .invalidBlockAlreadyExists
@@ -444,6 +455,7 @@ public actor BlockchainService: Sendable {
             next: refNext?.header.id,
             height: ref.height,
             confirmations: activeTip.height - ref.height + 1,
+            status: ref.status,
             difficulty: ref.difficulty,
             chainwork: ref.chainwork.data,
             medianTime: medianTime
@@ -791,6 +803,105 @@ public actor BlockchainService: Sendable {
         return block
     }
 
+    public func startReindex() async {
+        guard !reindexing else {
+            precondition(reindexTask != nil)
+            logger.info("Re-indexation already in progress")
+            return
+        }
+        logger.info("Starting re-indexation…")
+        precondition(reindexTask == nil)
+        reindexTask = Task {
+            await reindex()
+        }
+    }
+
+    public var isReindexing: Bool {
+        reindexing
+    }
+
+    public func stopReindex() async {
+        guard reindexing else {
+            precondition(reindexTask == nil)
+            return
+        }
+        logger.info("Stopping re-indexation…")
+        precondition(reindexTask != nil)
+        reindexTask?.cancel()
+        Task {
+            _ = await reindexTask?.value
+            precondition(!reindexing)
+            reindexTask = nil
+        }
+    }
+
+    public func reindex() async {
+        logger.info("Re-indexation started")
+        reindexing = true
+        defer {
+            reindexing = false
+        }
+
+        // Cancel validation task and wait for it to fishish
+        validationTask?.cancel()
+        _ = try? await validationTask?.value
+
+        await coins.clear()
+        await blockIndex.clear()
+        await blockStorage.clearUndo()
+
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        var maybeIt = await blockStorage.iterator
+        guard let genesisBlockIterator = maybeIt else {
+            logger.warning("No blocks stored")
+            return
+        }
+        precondition(genesisBlockIterator.block.id ==  Block.genesis(params).id)
+        precondition(genesisBlockIterator.locator == .init(file: 0, offset: 0, undoOffset: 0))
+        do {
+            activeTip = try await blockIndex.addGenesisBlock(genesisBlockIterator.block, locator: genesisBlockIterator.locator)
+            bestHeader = activeTip
+        } catch {
+            logger.error("Could not index genesis block.\n\(error)")
+            return
+        }
+
+        logger.info("Block index, coins, undo data cleared")
+
+        var count = 1
+        var lastFileTime = start
+        var file = genesisBlockIterator.locator.file
+
+        if Task.isCancelled {
+            logger.info("Reindexation cancelled")
+            return
+        }
+
+        maybeIt = await blockStorage.next(genesisBlockIterator, includeUndo: false)
+        while let it = maybeIt /*, count < 10000*/ {
+            if it.locator.file != file {
+                logger.info("Reindexed file \(file); Blocks: \(count); Time: \(clock.now - lastFileTime); Progress: \(guessVerificationProgress(activeTip))")
+                count = 0
+                file = it.locator.file
+                lastFileTime = clock.now
+            }
+            count += 1
+            try! await processBlockInternal(it.block, immediate: true, locator: it.locator)
+
+            if Task.isCancelled {
+                logger.info("Reindexation cancelled")
+                return
+            }
+
+            maybeIt = await blockStorage.next(it, includeUndo: false)
+        }
+
+        let time = clock.now - start
+        logger.info("Reindex finished in \(time); Blocks: \(activeTip.height + 1); Headers: \(bestHeader.height + 1)")
+    }
+
     /// Searches the mempool for missing transactions from the provided list.
     public func calculateMissingTxs(ids: [Transaction.ID]) async -> [Transaction.ID] {
         var newIDs = ids
@@ -986,7 +1097,7 @@ public actor BlockchainService: Sendable {
     /// If it is the first time we see this block, its header will be processed first.
     /// If the block builds on the acvite chain tip, it will be connected thus validating its transactions.
     /// Otherwise the index will be updated to reflect that the merkle root has been verified.
-    @discardableResult private func checkBlock(_ block: Block, ref blockRef: BlockRef) async throws(Error) -> BlockRef {
+    @discardableResult private func checkBlock(_ block: Block, ref blockRef: BlockRef, locator: BlockStorageLocator? = nil) async throws(Error) -> BlockRef {
         logger.debug("Processing block \(block.idHex)")
 
         // Verify coinbase
@@ -1013,8 +1124,12 @@ public actor BlockchainService: Sendable {
         logger.debug("Block \(block.idHex) merkle status validated")
         let updatedRef: BlockRef
         do {
-            let locator = try await blockStorage.store(block)
-            updatedRef = await blockIndex.updateHeader(block.id, locator: locator)
+            let locator = if let locator {
+                locator
+            } else {
+                try await blockStorage.store(block)
+            }
+            updatedRef = await blockIndex.updateHeader(blockRef, locator: locator)
             if updatedRef.header.id == bestHeader.header.id {
                 bestHeader = updatedRef
             }
@@ -1217,9 +1332,12 @@ public actor BlockchainService: Sendable {
         // Update best block and header
         let newLocator = try! await blockStorage.store(blockUndo, forBlockAt: blockOnlyLocator) // TODO: throw
 
-        activeTip = await blockIndex.updateBlock(block.id, locator: newLocator, status: .active, chainTxCount: activeTip.chainTxCount + block.txs.count)
+        activeTip = await blockIndex.updateBlock(blockRef, locator: newLocator, status: .active, chainTxCount: activeTip.chainTxCount + block.txs.count)
 
-        logger.info("New tip: \(block.idHex)")
+        if !reindexing {
+            logger.info("New tip: \(block.idHex)")
+        }
+
         // Notify other nodes of new tip
         Task { [ status = activeTip.status, height = activeTip.height] in
             await withDiscardingTaskGroup {

--- a/src/bitcoin-blockchain/block/index/BlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/BlockIndex.swift
@@ -17,13 +17,13 @@ protocol BlockIndex: Sendable {
 
     func missingBlocks(tip: BlockRef, stop: BlockRef, max: Int) async -> [Block.ID]
 
-    func addGenesisBlock(_ genesisBlock: Block, locator: BlockStorageLocator) async throws(BlockIndexError) -> BlockRef
+    mutating func addGenesisBlock(_ genesisBlock: Block, locator: BlockStorageLocator) async throws(BlockIndexError) -> BlockRef
 
-    func addHeader(_ header: Block) async throws(BlockIndexError) -> BlockRef
+    mutating func addHeader(_ header: Block) async throws(BlockIndexError) -> BlockRef
 
-    func updateBlock(_ id: Block.ID, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) async -> BlockRef
+    mutating func updateBlock(_ ref: BlockRef, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) async -> BlockRef
 
-    func updateHeader(_ id: Block.ID, locator: BlockStorageLocator) async -> BlockRef
+    mutating func updateHeader(_ ref: BlockRef, locator: BlockStorageLocator) async -> BlockRef
 
     func get(_ id: Block.ID) async -> BlockRef?
 
@@ -49,16 +49,18 @@ protocol BlockIndex: Sendable {
     ///   - tip: The best fully validated block to work our way backwards from.
     ///   - ancestor: The ancestor at which to stop (non-inclusive).
     /// - Returns: The deactivated (stale) blocks in descending height order. Use this to revert changes chainstate (coins) one by one.
-    func undo(from tip: BlockRef, backTo ancestor: BlockRef) async -> [BlockRef]
+    mutating func undo(from tip: BlockRef, backTo ancestor: BlockRef) async -> [BlockRef]
 
     /// Changes a string of stale blocks back to active (full).
     /// - Parameters:
     ///   - tip: The last header to work our way backwards from.
     ///   - ancestor: The ancestor at which to stop (non-inclusive).
     /// - Returns: The reactivated blocks in ascending height order. Use this to reapply changes to chainstate (coins) one by one.
-    func reactivate(from tip: BlockRef, backTo ancestor: BlockRef) async -> [BlockRef]
+    mutating func reactivate(from tip: BlockRef, backTo ancestor: BlockRef) async -> [BlockRef]
 
     func makeBlockLocator(from tip: BlockRef) async -> [Block.ID]
 
-    func undoLastBlock() async -> BlockRef
+    mutating func undoLastBlock() async -> BlockRef
+
+    mutating func clear() async
 }

--- a/src/bitcoin-blockchain/block/index/BlockRef.swift
+++ b/src/bitcoin-blockchain/block/index/BlockRef.swift
@@ -90,21 +90,26 @@ extension BlockRef: BinaryCodable {
     }
 }
 
-public enum ValidationStatus: UInt8, Sendable {
+public enum ValidationStatus: UInt8, CustomStringConvertible, Sendable {
     case header, merkle, active, invalid, stale
 
     var score: Int {
         switch self {
-        case .header:
-            0
-        case .merkle:
-            1
-        case .active:
-            3
-        case .invalid:
-            -1
-        case .stale:
-            2
+        case .header: 0
+        case .merkle: 1
+        case .active: 3
+        case .invalid: -1
+        case .stale: 2
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .header: "header"
+        case .merkle: "merkle"
+        case .active: "active"
+        case .invalid: "invalid"
+        case .stale: "stale"
         }
     }
 }

--- a/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
@@ -1,4 +1,5 @@
 import LMDB
+import _NIOFileSystem
 import struct SystemPackage.FilePath
 import Foundation
 import Logging
@@ -8,14 +9,14 @@ import Collections
 actor PersistentBlockIndex: BlockIndex {
 
     init(path: FilePath, logger: Logger) {
+        self.path = path.appending("block-index")
         self.logger = logger
-        env = try! Environment(at: URL(filePath: path.appending("block-index").string), maxDBs: 2, pages: 3_000, options: [.noSubDir])
-        try! env.createDB(byID)
-        try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey, .duplicateSort, .duplicateFixed])) { _, _ in }
+        env = initEnv(path: self.path)
     }
 
+    private let path: FilePath
     private let logger: Logger
-    private let env: Environment
+    private var env: Environment!
 
     var bestHeader: BlockRef? {
         try! env.withTransaction(db: byID, byHeight, options: .readOnly) { _, byID, byHeight in
@@ -151,22 +152,19 @@ actor PersistentBlockIndex: BlockIndex {
         return blockRef
     }
 
-    func updateBlock(_ id: Block.ID, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) -> BlockRef {
+    func updateBlock(_ ref: BlockRef, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) -> BlockRef {
         precondition([.active, .stale].contains(status))
         precondition(locator.isComplete)
-        return update(id: id, locator: locator, status: status, chainTxCount: chainTxCount)
+        return update(ref, locator: locator, status: status, chainTxCount: chainTxCount)
     }
 
-    func updateHeader(_ id: Block.ID, locator: BlockStorageLocator) -> BlockRef  {
+    func updateHeader(_ ref: BlockRef, locator: BlockStorageLocator) -> BlockRef  {
         precondition(!locator.isPlaceholder && !locator.hasUndoOffset)
-        return update(id: id, locator: locator, status: .merkle, chainTxCount: nil)
+        return update(ref, locator: locator, status: .merkle, chainTxCount: nil)
     }
 
-    private func update(id: Block.ID, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int?) -> BlockRef {
-        let data = try! env.withTransaction(db: byID, options: [.readOnly]) { _, byID in
-            try byID.get(id)!
-        }
-        var blockRef = try! BlockRef(data)
+    private func update(_ ref: BlockRef, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int?) -> BlockRef {
+        var blockRef = ref
 
         // Valid transitions header -> merkle; merkle -> active/stale
         precondition(blockRef.status == .header && status == .merkle || (blockRef.status == .merkle && [.active, .stale].contains(status)))
@@ -177,7 +175,7 @@ actor PersistentBlockIndex: BlockIndex {
 
         try! env.withTransaction(db: byID, byHeight) { _, byID, byHeight in
             try byID.put(blockRef.data, key: blockRef.header.id)
-            try byHeight.put(blockRef.header.id, key: blockRef.height)
+            // try byHeight.put(blockRef.header.id, key: blockRef.height)
         }
         return blockRef
     }
@@ -385,6 +383,21 @@ actor PersistentBlockIndex: BlockIndex {
         }
     }
 
+    func clear() async {
+        env = nil // closes env
+
+        // Removes folder
+        let fs = FileSystem.shared
+        do {
+            try await fs.removeItem(at: path)
+        } catch {
+            logger.error("Issue removing block index directory: \(error.localizedDescription)")
+            return // TODO: Probably throw here
+        }
+
+        env = initEnv(path: path)
+    }
+
     /*
     func get(from startHeight: Int, to endHeight: Int) -> [BlockRef] {
         try! env.withTransaction(db: byID, byHeight, options: [.readOnly]) { _, byID, byHeight in
@@ -486,4 +499,11 @@ private func findBestBlock(byID: borrowing LMDB.Database, byHeight: borrowing LM
         } while found == nil
         return found!
     }
+}
+
+private func initEnv(path: FilePath) -> Environment {
+    let env = try! Environment(at: URL(filePath: path.string), maxDBs: 2, pages: 3_000, options: [.noSubDir])
+    try! env.createDB(byID)
+    try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey, .duplicateSort, .duplicateFixed])) { _, _ in }
+    return env
 }

--- a/src/bitcoin-blockchain/block/index/TransientBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/TransientBlockIndex.swift
@@ -1,7 +1,7 @@
 import Collections
 
 /// In-memory block index service implementation.
-actor TransientBlockIndex: BlockIndex {
+struct TransientBlockIndex: BlockIndex {
 
     private var byID = [Block.ID : BlockRef]()
 
@@ -98,18 +98,18 @@ actor TransientBlockIndex: BlockIndex {
         return locators
     }
 
-    func addHeader(_ header: Block) throws(BlockIndexError) -> BlockRef {
+    mutating func addHeader(_ header: Block) throws(BlockIndexError) -> BlockRef {
         precondition(header.txs.isEmpty)
         return try add(header, locator: nil, status: .header, chainTxCount: -1)
     }
 
-    func addGenesisBlock(_ genesisBlock: Block, locator: BlockStorageLocator) throws(BlockIndexError) -> BlockRef {
+    mutating func addGenesisBlock(_ genesisBlock: Block, locator: BlockStorageLocator) throws(BlockIndexError) -> BlockRef {
         precondition(byID.isEmpty)
         precondition(genesisBlock.previous == Block.nullParent)
         return try add(genesisBlock, locator: locator, status: .active, chainTxCount: genesisBlock.txs.count)
     }
 
-    private func add(_ block: Block, locator: BlockStorageLocator?, status: ValidationStatus, chainTxCount: Int) throws(BlockIndexError) -> BlockRef {
+    private mutating func add(_ block: Block, locator: BlockStorageLocator?, status: ValidationStatus, chainTxCount: Int) throws(BlockIndexError) -> BlockRef {
         let previous = if block.previous != Block.nullParent {
             get(block.previous)
         } else {
@@ -132,21 +132,19 @@ actor TransientBlockIndex: BlockIndex {
         return blockRef
     }
 
-    func updateBlock(_ id: Block.ID, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) -> BlockRef {
+    mutating func updateBlock(_ ref: BlockRef, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int) -> BlockRef {
         precondition([.active, .stale].contains(status))
         precondition(locator.isComplete)
-        return update(id: id, locator: locator, status: status, chainTxCount: chainTxCount)
+        return update(ref, locator: locator, status: status, chainTxCount: chainTxCount)
     }
 
-    func updateHeader(_ id: Block.ID, locator: BlockStorageLocator) -> BlockRef  {
+    mutating func updateHeader(_ ref: BlockRef, locator: BlockStorageLocator) -> BlockRef  {
         precondition(!locator.isPlaceholder && !locator.hasUndoOffset)
-        return update(id: id, locator: locator, status: .merkle, chainTxCount: nil)
+        return update(ref, locator: locator, status: .merkle, chainTxCount: nil)
     }
 
-    private func update(id: Block.ID, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int?) -> BlockRef {
-        guard var blockRef = byID[id] else {
-            preconditionFailure()
-        }
+    private mutating func update(_ ref: BlockRef, locator: BlockStorageLocator, status: ValidationStatus, chainTxCount: Int?) -> BlockRef {
+        var blockRef = ref
 
         // Valid transitions header -> merkle; merkle -> active/stale
         precondition(blockRef.status == .header && status == .merkle || (blockRef.status == .merkle && [.active, .stale].contains(status)))
@@ -154,7 +152,7 @@ actor TransientBlockIndex: BlockIndex {
         blockRef.locator = locator
         blockRef.status = status
         if let chainTxCount { blockRef.chainTxCount = chainTxCount }
-        byID[id] = blockRef
+        byID[ref.header.id] = blockRef
         return blockRef
     }
 
@@ -226,7 +224,7 @@ actor TransientBlockIndex: BlockIndex {
         return missing
     }
 
-    func undo(from tip: BlockRef, backTo ancestor: BlockRef) -> [BlockRef] {
+    mutating func undo(from tip: BlockRef, backTo ancestor: BlockRef) -> [BlockRef] {
         var id = tip.header.id
         var refs = [BlockRef]()
         repeat {
@@ -239,7 +237,7 @@ actor TransientBlockIndex: BlockIndex {
         return refs
     }
 
-    func reactivate(from tip: BlockRef, backTo ancestor: BlockRef) -> [BlockRef] {
+    mutating func reactivate(from tip: BlockRef, backTo ancestor: BlockRef) -> [BlockRef] {
         var id = tip.header.id
         var refs = [BlockRef]()
         repeat {
@@ -272,7 +270,7 @@ actor TransientBlockIndex: BlockIndex {
         return have
     }
 
-    func undoLastBlock() -> BlockRef {
+    mutating func undoLastBlock() -> BlockRef {
         let ref = bestHeader!
         precondition(ref.status == .active) // The chain is fully sync'ed
         byID[ref.header.id]!.status = .stale
@@ -299,6 +297,11 @@ actor TransientBlockIndex: BlockIndex {
             }
         }
         return forks
+    }
+
+    mutating func clear() {
+        byHeight = .init()
+        byID = .init()
     }
 
     private func findActiveRef(_ height: Int) -> BlockRef? {

--- a/src/bitcoin-blockchain/block/storage/BlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/BlockStorage.swift
@@ -6,14 +6,27 @@ protocol BlockStorage: Sendable {
     var config: BlockStorageConfig { get async }
     var sizeOnDisk: Int { get async }
 
+    var iterator: BlockIterator? { get async }
+
     init(config: BlockStorageConfig, logger: Logger) async throws(BlockStorageError)
 
     /// Stores a block together with its undo data
-    func store(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator
+    func storeGenesisBlock(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator
 
     func store(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator
 
     func store(_ undo: BlockUndo, forBlockAt locator: BlockStorageLocator) async throws(BlockStorageError) -> BlockStorageLocator
 
     func retrieve(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> (Block, BlockUndo?)
+
+    func next(_ iterator: BlockIterator) async -> BlockIterator?
+    func next(_ iterator: BlockIterator, includeUndo: Bool) async -> BlockIterator?
+
+    func clearUndo() async
+}
+
+struct BlockIterator {
+    let locator: BlockStorageLocator
+    let block: Block
+    let undo: BlockUndo?
 }

--- a/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
@@ -6,17 +6,19 @@ import _NIOFileSystem
 /// Block storage service.
 actor PersistentBlockStorage: BlockStorage {
 
-    init(config: BlockStorageConfig = .init(), logger: Logger) async throws(BlockStorageError) {
+    init(config: BlockStorageConfig, logger: Logger) async throws(BlockStorageError) {
         self.config = config
         self.logger = logger
 
-        guard let path = config.path else { return }
+        guard let path = config.path else {
+            preconditionFailure()
+        }
         logger.info("Using data dir path \"\(path.string)\".")
 
         // Attempt to find or create the blocks subdirectory.
         let fs = FileSystem.shared
         // let currentDir = try! await fs.currentWorkingDirectory
-        let blocksDir = path.appending(config.blocksSubdirectoryName) // TODO: use config.blocksPath instead or centralize "blocks"
+        self.blocksDir = path.appending(config.blocksSubdirectoryName) // TODO: use config.blocksPath instead or centralize "blocks"
         logger.info("Will attempt to create \"\(blocksDir.string)\".")
         let blocksDirInfo = try? await fs.info(forFileAt: blocksDir)
         if blocksDirInfo == nil {
@@ -28,21 +30,16 @@ actor PersistentBlockStorage: BlockStorage {
             }
         }
 
-        // Save the path to the blocks dir.
-        self.blocksDir = blocksDir
-
         // Find the last file. Careful: the value of `digits` needs to be in the regex as a literal
         let regex = /blk(\d{5})/
 
-        let initialFileNumber = fileNumber // Will be -1
-        let maxNumber: Int
-        let totalFiles: Int
-        let totalSize: Int
+        let blocksDir = self.blocksDir
+        var fileSizes: OrderedDictionary<Int, Int> = [:]
+        var undoFileSizes: OrderedDictionary<Int, Int> = [:]
         do {
-            (maxNumber, totalFiles, totalSize) = try await fs.withDirectoryHandle(atPath: blocksDir) { [logger] dir in
-                var maxNumber = initialFileNumber // Will be -1
-                var totalFiles = 0
-                var totalSize = 0
+            (fileSizes, undoFileSizes) = try await fs.withDirectoryHandle(atPath: blocksDir) { [logger] dir in
+                var fileSizes: OrderedDictionary<Int, Int> = [:]
+                var undoFileSizes: OrderedDictionary<Int, Int> = [:]
                 for try await file in dir.listContents() {
                     logger.debug("\(file.path)")
                     let name = file.name
@@ -55,18 +52,15 @@ actor PersistentBlockStorage: BlockStorage {
                         logger.error("Could not find the block file at \(file.path.string).")
                         throw BlockStorageError.dataLocationIssue
                     }
-                    totalSize += Int(info.size)
+                    fileSizes[number] = Int(info.size)
+
+                    if let undoInfo = try! await fs.info(forFileAt: filePath(blocksDir, for: number, undo: true)) {
+                        undoFileSizes[number] = Int(undoInfo.size)
+                    }
 
                     logger.trace("Evaluating \(name)")
-                    maxNumber = max(number, maxNumber)
-                    totalFiles += 1
-
                 }
-                return (
-                    maxNumber: maxNumber,
-                    totalFiles: totalFiles,
-                    totalSize: totalSize
-                )
+                return (fileSizes, undoFileSizes)
             }
         } catch let error as BlockStorageError {
             throw error
@@ -74,16 +68,20 @@ actor PersistentBlockStorage: BlockStorage {
             logger.error("Data location issue.")
             throw .dataLocationIssue
         }
-        logger.debug("Max number: \(maxNumber)")
-        logger.debug("Total files: \(totalFiles)")
-        logger.info("Total size: \(totalSize)")
-        guard maxNumber == totalFiles - 1 else {
+        fileSizes.sort()
+        if let lastKey = fileSizes.keys.last, lastKey != fileSizes.count - 1 {
             logger.error("Missing some block data files.")
             throw .missingBlockFiles
         }
-        fileNumber = maxNumber
-        self.sizeOnDisk = totalSize
+        undoFileSizes.sort()
+        if let lastKey = undoFileSizes.keys.last, lastKey != undoFileSizes.count - 1 {
+            logger.error("Missing some undo block data files.")
+            throw .missingBlockFiles
+        }
+        self.fileSizes = [Int](fileSizes.values)
+        self.undoFileSizes = [Int](undoFileSizes.values)
 
+        logger.info("Files: \(fileSizes.count), \(undoFileSizes.count); Total size: \(sizeOnDisk)")
         // TODO: Prepopulate cache with the last `Self.cacheSize` blocks.
     }
 
@@ -94,10 +92,17 @@ actor PersistentBlockStorage: BlockStorage {
     let config: BlockStorageConfig
     let logger: Logger
 
-    private var blocksDir = FilePath?.none
-    private var fileNumber = -1
+    private let blocksDir: FilePath
+    private var fileSizes: [Int]
+    private var undoFileSizes: [Int]
 
-    internal private(set) var sizeOnDisk = 0
+    private var fileNumber: Int {
+        fileSizes.count - 1
+    }
+
+    var sizeOnDisk: Int {
+        fileSizes.reduce(0, +) + undoFileSizes.reduce(0, +)
+    }
 
     private var lastFileInfo: FileInfo? { get async throws(BlockStorageError) {
         try await fileInfo(for: fileNumber)
@@ -106,7 +111,7 @@ actor PersistentBlockStorage: BlockStorage {
     private func fileInfo(for number: Int, undo: Bool = false) async throws(BlockStorageError) -> FileInfo? {
         guard number >= 0 else { return nil }
         let fs = FileSystem.shared
-        let filePath = filePath(for: number, undo: undo)
+        let filePath = filePath(blocksDir, for: number, undo: undo)
         guard let fileInfo = try? await fs.info(forFileAt: filePath) else {
             logger.error("Could not get info for file at \(filePath.string).")
             throw .dataLocationIssue
@@ -114,9 +119,13 @@ actor PersistentBlockStorage: BlockStorage {
         return fileInfo
     }
 
-    func store(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator {
-        let locator = try await store(block)
-        return try await store(undo, forBlockAt: locator)
+    func storeGenesisBlock(_ block: Block, undo: BlockUndo) async throws(BlockStorageError) -> BlockStorageLocator {
+        if fileSizes.isEmpty {
+            let locator = try await store(block)
+            return try await store(undo, forBlockAt: locator)
+        } else {
+            return .init(file: 0, offset: 0, undoOffset: undoFileSizes.isEmpty ? -1 : 0)
+        }
     }
 
     func store(_ block: Block) async throws(BlockStorageError) -> BlockStorageLocator {
@@ -127,14 +136,15 @@ actor PersistentBlockStorage: BlockStorage {
         let serializedBlock = block.data(encoding: encoding)
 
         var offset: Int64
-        if let info = try await lastFileInfo, info.size + Int64(serializedBlock.count) <= maxSize {
-            offset = info.size
-        } else {
+        if fileSizes.count == 0 || Int64(fileSizes.last!) + Int64(serializedBlock.count) > maxSize {
             offset = 0
-            fileNumber += 1
+            fileSizes.append(serializedBlock.count)
+        } else {
+            offset = Int64(fileSizes.last!)
+            fileSizes[fileSizes.count - 1] += serializedBlock.count
         }
 
-        let path = filePath(for: fileNumber)
+        let path = filePath(blocksDir, for: fileNumber)
         do {
             _ = try await fs.withFileHandle(
                 forWritingAt: path,
@@ -147,12 +157,12 @@ actor PersistentBlockStorage: BlockStorage {
             throw offset == 0 ? .blockFileCreateIssue : .blockFileWriteIssue
         }
 
-        sizeOnDisk += serializedBlock.count
-
         // Sanity check
+        /*
         if let info = try await lastFileInfo {
-            logger.debug("Written file \(filePath(for: fileNumber).string) at offset \(offset), file size: \(info.size)")
+            logger.debug("Written file \(filePath(blocksDir, for: fileNumber).string) at offset \(offset), file size: \(info.size)")
         }
+        */
         return .init(file: fileNumber, offset: Int(offset), undoOffset: -1)
     }
 
@@ -166,12 +176,14 @@ actor PersistentBlockStorage: BlockStorage {
 
         var undoOffset: Int64
 
-        let filePath = filePath(for: locator.file, undo: true)
-        if let info = try! await fs.info(forFileAt: filePath) {
-            precondition(info.size + Int64(serializedUndoBlock.count) <= maxSize, "Undo file cannot be larger than the max block file")
-            undoOffset = info.size
+        let filePath = filePath(blocksDir, for: locator.file, undo: true)
+        if undoFileSizes.indices.contains(locator.file) {
+            undoOffset = Int64(undoFileSizes[locator.file])
+            undoFileSizes[locator.file] += serializedUndoBlock.count
+            precondition(undoFileSizes[locator.file] <= maxSize, "Undo file cannot be larger than the max block file")
         } else {
             undoOffset = 0
+            undoFileSizes.append(serializedUndoBlock.count)
         }
 
         do {
@@ -186,12 +198,12 @@ actor PersistentBlockStorage: BlockStorage {
             throw undoOffset == 0 ? .blockFileCreateIssue : .blockFileWriteIssue
         }
 
-        sizeOnDisk += serializedUndoBlock.count
-
         // Sanity check
+        /*
         if let info = try await fileInfo(for: locator.file, undo: true) {
             logger.debug("Written undo file \(filePath) as offset \(undoOffset), file size: \(info.size)")
         }
+         */
         return .init(file: locator.file, offset: locator.offset, undoOffset: Int(undoOffset))
     }
 
@@ -207,19 +219,133 @@ actor PersistentBlockStorage: BlockStorage {
         return (block, undo)
     }
 
+    var iterator: BlockIterator? { get async {
+        guard !fileSizes.isEmpty else {
+            return nil
+        }
+        let undoOffset = undoFileSizes.isEmpty ? -1 : 0
+        let locator = BlockStorageLocator(file: 0, offset: 0, undoOffset: undoOffset)
+        guard let block = try? await retrieveBlock(locator) else {
+            logger.error("Could not retrieve genesis block at \(locator.file):\(locator.offset)")
+            return nil
+        }
+        let undo: BlockUndo?
+        if locator.undoOffset == -1 {
+            undo = nil
+        } else {
+            guard let u = try? await retrieveUndo(locator) else {
+                logger.error("Could not retrieve genesis block undo data at \(locator.file):\(locator.undoOffset)")
+                return nil
+            }
+            undo = u
+        }
+        return .init(locator: locator, block: block, undo: undo)
+    } }
+
+    func next(_ iterator: BlockIterator) async -> BlockIterator? {
+        await next(iterator, includeUndo: false)
+    }
+
+    func clearUndo() async {
+        guard !undoFileSizes.isEmpty, let genesisUndo = try? await retrieveUndo(.init(file: 0, offset: 0, undoOffset: 0)) else {
+            logger.error("Could not find undo data for genesis block")
+            return
+        }
+
+        // Find the last file. Careful: the value of `digits` needs to be in the regex as a literal
+        let regex = /rev(\d{5})/
+
+        let fs = FileSystem.shared
+        let blocksDir = self.blocksDir
+        try? await fs.withDirectoryHandle(atPath: blocksDir) { [logger] dir in
+            for try await file in dir.listContents() {
+                let name = file.name
+                let stem = name.stem
+                guard file.type == .regular, let ext = name.extension, ext == "dat", let match = try regex.wholeMatch(in: stem), Int(match.output.1) != nil else {
+                    logger.trace("skiping \(name)")
+                    continue
+                }
+                do {
+                    try await fs.removeItem(at: file.path)
+                } catch {
+                    logger.error("Could not remove item at \(file.path)\n\(error)")
+                }
+            }
+        }
+
+        undoFileSizes = []
+
+        guard let locator = try? await store(genesisUndo, forBlockAt: .init(file: 0, offset: 0, undoOffset: -1)) else {
+            logger.error("Could not save undo data for genesis block")
+            return
+        }
+        assert(locator == .init(file: 0, offset: 0, undoOffset: 0))
+        assert(undoFileSizes.count == 1 && undoFileSizes[0] == genesisUndo.dataSize)
+    }
+
+    func next(_ iterator: BlockIterator, includeUndo: Bool) async -> BlockIterator? {
+        let encoding = Block.Encoding.file(magicBytes: config.magic)
+
+        var file = iterator.locator.file
+        var offset = iterator.locator.offset + iterator.block.dataSize(encoding: encoding)
+        if offset >= fileSizes[file] {
+            file += 1
+            offset = 0
+        }
+        guard file < fileSizes.count else {
+            // We have reached the end of the last file
+            return nil
+        }
+
+        let undoOffset: Int
+
+        if includeUndo, let prevUndo = iterator.undo, undoFileSizes.indices.contains(file) {
+            let nextUndoOffset = iterator.locator.undoOffset + prevUndo.dataSize
+            if offset == 0 {
+                // If the blk file increases, the rev file also increments. Offsets must both be 0.
+               undoOffset = 0
+            } else if nextUndoOffset < undoFileSizes[file] {
+                // The offset is within the limits of the file, we can just add the size of the previous undo data to the previous offset to get the next offset
+                undoOffset = nextUndoOffset
+            } else {
+                // The rev file does not have undo data for every block in the corresponding blk file.
+                undoOffset = -1
+            }
+        } else {
+            // Either we were asked explicitely not to include undo data, we don't have the previous undo data or the current blk file does not hava a corresponding rev file.
+            undoOffset = -1
+        }
+
+        let locator = BlockStorageLocator(file: file, offset: offset, undoOffset: undoOffset)
+        guard let block = try? await retrieveBlock(locator) else {
+            logger.error("Could not retrieve block at \(locator.file):\(locator.offset)")
+            return nil
+        }
+        let undo: BlockUndo?
+        if locator.undoOffset == -1 {
+            undo = nil
+        } else {
+            guard let u = try? await retrieveUndo(locator) else {
+                logger.error("Could not retrieve block undo data at \(locator.file):\(locator.undoOffset)")
+                return nil
+            }
+            undo = u
+        }
+        return .init(locator: locator, block: block, undo: undo)
+    }
+
     private func retrieveBlock(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> Block {
+        precondition(fileSizes.indices.contains(locator.file) && locator.offset >= 0 && locator.offset < fileSizes[locator.file] )
+
         let fs = FileSystem.shared
         let maxBlockSize = Int64(config.maxBlock + MemoryLayout<UInt32>.size * 2) // Accounts for magic bytes header and block length prefix
         let encoding = Block.Encoding.file(magicBytes: config.magic)
 
-        guard let info = try await fileInfo(for: locator.file) else {
-            throw .invalidFileRef
-        }
-        logger.trace("Located block file \(locator.file) at offset \(locator.offset), file size: \(info.size)")
+        logger.trace("Located block file \(locator.file) at offset \(locator.offset), file size: \(fileSizes[locator.file])")
 
         let blockData: [UInt8]
         do {
-            blockData = try await fs.withFileHandle(forReadingAt: filePath(for: locator.file)) { handle in
+            blockData = try await fs.withFileHandle(forReadingAt: filePath(blocksDir, for: locator.file)) { handle in
                 var reader = handle.bufferedReader(startingAtAbsoluteOffset: Int64(locator.offset), capacity: .bytes(maxBlockSize))
                 var buffer = try await reader.read(.bytes(maxBlockSize))
 
@@ -231,7 +357,7 @@ actor PersistentBlockStorage: BlockStorage {
                 // `Int(length +  MemoryLayout<UInt32>.size * 2)` could also be `newFileInfo.size - offset` which will be higher.
             }
         } catch {
-            logger.error("There was an issue reading the file or attempting to decode block from file's data.")
+            logger.error("There was an issue reading the file or attempting to decode block from file's data at \(locator.file):\(locator.offset)")
             throw .corruptedBlockData // TODO: Differenciate from not being able to open the file for reading.
         }
         let block: Block
@@ -246,21 +372,19 @@ actor PersistentBlockStorage: BlockStorage {
 
     private func retrieveUndo(_ locator: BlockStorageLocator) async throws(BlockStorageError) -> BlockUndo {
         precondition(locator.undoOffset != -1)
+        precondition(undoFileSizes.indices.contains(locator.file) && locator.undoOffset < undoFileSizes[locator.file] )
 
         let fs = FileSystem.shared
 
         // TODO: What's the max undo data size?
         let maxBlockSize = Int64(config.maxBlock + MemoryLayout<UInt32>.size) // Accounts for length prefix
 
-        guard let undoInfo = try await fileInfo(for: locator.file, undo: true) else {
-            throw .invalidFileRef
-        }
-        logger.trace("Located revert file \(locator.file) at \(locator.undoOffset), file size: \(undoInfo.size)")
+        logger.trace("Located revert file \(locator.file) at \(locator.undoOffset), file size: \(undoFileSizes[locator.file])")
 
 
         let blockUndoData: [UInt8]
         do {
-            blockUndoData = try await fs.withFileHandle(forReadingAt: filePath(for: locator.file, undo: true)) { handle in
+            blockUndoData = try await fs.withFileHandle(forReadingAt: filePath(blocksDir, for: locator.file, undo: true)) { handle in
                 var reader = handle.bufferedReader(startingAtAbsoluteOffset: Int64(locator.undoOffset), capacity: .bytes(maxBlockSize))
                 var buffer = try await reader.read(.bytes(maxBlockSize))
                 let lengthBytes = buffer.viewBytes(at: 0, length: MemoryLayout<UInt32>.size)!
@@ -270,7 +394,7 @@ actor PersistentBlockStorage: BlockStorage {
                 return buffer.readBytes(length: Int(length))!
             }
         } catch {
-            logger.error("There was an issue reading the file or attempting to decode block from file's data.")
+            logger.error("There was an issue reading the file or attempting to decode block undo from file's data.")
             throw .corruptedBlockData // TODO: Differenciate from not being able to open the file for reading.
         }
 
@@ -283,14 +407,13 @@ actor PersistentBlockStorage: BlockStorage {
         }
         return blockUndo
     }
-
-    private func filePath(for number: Int, undo: Bool = false) -> FilePath {
-        guard let blocksDir else { preconditionFailure() }
-        let formatted = String(format: "%0\(digits)d", number)
-        return blocksDir.appending("\(undo ? undoFilePrefix : blockFilePrefix)\(formatted).dat")
-    }
 }
 
 private let blockFilePrefix = "blk"
 private let undoFilePrefix = "rev"
 private let digits = 5 // Warning: If this value changes, also must the `regex` local variable
+
+private func filePath(_ base: FilePath, for number: Int, undo: Bool = false) -> FilePath {
+    let formatted = String(format: "%0\(digits)d", number)
+    return base.appending("\(undo ? undoFilePrefix : blockFilePrefix)\(formatted).dat")
+}

--- a/src/bitcoin-blockchain/block/storage/TransientBlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/TransientBlockStorage.swift
@@ -19,8 +19,9 @@ actor TransientBlockStorage: BlockStorage {
 
     internal private(set) var sizeOnDisk = 0
 
-    func store(_ block: Block, undo: BlockUndo) throws(BlockStorageError) -> BlockStorageLocator {
-        try store(block: block, undo: undo)
+    func storeGenesisBlock(_ block: Block, undo: BlockUndo) throws(BlockStorageError) -> BlockStorageLocator {
+        precondition(blocks.isEmpty)
+        return try store(block: block, undo: undo)
     }
 
     func store(_ block: Block) throws(BlockStorageError) -> BlockStorageLocator {
@@ -66,5 +67,44 @@ actor TransientBlockStorage: BlockStorage {
             undo = nil
         }
         return (blocks[locator.offset], undo)
+    }
+
+    var iterator: BlockIterator? {
+        next(BlockStorageLocator(file: -1, offset: -1, undoOffset: -1), includeUndo: true)
+    }
+
+    func next(_ iterator: BlockIterator) -> BlockIterator? {
+        next(iterator.locator, includeUndo: false)
+    }
+
+    func next(_ iterator: BlockIterator, includeUndo: Bool) -> BlockIterator? {
+        next(iterator.locator, includeUndo: includeUndo)
+    }
+
+    func clearUndo() {
+        blockUndos = .init()
+    }
+
+    private func next(_ locator: BlockStorageLocator, includeUndo: Bool) -> BlockIterator? {
+        let offset: Int
+        if locator.offset == -1 {
+            offset = 0
+        } else {
+            offset = locator.offset + 1
+        }
+        guard blocks.indices.contains(offset) else {
+            return nil
+        }
+        let block = blocks[offset]
+
+        let undoOffset: Int
+        if locator.offset == -1 {
+            undoOffset = blockUndos.isEmpty || !includeUndo ? -1 : 0
+        } else {
+            undoOffset = locator.undoOffset == -1 || !includeUndo || !blockUndos.indices.contains(locator.undoOffset + 1) ? -1 : locator.undoOffset + 1
+        }
+        let blockUndo = undoOffset == -1 ? nil : blockUndos[undoOffset]
+        let locator = BlockStorageLocator(file: -1, offset: offset, undoOffset: undoOffset)
+        return .init(locator: locator, block: block, undo: blockUndo)
     }
 }

--- a/src/bitcoin-blockchain/coins/CoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/CoinsIndex.swift
@@ -17,6 +17,7 @@ protocol CoinsIndex: Sendable {
 
     mutating func add(_ coin: UnspentOutput, for outpoint: Outpoint) async
     mutating func remove(_ outpoint: Outpoint) async throws
+    mutating func clear() async
 }
 
 enum CoinsError: Error {

--- a/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/PersistentCoinsIndex.swift
@@ -1,4 +1,5 @@
 import LMDB
+import _NIOFileSystem
 import Foundation
 import struct SystemPackage.FilePath
 import Logging
@@ -12,13 +13,14 @@ actor PersistentCoinsIndex: CoinsIndex {
     }
 
     init(path: FilePath, logger: Logger) {
+        self.path = path.appending("coins")
         self.logger = logger
-        env = try! Environment(at: URL(filePath: path.appending("coins").string), maxDBs: 1, pages: 380_000, options: [.noSubDir])
-        try! env.createDB(byID)
+        env = initEnv(path: self.path)
     }
 
-    let logger: Logger
-    private let env: Environment
+    private let path: FilePath
+    private let logger: Logger
+    private var env: Environment!
 
     var all: [Outpoint : UnspentOutput] { get {
         var unordered = [Outpoint : UnspentOutput]()
@@ -113,6 +115,21 @@ actor PersistentCoinsIndex: CoinsIndex {
             throw .deletionIssue
         }
     }
+
+    func clear() async {
+        env = nil // closes env
+
+        // Removes folder
+        let fs = FileSystem.shared
+        do {
+            try await fs.removeItem(at: path)
+        } catch {
+            logger.error("Issue removing block index directory: \(error.localizedDescription)")
+            return // TODO: Probably throw here
+        }
+
+        env = initEnv(path: path)
+    }
 }
 
 private let byID = Database.Descriptor("by-id")
@@ -132,4 +149,10 @@ private func _get(_ outpoint: Outpoint, byID: borrowing LMDB.Database) throws(Co
     } catch {
         throw .corruptedCoinData
     }
+}
+
+private func initEnv(path: FilePath) -> Environment {
+    let env = try! Environment(at: URL(filePath: path.string), maxDBs: 1, pages: 380_000, options: [.noSubDir])
+    try! env.createDB(byID)
+    return env
 }

--- a/src/bitcoin-blockchain/coins/TransientCoinsIndex.swift
+++ b/src/bitcoin-blockchain/coins/TransientCoinsIndex.swift
@@ -42,4 +42,8 @@ struct TransientCoinsIndex: CoinsIndex {
     mutating func remove(_ outpoint: Outpoint) {
         coins[outpoint] = nil
     }
+
+    mutating func clear() {
+        coins = .init()
+    }
 }

--- a/src/bitcoin-node/config/NodeConfig+parse.swift
+++ b/src/bitcoin-node/config/NodeConfig+parse.swift
@@ -15,7 +15,7 @@ extension NodeConfig {
         // Check whether we are accessing the default location
         let isDefault = location == Self.defaultLocation
         if isDefault {
-            print("Checking default location \"\(location)\"…")
+            print("Checking default location \"\(location)\"…") // TODO: Remove prints
         } else {
             print("Checking custom location \"\(location)\"…")
         }

--- a/src/bitcoin-node/services/RPCService.swift
+++ b/src/bitcoin-node/services/RPCService.swift
@@ -142,6 +142,9 @@ actor RPCService: Service {
             case .getBlock(let params):
                 let result = try await GetBlockRPC(params).run(blockchain: blockchain)
                 try await outbound.write(.init(id: request.id, result: .getBlock(result)))
+            case .getHeader(let params):
+                let result = try await GetHeaderRPC(params).run(blockchain: blockchain)
+                try await outbound.write(.init(id: request.id, result: .getHeader(result)))
             case .generateToAddress(let params):
                 let result = try await GenerateToAddressRPC(params).run(blockchain: blockchain)
                 try await outbound.write(.init(id: request.id, result: .generateToAddress(result)))
@@ -163,6 +166,13 @@ actor RPCService: Service {
             case .sendTransaction(let params):
                 let result = try await SendTransactionRPC(params).run(blockchain: blockchain)
                 try await outbound.write(.init(id: request.id, result: .sendTransaction(result)))
+            case .reindex:
+                await ReindexRPC().run(blockchain: blockchain)
+            case .reindexStatus:
+                let result = await ReindexStatusRPC().run(blockchain: blockchain)
+                try await outbound.write(.init(id: request.id, result: .reindexStatus(result)))
+            case .reindexStop:
+                await ReindexStopRPC().run(blockchain: blockchain)
             }
         } catch let error as JSONRPCResponse.Error {
             // try await outbound.write(.init(id: request.id, error: error))

--- a/src/bitcoin-rpc/commands/GetHeaderRPC.swift
+++ b/src/bitcoin-rpc/commands/GetHeaderRPC.swift
@@ -1,0 +1,40 @@
+import Foundation
+import JSONRPC
+import BitcoinCrypto
+import BitcoinBase
+import BitcoinBlockchain
+
+extension GetHeaderRPC {
+
+    public func run(blockchain: BlockchainService) async throws(JSONRPCResponse.Error) -> Result {
+
+        guard let blockIDByteSwapped = Data(hex: params.blockID), blockIDByteSwapped.count == Block.idLength else {
+            throw .init(.invalidParams, "Invalid block hash.")
+        }
+        let blockID = Data(blockIDByteSwapped.reversed())
+        guard let block = await blockchain.getHeader(blockID) else {
+            throw .init(.invalidParams, "Block not found.")
+        }
+        guard let info = await blockchain.getBlockInfo(blockID) else {
+            throw .init(.internalError, "Failed to get blockchain information for block.")
+        }
+
+        return .init(
+            id: block.idHex,
+            confirmations: info.confirmations,
+            status: info.status.description,
+            height: info.height,
+            version: block.version,
+            versionHex: BinaryEncoder.encode(Int32(block.version)).reversed().hex, // verion as hex string
+            merkleRoot: block.merkleRoot.reversed().hex,
+            time: Int(block.time.timeIntervalSince1970),
+            medianTime: Int(info.medianTime.timeIntervalSince1970),
+            nonce: block.nonce,
+            bits: BinaryEncoder.encode(UInt32(block.target)).reversed().hex, // block.target as hex
+            difficulty: info.difficulty, // block.difficulty as double
+            chainwork: info.chainwork.reversed().hex,
+            previous: block.previous.reversed().hex,
+            nextBlock: info.next?.reversed().hex
+        )
+    }
+}

--- a/src/bitcoin-rpc/commands/HelpRPC.swift
+++ b/src/bitcoin-rpc/commands/HelpRPC.swift
@@ -46,11 +46,15 @@ private let commands: [any RPCCommand.Type] = [
     ConnectRPC.self,
     GetBlockHashRPC.self,
     GetBlockRPC.self,
+    GetHeaderRPC.self,
     GenerateToAddressRPC.self,
     GetBlockchainInfoRPC.self,
     GetChainTipsRPC.self,
     GetMempoolRPC.self,
     GetTransactionRPC.self,
     SendTransactionRPC.self,
-    GetPeerInfoRPC.self
+    GetPeerInfoRPC.self,
+    ReindexRPC.self,
+    ReindexStatusRPC.self,
+    ReindexStopRPC.self
 ]

--- a/src/bitcoin-rpc/commands/ReindexRPC.swift
+++ b/src/bitcoin-rpc/commands/ReindexRPC.swift
@@ -1,0 +1,10 @@
+import Foundation
+import JSONRPC
+import BitcoinBlockchain
+
+extension ReindexRPC {
+
+    public func run(blockchain: BlockchainService) async {
+        await blockchain.startReindex()
+    }
+}

--- a/src/bitcoin-rpc/commands/ReindexStatusRPC.swift
+++ b/src/bitcoin-rpc/commands/ReindexStatusRPC.swift
@@ -1,0 +1,10 @@
+import Foundation
+import JSONRPC
+import BitcoinBlockchain
+
+extension ReindexStatusRPC {
+
+    public func run(blockchain: BlockchainService) async -> Result {
+        await blockchain.isReindexing
+    }
+}

--- a/src/bitcoin-rpc/commands/ReindexStopRPC.swift
+++ b/src/bitcoin-rpc/commands/ReindexStopRPC.swift
@@ -1,0 +1,10 @@
+import Foundation
+import JSONRPC
+import BitcoinBlockchain
+
+extension ReindexStopRPC {
+
+    public func run(blockchain: BlockchainService) async {
+        await blockchain.stopReindex()
+    }
+}

--- a/src/bitcoin-utility/commands/BitcoinUtility.swift
+++ b/src/bitcoin-utility/commands/BitcoinUtility.swift
@@ -14,5 +14,5 @@ struct BitcoinUtility: AsyncParsableCommand {
         """,
         discussion: "Use bcutil to perform off-chain operations as well as to control and use either a single or multiple running Swift Bitcoin nodes (bcnode).",
         version: "1.0.0",
-        subcommands: [Node.self, Seed.self, ECNew.self, ECToPublic.self, ECToAddress.self, ScriptToAddress.self, AddressDecode.self, ScriptDecode.self, HDNew.self, HDToPublic.self, HDPrivate.self, HDPublic.self, MnemonicNew.self, MnemonicToSeed.self, ECToWIF.self, WIFToEC.self, MessageSign.self, MessageVerify.self, CreateTransaction.self, SignTransaction.self],
+        subcommands: [Node.self, Seed.self, ECNew.self, ECToPublic.self, ECToAddress.self, ScriptToAddress.self, AddressDecode.self, ScriptDecode.self, HDNew.self, HDToPublic.self, HDPrivate.self, HDPublic.self, MnemonicNew.self, MnemonicToSeed.self, ECToWIF.self, WIFToEC.self, MessageSign.self, MessageVerify.self, CreateTransaction.self, SignTransaction.self, DB.self, Chain.self],
         defaultSubcommand: Node.self)}

--- a/src/bitcoin-utility/commands/Chain.swift
+++ b/src/bitcoin-utility/commands/Chain.swift
@@ -1,0 +1,18 @@
+import ArgumentParser
+import enum BitcoinTransport.NodeNetwork
+
+struct Chain: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: "",
+        discussion: """
+        Access local chain data.
+        """,
+        subcommands: [
+            ChainInfo.self, Reindex.self
+        ]
+    )
+
+    @Option(name: .shortAndLong, help: "The P2P network for the data directory. During development this value will default to regtest.")
+    var network = NodeNetwork.testnet // TODO: Eventually switch to testnet4 and then mainnet.
+}

--- a/src/bitcoin-utility/commands/Chain/ChainInfo.swift
+++ b/src/bitcoin-utility/commands/Chain/ChainInfo.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import BitcoinBlockchain
+import struct SystemPackage.FilePath
+import Foundation
+
+struct ChainInfo: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "info",
+        abstract: ""
+    )
+
+    @OptionGroup var parent: Chain
+
+    mutating func run() async throws {
+        let params: ConsensusParams = switch parent.network {
+        case .mainnet: .mainnet
+        case .testnet: .testnet
+        case .regtest: .regtest
+        }
+        let blockchain = try await BlockchainService(params: params, config: .init(dataLocation: .defaultPath), logger: .init(label: ""))
+        print("""
+        Headers: \(await blockchain.headers)
+        Blocks: \(await blockchain.height)
+        """)
+    }
+}

--- a/src/bitcoin-utility/commands/Chain/Reindex.swift
+++ b/src/bitcoin-utility/commands/Chain/Reindex.swift
@@ -1,0 +1,26 @@
+import ArgumentParser
+import BitcoinBlockchain
+import struct SystemPackage.FilePath
+import Foundation
+import Logging
+
+struct Reindex: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ""
+    )
+
+    @OptionGroup var parent: Chain
+
+    mutating func run() async throws {
+        let params: ConsensusParams = switch parent.network {
+        case .mainnet: .mainnet
+        case .testnet: .testnet
+        case .regtest: .regtest
+        }
+        var logger = Logger(label: "reindex")
+        logger.logLevel = .info
+        let blockchain = try await BlockchainService(params: params, config: .init(dataLocation: .defaultPath), logger: logger)
+        await blockchain.reindex()
+    }
+}

--- a/src/bitcoin-utility/commands/DB.swift
+++ b/src/bitcoin-utility/commands/DB.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+
+struct DB: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: "",
+        discussion: """
+
+        """,
+        subcommands: [
+            Stats.self, Drop.self, Duplicate.self
+        ],
+        defaultSubcommand: Stats.self
+    )
+
+    @Option var path: String
+}

--- a/src/bitcoin-utility/commands/DB/Drop.swift
+++ b/src/bitcoin-utility/commands/DB/Drop.swift
@@ -1,0 +1,29 @@
+import ArgumentParser
+import LMDB
+import struct SystemPackage.FilePath
+import Foundation
+
+struct Drop: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ""
+    )
+
+    @OptionGroup var parent: DB
+
+    mutating func run() async throws {
+        let path = FilePath(URL.homeDirectory.relativePath).appending(".swift-bitcoin/data").appending("block-index")
+        var env = try! Environment(at: URL(filePath: path.string), maxDBs: 2, pages: 3_000, options: [.noSubDir])
+        try! env.createDB(byID)
+        try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey, .duplicateSort, .duplicateFixed])) { _, _ in }
+        try env.withTransaction(db: byID, byHeight) { tx, byID, byHeight in
+            try byHeight.drop(delete: true)
+            try byID.drop(delete: true)
+        }
+        env.drop()
+    }
+}
+private let byIDName = "by-id"
+private let byHeightName = "by-height"
+private let byID = Database.Descriptor(byIDName)
+private let byHeight = Database.Descriptor(byHeightName)

--- a/src/bitcoin-utility/commands/DB/Duplicate.swift
+++ b/src/bitcoin-utility/commands/DB/Duplicate.swift
@@ -1,0 +1,25 @@
+import ArgumentParser
+import LMDB
+import struct SystemPackage.FilePath
+import Foundation
+
+struct Duplicate: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ""
+    )
+
+    @OptionGroup var parent: DB
+
+    mutating func run() async throws {
+        let path = FilePath(URL.homeDirectory.relativePath).appending(".swift-bitcoin/data").appending("coins")
+        let env = try! Environment(at: URL(filePath: path.string), maxDBs: 2, pages: 3_000, options: [.noSubDir])
+        //try! env.createDB(byID)
+        //try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey, .duplicateSort, .duplicateFixed])) { _, _ in }
+        try env.copy(options: .compact)
+    }
+}
+private let byIDName = "by-id"
+private let byHeightName = "by-height"
+private let byID = Database.Descriptor(byIDName)
+private let byHeight = Database.Descriptor(byHeightName)

--- a/src/bitcoin-utility/commands/DB/Stats.swift
+++ b/src/bitcoin-utility/commands/DB/Stats.swift
@@ -1,0 +1,30 @@
+import ArgumentParser
+import LMDB
+import struct SystemPackage.FilePath
+import Foundation
+
+struct Stats: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ""
+    )
+
+    @OptionGroup var parent: DB
+
+    mutating func run() async throws {
+        let path = FilePath(parent.path)
+        let env = try! Environment(at: URL(filePath: path.string), options: [.noSubDir, .readOnly])
+//        try! env.createDB(byID)
+//        try! env.withTransaction(db: .init(byHeightName, options: [.create, .integerKey, .duplicateSort, .duplicateFixed])) { _, _ in }
+
+        let (byIDStats, byHeightStats) = try env.withTransaction(db: byID, byHeight, options: .readOnly) { tx, byID, byHeight in
+            (try byID.stats, try byHeight.stats)
+        }
+        print("By-ID Entries: \(byIDStats.entries)")
+        print("By-Height Entries: \(byHeightStats.entries)")
+    }
+}
+private let byIDName = "by-id"
+private let byHeightName = "by-height"
+private let byID = Database.Descriptor(byIDName)
+private let byHeight = Database.Descriptor(byHeightName)

--- a/src/bitcoin-utility/commands/Node.swift
+++ b/src/bitcoin-utility/commands/Node.swift
@@ -1,5 +1,5 @@
 import ArgumentParser
-import BitcoinTransport // NodeNetwork
+import enum BitcoinTransport.NodeNetwork
 
 struct Node: AsyncParsableCommand {
 
@@ -18,6 +18,7 @@ struct Node: AsyncParsableCommand {
             DisconnectPeer.self,
             GetBlockHash.self,
             GetBlock.self,
+            GetHeader.self,
             GenerateToAddress.self,
             GetBlockchainInfo.self,
             GetChainTips.self,
@@ -25,7 +26,10 @@ struct Node: AsyncParsableCommand {
             GetPeerInfo.self,
             GetTransaction.self,
             SendTransaction.self,
-            SendCommand.self
+            SendCommand.self,
+            ReindexCommand.self,
+            ReindexStatus.self,
+            ReindexStop.self
         ],
         defaultSubcommand: SendCommand.self
     )

--- a/src/bitcoin-utility/commands/Node/GetHeader.swift
+++ b/src/bitcoin-utility/commands/Node/GetHeader.swift
@@ -1,0 +1,19 @@
+import ArgumentParser
+import JSONRPC
+
+struct GetHeader: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: GetBlockRPC.description
+    )
+
+    @OptionGroup var parent: Node
+
+    @Argument(help: "A block identifier.")
+    var blockID: String
+
+    mutating func run() async throws {
+        let request = JSONRPCRequest(.getHeader(.init(blockID: blockID)))
+        try await sendRPC(host: parent.host, port: parent.resolvedPort, request: request)
+    }
+}

--- a/src/bitcoin-utility/commands/Node/ReindexCommand.swift
+++ b/src/bitcoin-utility/commands/Node/ReindexCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import JSONRPC
+
+struct ReindexCommand: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "reindex",
+        abstract: ReindexRPC.description
+    )
+
+    @OptionGroup var parent: Node
+
+    mutating func run() async throws {
+        try await sendRPC(host: parent.host, port: parent.resolvedPort, request: JSONRPCRequest(.reindex))
+    }
+}

--- a/src/bitcoin-utility/commands/Node/ReindexStatus.swift
+++ b/src/bitcoin-utility/commands/Node/ReindexStatus.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+import JSONRPC
+
+struct ReindexStatus: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ReindexStatusRPC.description
+    )
+
+    @OptionGroup var parent: Node
+
+    mutating func run() async throws {
+        try await sendRPC(host: parent.host, port: parent.resolvedPort, request: JSONRPCRequest(.reindexStatus))
+    }
+}

--- a/src/bitcoin-utility/commands/Node/ReindexStop.swift
+++ b/src/bitcoin-utility/commands/Node/ReindexStop.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+import JSONRPC
+
+struct ReindexStop: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: ReindexStopRPC.description
+    )
+
+    @OptionGroup var parent: Node
+
+    mutating func run() async throws {
+        try await sendRPC(host: parent.host, port: parent.resolvedPort, request: JSONRPCRequest(.reindexStop))
+    }
+}

--- a/src/bitcoin-utility/commands/Node/SendCommand.swift
+++ b/src/bitcoin-utility/commands/Node/SendCommand.swift
@@ -27,13 +27,17 @@ struct SendCommand: AsyncParsableCommand {
             DisconnectPeerRPC.self,
             GetBlockHashRPC.self,
             GetBlockRPC.self,
+            GetHeaderRPC.self,
             GenerateToAddressRPC.self,
             GetBlockchainInfoRPC.self,
             GetChainTipsRPC.self,
             GetMempoolRPC.self,
             GetPeerInfoRPC.self,
             GetTransactionRPC.self,
-            SendTransactionRPC.self
+            SendTransactionRPC.self,
+            ReindexRPC.self,
+            ReindexStatusRPC.self,
+            ReindexStopRPC.self
         ] as [any RPCCommand.Type]).map({ $0.method}).contains(method) {
             // try StartP2P.parseAsRoot(params).run()
             throw ValidationError("Use bcutil node \(method) command instead.")

--- a/src/json-rpc/Commands/GetHeaderRPC.swift
+++ b/src/json-rpc/Commands/GetHeaderRPC.swift
@@ -1,0 +1,67 @@
+/// Get information about the block header.
+public struct GetHeaderRPC: RPCCommand, Sendable {
+
+    public struct Params: Codable, Sendable {
+        public init(blockID: String) {
+            self.blockID = blockID
+        }
+
+        public let blockID: String // A block identifier.
+    }
+
+    public struct Result: Codable, Sendable {
+
+        public init(id: String, confirmations: Int, status: String, height: Int, version: Int, versionHex: String, merkleRoot: String, time: Int, medianTime: Int, nonce: Int, bits: String, difficulty: Double, chainwork: String, previous: String, nextBlock: String?) {
+            self.id = id
+            self.confirmations = confirmations
+            self.status = status
+            self.height = height
+            self.version = version
+            self.versionHex = versionHex
+            self.merkleRoot = merkleRoot
+            self.time = time
+            self.medianTime = medianTime
+            self.nonce = nonce
+            self.bits = bits
+            self.difficulty = difficulty
+            self.chainwork = chainwork
+            self.previous = previous
+            self.nextBlock = nextBlock
+        }
+
+
+        /// Block ID or _hash_ e.g. `1205ad9b86df6d01c2fbdaef1cc08dcbd02ec3b875763c978da44d87f55fedc2`
+        public let id: String
+
+        /// How many mined blocks on top of this one or `chain.totalBlocks - block.height`. Always 1 or higher.
+        public let confirmations: Int
+
+        public let status: String
+
+        /// The height of this block (0-based index).
+        public let height: Int
+
+        public let version: Int // "version": 536870912,
+        public let versionHex: String // "versionHex": "20000000",
+        public let merkleRoot: String // "merkleroot": "cda84ffb2707461958ad15d50387a167d31c0fd77205496b0761230e460c4ccc",
+        public let time: Int // "time": 1740763178,
+        public let medianTime: Int // "mediantime": 1740763178,
+        public let nonce: Int // "nonce": 4,
+        public let bits: String // "bits": "207fffff",
+        public let difficulty: Double // "difficulty": 4.656542373906925e-10,
+        public let chainwork: String  // "chainwork": "0000000000000000000000000000000000000000000000000000000000000004",
+
+        public let previous: String // "previousblockhash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+        public let nextBlock: String? // "nextblockhash": "3dc83cd173be15191c8f1bdbf5ac00a28a8c53f5ac40a912a4c9612378a1f258",
+    }
+
+    public init(_ params: Params) {
+        self.params = params
+    }
+
+    public let params: Params
+
+    public static let method = "get-header"
+    public static let params = "<block-id>"
+    public static let description = "Returns information about the specified block header."
+}

--- a/src/json-rpc/Commands/ReindexRPC.swift
+++ b/src/json-rpc/Commands/ReindexRPC.swift
@@ -1,0 +1,11 @@
+public struct ReindexRPC: RPCCommand, Sendable {
+
+    public typealias Params = Never
+    public typealias Result = Never
+
+    public init() {}
+
+    public static let method = "reindex"
+    public static let params = ""
+    public static let description = "Recreates the block index, chain state (coins) and block undo data files."
+}

--- a/src/json-rpc/Commands/ReindexStatusRPC.swift
+++ b/src/json-rpc/Commands/ReindexStatusRPC.swift
@@ -1,0 +1,11 @@
+public struct ReindexStatusRPC: RPCCommand, Sendable {
+
+    public typealias Params = Never
+    public typealias Result = Bool
+
+    public init() {}
+
+    public static let method = "reindex-status"
+    public static let params = ""
+    public static let description: String = "Returns whether there is currently a re-indexation process taking place."
+}

--- a/src/json-rpc/Commands/ReindexStopRPC.swift
+++ b/src/json-rpc/Commands/ReindexStopRPC.swift
@@ -1,0 +1,11 @@
+public struct ReindexStopRPC: RPCCommand, Sendable {
+
+    public typealias Params = Never
+    public typealias Result = Never
+
+    public init() {}
+
+    public static let method = "reindex-stop"
+    public static let params = ""
+    public static let description = "Interrupts the running re-indexation process."
+}

--- a/src/json-rpc/JSONRPCRequest+Params.swift
+++ b/src/json-rpc/JSONRPCRequest+Params.swift
@@ -12,13 +12,17 @@ extension JSONRPCRequest {
             disconnectPeer(DisconnectPeerRPC.Params),
             getBlockHash(GetBlockHashRPC.Params),
             getBlock(GetBlockRPC.Params),
+            getHeader(GetHeaderRPC.Params),
             generateToAddress(GenerateToAddressRPC.Params),
             getBlockchainInfo,
             getChainTips,
             getMempool,
             getPeerInfo,
             getTransaction(GetTransactionRPC.Params),
-            sendTransaction(SendTransactionRPC.Params)
+            sendTransaction(SendTransactionRPC.Params),
+            reindex,
+            reindexStatus,
+            reindexStop
     }
 }
 
@@ -42,6 +46,7 @@ extension JSONRPCRequest.Params {
         case DisconnectPeerRPC.method: .disconnectPeer(try .init(from: decoder))
         case GetBlockHashRPC.method: .getBlockHash(try .init(from: decoder))
         case GetBlockRPC.method: .getBlock(try .init(from: decoder))
+        case GetHeaderRPC.method: .getHeader(try .init(from: decoder))
         case GenerateToAddressRPC.method: .generateToAddress(try .init(from: decoder))
         case GetBlockchainInfoRPC.method: .getBlockchainInfo
         case GetChainTipsRPC.method: .getChainTips
@@ -49,6 +54,9 @@ extension JSONRPCRequest.Params {
         case GetPeerInfoRPC.method: .getPeerInfo
         case GetTransactionRPC.method: .getTransaction(try .init(from: decoder))
         case SendTransactionRPC.method: .sendTransaction(try .init(from: decoder))
+        case ReindexRPC.method: .reindex
+        case ReindexStatusRPC.method: .reindexStatus
+        case ReindexStopRPC.method: .reindexStop
         default: throw DecodingError.typeMismatch(Self.self, .init(codingPath: decoder.codingPath, debugDescription: ""))
         }
     }
@@ -65,6 +73,7 @@ extension JSONRPCRequest.Params {
         case .disconnectPeer(let params): try params.encode(to: encoder)
         case .getBlockHash(let params): try params.encode(to: encoder)
         case .getBlock(let params): try params.encode(to: encoder)
+        case .getHeader(let params): try params.encode(to: encoder)
         case .generateToAddress(let params): try params.encode(to: encoder)
         case .getBlockchainInfo: try container.encodeNil()
         case .getChainTips: try container.encodeNil()
@@ -72,6 +81,9 @@ extension JSONRPCRequest.Params {
         case .getPeerInfo: try container.encodeNil()
         case .getTransaction(let params): try params.encode(to: encoder)
         case .sendTransaction(let params): try params.encode(to: encoder)
+        case .reindex: try container.encodeNil()
+        case .reindexStatus: try container.encodeNil()
+        case .reindexStop: try container.encodeNil()
         }
     }
 
@@ -86,6 +98,7 @@ extension JSONRPCRequest.Params {
         case .disconnectPeer(_): DisconnectPeerRPC.method
         case .getBlockHash(_): GetBlockHashRPC.method
         case .getBlock(_): GetBlockRPC.method
+        case .getHeader(_): GetHeaderRPC.method
         case .generateToAddress(_): GenerateToAddressRPC.method
         case .getBlockchainInfo: GetBlockchainInfoRPC.method
         case .getChainTips: GetChainTipsRPC.method
@@ -93,6 +106,9 @@ extension JSONRPCRequest.Params {
         case .getPeerInfo: GetPeerInfoRPC.method
         case .getTransaction(_): GetTransactionRPC.method
         case .sendTransaction(_): SendTransactionRPC.method
+        case .reindex: ReindexRPC.method
+        case .reindexStatus: ReindexStatusRPC.method
+        case .reindexStop: ReindexStopRPC.method
         }
     }
 }

--- a/src/json-rpc/JSONRPCResponse+Result.swift
+++ b/src/json-rpc/JSONRPCResponse+Result.swift
@@ -12,13 +12,17 @@ extension JSONRPCResponse {
             disconnectPeer(DisconnectPeerRPC.Result),
             getBlockHash(GetBlockHashRPC.Result),
             getBlock(GetBlockRPC.Result),
+            getHeader(GetHeaderRPC.Result),
             generateToAddress(GenerateToAddressRPC.Result),
             getBlockchainInfo(GetBlockchainInfoRPC.Result),
             getChainTips(GetChainTipsRPC.Result),
             getMempool(GetMempoolRPC.Result),
             getPeerInfo(GetPeerInfoRPC.Result),
             getTransaction(GetTransactionRPC.Result),
-            sendTransaction(SendTransactionRPC.Result)
+            sendTransaction(SendTransactionRPC.Result),
+            reindex,
+            reindexStatus(ReindexStatusRPC.Result),
+            reindexStop
     }
 }
 
@@ -38,6 +42,7 @@ extension JSONRPCResponse.Result {
         case DisconnectPeerRPC.method: .disconnectPeer(try .init(from: decoder))
         case GetBlockHashRPC.method: .getBlockHash(try .init(from: decoder))
         case GetBlockRPC.method: .getBlock(try .init(from: decoder))
+        case GetHeaderRPC.method: .getHeader(try .init(from: decoder))
         case GenerateToAddressRPC.method: .generateToAddress(try .init(from: decoder))
         case GetBlockchainInfoRPC.method: .getBlockchainInfo(try .init(from: decoder))
         case GetChainTipsRPC.method: .getChainTips(try .init(from: decoder))
@@ -45,6 +50,9 @@ extension JSONRPCResponse.Result {
         case GetPeerInfoRPC.method: .getPeerInfo(try .init(from: decoder))
         case GetTransactionRPC.method: .getTransaction(try .init(from: decoder))
         case SendTransactionRPC.method: .sendTransaction(try .init(from: decoder))
+        case ReindexRPC.method: .reindex
+        case ReindexStatusRPC.method: .reindexStatus(try .init(from: decoder))
+        case ReindexStopRPC.method: .reindexStop
         default: throw DecodingError.typeMismatch(Self.self, .init(codingPath: decoder.codingPath, debugDescription: ""))
         }
     }
@@ -61,6 +69,7 @@ extension JSONRPCResponse.Result {
         case .disconnectPeer(let result): try result.encode(to: encoder)
         case .getBlockHash(let result): try result.encode(to: encoder)
         case .getBlock(let result): try result.encode(to: encoder)
+        case .getHeader(let result): try result.encode(to: encoder)
         case .generateToAddress(let result): try result.encode(to: encoder)
         case .getBlockchainInfo(let result): try result.encode(to: encoder)
         case .getChainTips(let result): try result.encode(to: encoder)
@@ -68,6 +77,9 @@ extension JSONRPCResponse.Result {
         case .getPeerInfo(let result): try result.encode(to: encoder)
         case .getTransaction(let result): try result.encode(to: encoder)
         case .sendTransaction(let result): try result.encode(to: encoder)
+        case .reindex: try container.encodeNil()
+        case .reindexStatus(let result): try result.encode(to: encoder)
+        case .reindexStop: try container.encodeNil()
         }
     }
 }

--- a/src/lmdb/Database.swift
+++ b/src/lmdb/Database.swift
@@ -140,8 +140,8 @@ package struct Database: ~Copyable {
     /// - warning: Dropping a database also closes it. You may no longer use the database after dropping it.
     /// - seealso: `empty()`
     /// - throws: an error if operation fails. See `AccessError`.
-    public func drop() throws(AccessError) {
-        guard mdb_drop(txHandle, handle, 0) == MDB_SUCCESS else {
+    public func drop(delete: Bool = false) throws(AccessError) {
+        guard mdb_drop(txHandle, handle, delete ? 1 : 0) == MDB_SUCCESS else {
             throw .dropIssue
         }
     }

--- a/src/lmdb/Environment+CopyOptions.swift
+++ b/src/lmdb/Environment+CopyOptions.swift
@@ -1,0 +1,15 @@
+import CLMDB
+import Foundation
+
+extension Environment {
+
+    package struct CopyOptions: OptionSet, Sendable {
+
+        package let rawValue: Int32
+        package init(rawValue: Int32) { self.rawValue = rawValue}
+
+        package static let compact = Self(rawValue: MDB_CP_COMPACT)
+
+        var unsigned: UInt32 { .init(rawValue) }
+    }
+}

--- a/src/lmdb/Environment.swift
+++ b/src/lmdb/Environment.swift
@@ -10,7 +10,7 @@ package struct Environment: ~Copyable {
 
         var handle: OpaquePointer?
         var status = mdb_env_create(&handle)
-        guard status == MDB_SUCCESS else {
+        guard status == MDB_SUCCESS, let handle else {
             throw .createIssue
         }
 
@@ -38,10 +38,50 @@ package struct Environment: ~Copyable {
             throw .openIssue
         }
 
-        self.handle = handle!
+        self.handle = handle
     }
 
     private let handle: OpaquePointer
+
+    func databases() throws -> [String] {
+        try withTransaction(db: .init()) { _, db in
+            try db.withCursor(readOnly: true) { cursor in
+                var names = [String]()
+                while let (key, _) = try cursor.getPair() {
+                    guard let name = String(data: key, encoding: .utf8) else {
+                        continue
+                    }
+                    names.append(name)
+                }
+                return names
+            }
+        }
+    }
+
+    func dropAll() throws {
+        for db in try databases() {
+            try withTransaction(db: .init(db)) { _, db in
+                try db.drop(delete: true)
+            }
+        }
+    }
+
+    package mutating func drop() {
+        guard mdb_env_sync(handle, 1) == MDB_SUCCESS else {
+            preconditionFailure()
+        }
+    }
+
+    public func copy(options: CopyOptions = []) throws(InitError) {
+        var cPathPtr: UnsafePointer<CChar>? = nil
+        guard mdb_env_get_path(handle, &cPathPtr) == MDB_SUCCESS, let cPathPtr else {
+            throw .createIssue
+        }
+        let path = String(cString: cPathPtr) + "-2"
+        guard mdb_env_copy2(handle, path.cString(using: .utf8), options.unsigned) == MDB_SUCCESS else {
+            throw .createIssue
+        }
+    }
 
     package func createDB(_ db: Database.Descriptor) throws(Transaction.InitError<Never>) {
         var db = db


### PR DESCRIPTION
Chain reindex bcutil command
Reindex start, status and stop RPC commands
Optimizations for block/undo disk storage: keep track file sizes to facilitate offset calculation Block storage iterable
Get header RPC with index information
DB utility command group with lmdb database utilities for devs Better LMDB integration allowing to recreate environment LMDB bindings for clearing env, DBs, drop

Argument parser, NIO updated

Fixes #476