### PR TITLE
Miniscript DSL: replace wrapper operator `¦`

### DIFF
--- a/src/bitcoin-miniscript/dsl/Wrapper.swift
+++ b/src/bitcoin-miniscript/dsl/Wrapper.swift
@@ -2,11 +2,11 @@ import Foundation
 import BitcoinBase
 import BitcoinCrypto
 
-infix operator ~: AssignmentPrecedence
+infix operator ¦: AssignmentPrecedence
 
 // MARK: - Identity A
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> A_<X>, rhs: X) -> A_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> A_<X>, rhs: X) -> A_<X> { lhs(rhs) }
 public func A<X: ExpB>(_ x: X) -> A_<X> { A_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `a:X`; BitcoinScript: `TOALTSTACK [X] FROMALTSTACK`.
@@ -28,7 +28,7 @@ extension A_: ModU where X: ModU { }
 
 // MARK: - Identity S
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> S_<X>, rhs: X) -> S_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> S_<X>, rhs: X) -> S_<X> { lhs(rhs) }
 public func S<X: ExpB>(_ x: X) -> S_<X> { S_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `s:X`; BitcoinScript: `SWAP [X]`.
@@ -55,7 +55,7 @@ extension S_: ModU where X: ModU { }
 
 // MARK: - Identity T
 
-public func ~<X: ExpV>(lhs: @escaping (_ x: X) -> T_<X>, rhs: X) -> T_<X> { lhs(rhs) }
+public func ¦<X: ExpV>(lhs: @escaping (_ x: X) -> T_<X>, rhs: X) -> T_<X> { lhs(rhs) }
 public func T<X: ExpV>(_ x: X) -> T_<X> { T_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `t:X = and_v(X,1)`; BitcoinScript: `[X] 1`.
@@ -81,7 +81,7 @@ extension T_: ModN where X: ModN { }
 
 // MARK: - Identity C
 
-public func ~<X: ExpK>(lhs: @escaping (_ x: X) -> C_<X>, rhs: X) -> C_<X> { lhs(rhs) }
+public func ¦<X: ExpK>(lhs: @escaping (_ x: X) -> C_<X>, rhs: X) -> C_<X> { lhs(rhs) }
 public func C<X: ExpK>(_ x: X) -> C_<X> { C_(x) }
 
 /// Semantics: `C (identities)`; Miniscript: `c:X`; BitcoinScript: `[X] CHECKSIG`.
@@ -110,7 +110,7 @@ extension C_: ModD where X: ModD { }
 
 // MARK: - Identity D
 
-public func ~<X: ExpV>(lhs: @escaping (_ x: X) -> D_<X>, rhs: X) -> D_<X> { lhs(rhs) }
+public func ¦<X: ExpV>(lhs: @escaping (_ x: X) -> D_<X>, rhs: X) -> D_<X> { lhs(rhs) }
 public func D<X: ExpV>(_ x: X) -> D_<X> { D_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `d:X`; BitcoinScript: `DUP IF [X] ENDIF`.
@@ -137,7 +137,7 @@ public struct D_<X: ExpV>: ExpB, ModO, ModN, ModD, ModU {
 
 // MARK: - Identity V
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> V_<X>, rhs: X) -> V_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> V_<X>, rhs: X) -> V_<X> { lhs(rhs) }
 public func V<X: ExpB>(_ x: X) -> V_<X> { V_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `v:X`; BitcoinScript: `[X] VERIFY (or VERIFY version of last opcode in [X])`.
@@ -182,7 +182,7 @@ extension V_: ModN where X: ModN { }
 
 // MARK: - Identity J
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> J_<X>, rhs: X) -> J_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> J_<X>, rhs: X) -> J_<X> { lhs(rhs) }
 public func J<X: ExpB>(_ x: X) -> J_<X> { J_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `j:X`; BitcoinScript: `SIZE 0NOTEQUAL IF [X] ENDIF`.
@@ -210,7 +210,7 @@ extension J_: ModU where X: ModU { }
 
 // MARK: - Identity N
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> N_<X>, rhs: X) -> N_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> N_<X>, rhs: X) -> N_<X> { lhs(rhs) }
 public func N<X: ExpB>(_ x: X) -> N_<X> { N_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `n:X`; BitcoinScript: `[X] 0NOTEQUAL`.
@@ -239,7 +239,7 @@ extension N_: ModD where X: ModD { }
 
 // MARK: - Identity L
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> L_<X>, rhs: X) -> L_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> L_<X>, rhs: X) -> L_<X> { lhs(rhs) }
 public func L<X: ExpB>(_ x: X) -> L_<X> { L_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `l:X = or_i(0,X)`; BitcoinScript: `IF 0 ELSE [X] ENDIF`.
@@ -264,7 +264,7 @@ extension L_: ModU where X: ModU { }
 
 // MARK: - Identity U
 
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> U_<X>, rhs: X) -> U_<X> { lhs(rhs) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> U_<X>, rhs: X) -> U_<X> { lhs(rhs) }
 public func U<X: ExpB>(_ x: X) -> U_<X> { U_(x) }
 
 /// Semantics: `X (identities)`; Miniscript: `u:X = or_i(X,0)`; BitcoinScript: `IF [X] ELSE 0 ENDIF`.

