### PR TITLE
Modified block file encoding to include the length of the block only

### DIFF
--- a/src/bitcoin-blockchain/block/Block.swift
+++ b/src/bitcoin-blockchain/block/Block.swift
@@ -161,9 +161,11 @@ extension Block: CustomBinaryCodable {
             self.init(version: version, previous: previous, merkleRoot: merkleRoot, time: time, target: target, nonce: nonce, txs: txs)
         case .file(let magicBytes):
             let magic = Int(try decoder.decode() as UInt32)
-            guard magic == magicBytes else { throw BinaryDecodingError.limitExceeded } // TODO: Replace error for something appropriate
+            guard magic == magicBytes else {
+                throw BinaryDecodingError.limitExceeded
+            } // TODO: Replace error for something appropriate
             let length = Int(try decoder.decode() as UInt32)
-            decoder.setLimit(length - MemoryLayout<UInt32>.size * 2)
+            decoder.setLimit(length)
             try self.init(from: &decoder)
             decoder.resetLimit()
         }
@@ -183,7 +185,7 @@ extension Block: CustomBinaryCodable {
             }
         case .file(let magicBytes):
             encoder.encode(UInt32(magicBytes))
-            encoder.encode(UInt32(dataSize(encoding: encoding)))
+            encoder.encode(UInt32(dataSize))
             encode(to: &encoder)
         }
     }

--- a/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
+++ b/src/bitcoin-blockchain/block/storage/PersistentBlockStorage.swift
@@ -353,8 +353,8 @@ actor PersistentBlockStorage: BlockStorage {
                 let length = lengthBytes.withUnsafeBytes {
                     $0.loadUnaligned(as: UInt32.self)
                 }
-                return buffer.readBytes(length: Int(length))!
-                // `Int(length +  MemoryLayout<UInt32>.size * 2)` could also be `newFileInfo.size - offset` which will be higher.
+                return buffer.readBytes(length: Int(length) +  MemoryLayout<UInt32>.size * 2)!
+                // `Int(length) +  MemoryLayout<UInt32>.size * 2` could also be `newFileInfo.size - offset` which will be higher.
             }
         } catch {
             logger.error("There was an issue reading the file or attempting to decode block from file's data at \(locator.file):\(locator.offset)")

--- a/test/bitcoin-blockchain/BlockTests.swift
+++ b/test/bitcoin-blockchain/BlockTests.swift
@@ -7,8 +7,31 @@ import BitcoinBase
 struct BlockTests {
 
     /// Tests the creation of the genesis block and genesis coinbase transaction.
-    @Test("Genesis block")
-    func genesisBlock() async throws {
+    @Test("Mainnet genesis block")
+    func mainnetGenesisBlock() async throws {
+        let expectedGenesisTxHash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        let expectedBlockData = "f9beb4d91d0100000100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
+        let expectedBlockHash = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+
+        let blockchain = try await BlockchainService(params: .mainnet)
+
+        let genesisBlock = await blockchain.genesisBlock
+        let genesisTx = genesisBlock.txs[0]
+        let genesisTx2 = Transaction.genesis(ConsensusParams.mainnet.genesisTxParams)
+        #expect(genesisTx == genesisTx2)
+        #expect(genesisTx.idHex == expectedGenesisTxHash)
+
+        let genesisBlockData = genesisBlock.data(encoding: .file(magicBytes: ConsensusParams.mainnet.magicBytes))
+        #expect(genesisBlockData.hex == expectedBlockData)
+
+        let genesisBlockRedeserialized = try Block(genesisBlockData, encoding: .file(magicBytes: ConsensusParams.mainnet.magicBytes))
+        #expect(genesisBlockRedeserialized == genesisBlock)
+        #expect(genesisBlock.idHex == expectedBlockHash)
+    }
+
+    /// Tests the creation of the genesis block and genesis coinbase transaction.
+    @Test("Regtest genesis block")
+    func regtestGenesisBlock() async throws {
         let expectedGenesisTxHash = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
         let expectedBlockData = "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
         let expectedBlockHash = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"


### PR DESCRIPTION
Size of magic bytes and length field itself are excluded from the byte count.

Fixes #494