### PR TITLE
Choosing a single sync node to download headers from.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/bcnode.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/bcnode.xcscheme
@@ -142,6 +142,12 @@
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = ""
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -198,6 +198,11 @@ public actor BlockchainService: Sendable {
         bestHeader.status == .active
     }
 
+    /// Whether the best header is younger than 24 hours.
+    public var hasRecentHeader: Bool {
+        bestHeader.header.time > .now.addingTimeInterval(-60 * 60 * 24)
+    }
+
     /// The time of the best block.
     public var time: Date {
         activeTip.header.time

--- a/src/bitcoin-node/services/P2PClient.swift
+++ b/src/bitcoin-node/services/P2PClient.swift
@@ -103,7 +103,7 @@ actor P2PClient: Service {
                     logger.debug("Initial response messages sent for \(peerID)")
                 }
                 group.addTask { [peerID] in
-                    for await message in await self.node.getChannel(for: peerID).cancelOnGracefulShutdown() {
+                    for await message in await self.node.channel(for: peerID).cancelOnGracefulShutdown() {
                         try await outbound.write(message)
                     }
                     try? await clientChannel.channel.close()

--- a/src/bitcoin-node/services/P2PService.swift
+++ b/src/bitcoin-node/services/P2PService.swift
@@ -117,7 +117,7 @@ actor P2PService: Service {
                             try await connectionChannel.executeThenClose { [logger] inbound, outbound in
                                 try await withThrowingDiscardingTaskGroup { group in
                                     group.addTask {
-                                        for await message in await self.node.getChannel(for: peerID).cancelOnGracefulShutdown() {
+                                        for await message in await self.node.channel(for: peerID).cancelOnGracefulShutdown() {
                                             try await outbound.write(message)
                                         }
                                         try? await connectionChannel.channel.close()

--- a/src/bitcoin-transport/NodeService.swift
+++ b/src/bitcoin-transport/NodeService.swift
@@ -68,6 +68,9 @@ public actor NodeService: Sendable {
     /// BIP152
     private var pendingBlockTxs: [Block.ID : [Transaction?]] = [:]
 
+    /// The peer currently downloading headers from; `nil` means the peer has not been selected yet or we are close to the tip and accepting headers from all peers.
+    private var headersSyncPeerID: PeerID?
+
     private var maxPeerID = 0
 
     public func start() async {
@@ -135,6 +138,7 @@ public actor NodeService: Sendable {
         }
     }
 
+    /*
     /// Request headers from peers.
     public func requestHeaders() async {
         let maxHeight = state.peers.values.reduce(-1) { max($0, $1.height) }
@@ -145,6 +149,7 @@ public actor NodeService: Sendable {
         }
         await requestHeaders(id)
     }
+     */
 
     /// Registers a peer with the node. Incoming means we are the listener. Otherwise we are the node initiating the connection.
     public func addPeer(host: String = IPv4Address.empty.description, port: Int = 0, incoming: Bool = true) -> PeerID {
@@ -168,6 +173,9 @@ public actor NodeService: Sendable {
     /// Deregisters a peer and cleans up outbound channels.
     @discardableResult public func removePeer(_ id: PeerID) -> Bool {
         guard let _ = state.peers[id] else { return false }
+        if headersSyncPeerID == id {
+            headersSyncPeerID = nil
+        }
         state.peers[id]?.nextPingTask?.cancel()
         state.peers[id]?.checkPongTask?.cancel()
         peerOuts[id]?.finish()
@@ -177,7 +185,7 @@ public actor NodeService: Sendable {
     }
 
     /// Returns a channel for a given peer's outbox. The caller can be notified of new messages generated for this peer.
-    public func getChannel(for id: PeerID) -> AsyncChannel<NetworkMessage> {
+    public func channel(for id: PeerID) -> AsyncChannel<NetworkMessage> {
         precondition(state.peers[id] != nil)
         return peerOuts[id]!
     }
@@ -666,18 +674,50 @@ public actor NodeService: Sendable {
             state.peers[id]?.height = await blockchain.height
         }
 
+        // If we are close to the tip (24 hours) we allow parallel
+        if await blockchain.hasRecentHeader {
+            headersSyncPeerID = nil
+        } else if headersSyncPeerID == nil {
+            headersSyncPeerID = id
+        }
+
         if headersMessage.moreItems {
+            guard headersSyncPeerID == nil || headersSyncPeerID == id else {
+                return
+            }
             await requestHeaders(id)
         } else {
-            let headers = await blockchain.headers
-            logger.info("Headers downloaded \(headers).")
+            let headers = await blockchain.headers // Just the total
+            logger.info("All headers downloaded from peer \(id): \(headers).")
 
-            // BIP130 delaying `sendheaders` until we don't need more headers
-            if state.peers[id]?.sendHeadersSent == false {
+            if headersSyncPeerID == id {
+                headersSyncPeerID = nil
+
+                // BIP130 delay `sendheaders` until we don't need more headers. Do this for all peers except this one.
+                await withTaskGroup { group in
+                    for peerID in state.peers.keys {
+                        guard peerID != id else { continue }
+                        if !state.peers[peerID]!.sendHeadersSent {
+                            group.addTask {
+                                await self.sendSendHeaders(peerID)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // BIP130 delaying `sendheaders` until we don't need more headers. Do this for this particular peer.
+            if !state.peers[id]!.sendHeadersSent {
                 enqueue(.sendheaders, to: id)
+                state.peers[id]!.sendHeadersSent = true
             }
             await requestNextMissingBlocks(id)
         }
+    }
+
+    private func sendSendHeaders(_ id: PeerID) async {
+        await self.send(.sendheaders, to: id)
+        self.state.peers[id]!.sendHeadersSent = true
     }
 
     private func processSendHeaders(_ message: NetworkMessage, from id: PeerID) async throws {

--- a/test/bitcoin-transport/BlockSyncTests.swift
+++ b/test/bitcoin-transport/BlockSyncTests.swift
@@ -32,7 +32,7 @@ struct BlockSyncTests {
         self.alice = alice
         let peerB = await alice.addPeer(incoming: false)
         self.peerB = peerB
-        bobToAlice = await alice.getChannel(for: peerB).makeAsyncIterator()
+        bobToAlice = await alice.channel(for: peerB).makeAsyncIterator()
 
         let bobChain = try await BlockchainService(params: .swiftTesting)
         let pubkey = try #require(PublicKey(compressed: [0x03, 0x5a, 0xc9, 0xd1, 0x48, 0x78, 0x68, 0xec, 0xa6, 0x4e, 0x93, 0x2a, 0x06, 0xee, 0x8d, 0x6d, 0x2e, 0x89, 0xd9, 0x86, 0x59, 0xdb, 0x7f, 0x24, 0x74, 0x10, 0xd3, 0xe7, 0x9f, 0x88, 0xf8, 0xd0, 0x05])) // Testnet p2pkh address  miueyHbQ33FDcjCYZpVJdC7VBbaVQzAUg5
@@ -45,7 +45,7 @@ struct BlockSyncTests {
         self.bob = bob
         let peerA = await bob.addPeer()
         self.peerA = peerA
-        aliceToBob = await bob.getChannel(for: peerA).makeAsyncIterator()
+        aliceToBob = await bob.channel(for: peerA).makeAsyncIterator()
     }
 
     func cleanUp() async throws {

--- a/test/bitcoin-transport/NodeBootstrapTests.swift
+++ b/test/bitcoin-transport/NodeBootstrapTests.swift
@@ -40,7 +40,7 @@ struct NodeBootstrapTests {
         await Task.yield()
 
         // Channels
-        var aliceToBob = await alice.getChannel(for: peerB).makeAsyncIterator()
+        var aliceToBob = await alice.channel(for: peerB).makeAsyncIterator()
         // var bobToAlice = await bob.getChannel(for: peerA).makeAsyncIterator()
 
         // Begin testing
@@ -103,8 +103,8 @@ struct NodeBootstrapTests {
         await Task.yield()
 
         // Peer channels
-        var aliceToBob = await alice.getChannel(for: peerB).makeAsyncIterator()
-        var bobToCarol = await bob.getChannel(for: peerC).makeAsyncIterator()
+        var aliceToBob = await alice.channel(for: peerB).makeAsyncIterator()
+        var bobToCarol = await bob.channel(for: peerC).makeAsyncIterator()
 
         // Begin testing
         let block1 = try #require(await alice.blockchain.generateTo(pubkey))
@@ -190,8 +190,8 @@ struct NodeBootstrapTests {
         await Task.yield()
 
         // Peer channels
-        var aliceToBob = await alice.getChannel(for: peerB).makeAsyncIterator()
-        var bobToCarol = await bob.getChannel(for: peerC).makeAsyncIterator()
+        var aliceToBob = await alice.channel(for: peerB).makeAsyncIterator()
+        var bobToCarol = await bob.channel(for: peerC).makeAsyncIterator()
 
         // Begin testing
         try await alice.blockchain.addTransaction(tx)
@@ -318,8 +318,8 @@ struct NodeBootstrapTests {
         await Task.yield()
 
         // Peer channels
-        var aliceToBob = await alice.getChannel(for: peerB).makeAsyncIterator()
-        var bobToCarol = await bob.getChannel(for: peerC).makeAsyncIterator()
+        var aliceToBob = await alice.channel(for: peerB).makeAsyncIterator()
+        var bobToCarol = await bob.channel(for: peerC).makeAsyncIterator()
 
         // Begin testing
         let aliceBlock2 = try #require(await alice.blockchain.generateTo(pubkey))
@@ -431,8 +431,8 @@ struct NodeBootstrapTests {
         await Task.yield()
 
         // Peer channels
-        var aliceToBob = await alice.getChannel(for: peerB).makeAsyncIterator()
-        var bobToCarol = await bob.getChannel(for: peerC).makeAsyncIterator()
+        var aliceToBob = await alice.channel(for: peerB).makeAsyncIterator()
+        var bobToCarol = await bob.channel(for: peerC).makeAsyncIterator()
 
         // Begin testing
         let aliceBlock2 = try #require(await alice.blockchain.generateTo(pubkey))

--- a/test/bitcoin-transport/NodeServiceTests.swift
+++ b/test/bitcoin-transport/NodeServiceTests.swift
@@ -27,7 +27,7 @@ struct NodeServiceTests: ~Copyable {
         self.satoshi = satoshi
         let halPeer = await satoshi.addPeer()
         self.halPeer = halPeer
-        satoshiOut = await satoshi.getChannel(for: halPeer).makeAsyncIterator()
+        satoshiOut = await satoshi.channel(for: halPeer).makeAsyncIterator()
 
         let halChain = try await BlockchainService()
         self.halChain = halChain
@@ -38,7 +38,7 @@ struct NodeServiceTests: ~Copyable {
         self.hal = hal
         let satoshiPeer = await hal.addPeer(incoming: false)
         self.satoshiPeer = satoshiPeer
-        halOut = await hal.getChannel(for: satoshiPeer).makeAsyncIterator()
+        halOut = await hal.channel(for: satoshiPeer).makeAsyncIterator()
     }
 
     deinit {


### PR DESCRIPTION
When close to tip, headers can be received by all peers.