--- a/src/bitcoin-miniscript/dsl/WrapperCombinations.swift
+++ b/src/bitcoin-miniscript/dsl/WrapperCombinations.swift
@@ -1,4 +1,4 @@
-public func ~<X: ExpB>(lhs: @escaping (_ x: X) -> S_<L_<N_<X>>>, rhs: X) -> S_<L_<N_<X>>> { lhs(rhs) }
-public func SLN<X: ExpB>(_ x: X) -> S_<L_<N_<X>>> { S_(L_(N_(x))) }
+public func ¦<X: ExpB>(lhs: @escaping (_ x: X) -> S_<L_<N_<X>>>, rhs: X) -> S_<L_<N_<X>>> { lhs(rhs) }
+public func SLN<X: ExpB>(_ x: X) -> S_<L_<N_<X>>> { S¦L¦N(x) }
 
-// TODO: Generate remaining valid combinations
+// TODO: Generate remaining valid combinations using Swift Plugin or Swift Macro. e.g. `#validWrapperPermutations(S, L, N)`

--- a/test/bitcoin-miniscript/MiniscriptTests.swift
+++ b/test/bitcoin-miniscript/MiniscriptTests.swift
@@ -37,7 +37,7 @@ struct MiniscriptTests {
 
     @Test("One of two keys (equally likely)") func oneOfTwoLikely() throws {
         // The Miniscript
-        let exp = OrB(PK(key1), S~PK(key2))
+        let exp = OrB(PK(key1), S¦PK(key2))
 
         #expect(exp.description == "or_b(pk(\(key1Hex)),s:pk(\(key2Hex)))")
         let asm = Script(exp.compiled).asm()
@@ -75,7 +75,7 @@ struct MiniscriptTests {
 
     @Test("A user and a 2FA service need to sign off, but after 90 days the user alone is enough") func userPlu2FA() throws {
         // The Miniscript
-        let exp = AndV(V~PK(key1), OrD(PK(key2), Older(12960)))
+        let exp = AndV(V¦PK(key1), OrD(PK(key2), Older(12960)))
 
         #expect(exp.description == "and_v(v:pk(\(key1Hex)),or_d(pk(\(key2Hex)),older(12960)))")
         let asm = Script(exp.compiled).asm()
@@ -93,7 +93,7 @@ struct MiniscriptTests {
 
     @Test("A 3-of-3 that turns into a 2-of-3 after 90 days") func threeOfThree() throws {
         // The Miniscript
-        let exp = Thresh(3, PK(key1), S~PK(key2), S~PK(key3), SLN~Older(12960))
+        let exp = Thresh(3, PK(key1), S¦PK(key2), S¦PK(key3), SLN¦Older(12960))
 
         #expect(exp.description == "thresh(3,pk(\(key1Hex)),s:pk(\(key2Hex)),s:pk(\(key3Hex)),sln:older(12960))")
         let asm = Script(exp.compiled).asm()
@@ -137,7 +137,7 @@ struct MiniscriptTests {
         // H = hash key2
 
         // The Miniscript
-        let exp = T~OrC(PK(key1), AndV(V~PK(key2), OrC(PK(key3), V~Hash160(key2HashData))))
+        let exp = T¦OrC(PK(key1), AndV(V¦PK(key2), OrC(PK(key3), V¦Hash160(key2HashData))))
 
         #expect(exp.description == "t:or_c(pk(\(key1Hex)),and_v(v:pk(\(key2Hex)),or_c(pk(\(key3Hex)),v:hash160(\(key2HashData.hex)))))")
         let asm = Script(exp.compiled).asm()
@@ -157,7 +157,7 @@ struct MiniscriptTests {
         let key2HashData = Data([0xbf, 0xeb, 0xfd, 0xdc, 0xc8, 0x14, 0x14, 0xd6, 0x99, 0x7c, 0xd3, 0xc1, 0x28, 0x72, 0x00, 0x6d, 0x64, 0x60, 0x4b, 0x07])
 
         // The Miniscript
-        let exp = AndOr(PK(key1), OrI(AndV(V~PKH(key2), Hash160(key2HashData)), Older(1008)), PK(key3))
+        let exp = AndOr(PK(key1), OrI(AndV(V¦PKH(key2), Hash160(key2HashData)), Older(1008)), PK(key3))
         // remote key: key1; local key: key2; revocation:key3
 
         #expect(exp.description == "andor(pk(\(key1Hex)),or_i(and_v(v:pkh(\(key2Hex)),hash160(\(key2Hash))),older(1008)),pk(\(key3Hex)))")


### PR DESCRIPTION
`¦` better resembles the original language's `:` than the previously used tilde character

Fixes #502