### PR TITLE
Standard limits, mainly sigops.

### DIFF
--- a/src/bitcoin-base/script/Script+Operation.swift
+++ b/src/bitcoin-base/script/Script+Operation.swift
@@ -4,11 +4,22 @@ import BitcoinCrypto
 extension Script {
     /// A script operation.
     public enum Operation: Equatable, Sendable {
-        case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, /* reserved(UInt8), */ success(UInt8), constant(UInt8), noOp, /* ver, */ `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, checkMultisig, checkMultisigVerify, noOp1, checkLockTimeVerify, checkSequenceVerify, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, checkSigAdd, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
+        case zero, pushBytes(Data), pushData1(Data), pushData2(Data), pushData4(Data), oneNegate, /* reserved(UInt8), */ success(UInt8), constant(UInt8), noOp, /* ver, */ `if`, notIf, verIf, verNotIf, `else`, endIf, verify, `return`, toAltStack, fromAltStack, twoDrop, twoDup, threeDup, twoOver, twoRot, twoSwap, ifDup, depth, drop, dup, nip, over, pick, roll, rot, swap, tuck, cat, subStr, left, right, size, invert, and, or, xor, equal, equalVerify, oneAdd, oneSub, twoMul, twoDiv, negate, abs, not, zeroNotEqual, add, sub, mul, div, mod, lShift, rShift, boolAnd, boolOr, numEqual, numEqualVerify, numNotEqual, lessThan, greaterThan, lessThanOrEqual, greaterThanOrEqual, min, max, within, ripemd160, sha1, sha256, hash160, hash256, codeSeparator, checkSig, checkSigVerify, checkMultisig, checkMultisigVerify, noOp1, checkLocktimeVerify, checkSequenceVerify, noOp4, noOp5, noOp6, noOp7, noOp8, noOp9, noOp10, checkSigAdd, unknown(UInt8), pubKeyHash, pubKey, invalidOpCode
     }
 }
 
 extension Script.Operation {
+
+    public var pushedData: Data? {
+        switch self {
+        case .zero: Data()
+        case .oneNegate: try! ScriptNumber(-1).data
+        case let .constant(k): ScriptNumber(k).data
+        case let .pushBytes(d), let .pushData1(d), let .pushData2(d), let .pushData4(d): d
+        default: nil
+        }
+    }
+
     public var isPush: Bool {
         switch self {
         case .zero, .oneNegate, .constant(_), .pushBytes(_), .pushData1(_), .pushData2(_), .pushData4(_): true
@@ -126,7 +137,7 @@ extension Script.Operation {
         case .checkMultisig: 0xae
         case .checkMultisigVerify: 0xaf
         case .noOp1: 0xb0
-        case .checkLockTimeVerify: 0xb1
+        case .checkLocktimeVerify: 0xb1
         case .checkSequenceVerify: 0xb2
         case .noOp4: 0xb3
         case .noOp5: 0xb4
@@ -246,7 +257,7 @@ extension Script.Operation {
         case .checkMultisig: "OP_CHECKMULTISIG"
         case .checkMultisigVerify: "OP_CHECKMULTISIGVERIFY"
         case .noOp1: "OP_NOP1"
-        case .checkLockTimeVerify: "OP_CHECKLOCKTIMEVERIFY"
+        case .checkLocktimeVerify: "OP_CHECKLOCKTIMEVERIFY"
         case .checkSequenceVerify: "OP_CHECKSEQUENCEVERIFY"
         case .noOp4: "OP_NOP4"
         case .noOp5: "OP_NOP5"
@@ -319,7 +330,16 @@ extension Script.Operation {
     public static func encodeMinimally(_ data: Data) -> Script.Operation {
         switch data.count {
         case 0: .zero
-        case 1...75: .pushBytes(data)
+        case 1:
+            // TODO: Test this logic
+            if data == ScriptNumber.negativeOne.data {
+                encodeMinimally(-1)
+            } else if data[0] >= 1 && data[0] <= 16 {
+                encodeMinimally(Int(data[0]))
+            } else {
+                .pushBytes(data)
+            }
+        case 2...75: .pushBytes(data)
         case 76...Int(UInt8.max): .pushData1(data)
         case (Int(UInt8.max) + 1)...Int(UInt16.max): .pushData2(data)
         case (Int(UInt16.max) + 1)...Int(UInt32.max): .pushData4(data)
@@ -466,7 +486,7 @@ extension Script.Operation: BinaryCodable {
         case Self.checkMultisig.opCode: self = .checkMultisig
         case Self.checkMultisigVerify.opCode: self = .checkMultisigVerify
         case Self.noOp1.opCode: self = .noOp1
-        case Self.checkLockTimeVerify.opCode: self = .checkLockTimeVerify
+        case Self.checkLocktimeVerify.opCode: self = .checkLocktimeVerify
         case Self.checkSequenceVerify.opCode: self = .checkSequenceVerify
         case Self.noOp4.opCode: self = .noOp4
         case Self.noOp5.opCode: self = .noOp5
@@ -673,7 +693,7 @@ extension Script.Operation {
         case Self.checkMultisig.opCode: self = .checkMultisig
         case Self.checkMultisigVerify.opCode: self = .checkMultisigVerify
         case Self.noOp1.opCode: self = .noOp1
-        case Self.checkLockTimeVerify.opCode: self = .checkLockTimeVerify
+        case Self.checkLocktimeVerify.opCode: self = .checkLocktimeVerify
         case Self.checkSequenceVerify.opCode: self = .checkSequenceVerify
         case Self.noOp4.opCode: self = .noOp4
         case Self.noOp5.opCode: self = .noOp5

--- a/src/bitcoin-base/script/Script.swift
+++ b/src/bitcoin-base/script/Script.swift
@@ -252,8 +252,9 @@ extension Script {
         return n
     }
 
-    /// GetSigopCount(const CScript& scriptSig) from Bitcoin Core, adapted to Swift.
     /// If this is not P2SH, returns sigopCount(true). Otherwise, extracts the redeemScript from scriptSig's last push and returns its sigop count.
+    ///
+    /// `GetSigopCount(const CScript& scriptSig)` from Bitcoin Core, adapted to Swift.
     public func sigopCount(inputScript scriptSig: Script) -> Int {
         guard isPayToScriptHash else {
             return sigopCount(accurate: true)
@@ -261,26 +262,10 @@ extension Script {
 
         // This is a pay-to-script-hash scriptPubKey;
         // get the last item that the scriptSig pushes onto the stack:
-        var lastPush = Data?.none // Scan scriptSig.ops and remember the last pushBytes data
-        guard !scriptSig.ops.isEmpty else {
-            preconditionFailure()
-        }
-        for op in scriptSig.ops {
-            switch op {
-            case .pushBytes(let data), .pushData1(let data), .pushData2(let data), .pushData4(let data):
-                lastPush = data
-            case .constant(let value):
-                // Minimal integers are pushes too; encode minimally to bytes as in script.
-                lastPush = Data([value])
-            default:
-                // Any non-push opcode means we cannot extract a redeemScript here; return 0 like Core.
-                return 0
-            }
-        }
-        // …and return its opcount:
-        if let lastPush, let subScript = try? Script(lastPush) {
+        if let lastOp = scriptSig.ops.last, let lastPush = lastOp.pushedData, let subScript = try? Script(lastPush) {
             return subScript.sigopCount(accurate: true)
         }
+        // TODO: Return 0? check Bitcoin Core
         fatalError()
     }
 }

--- a/src/bitcoin-base/script/ScriptConfig.swift
+++ b/src/bitcoin-base/script/ScriptConfig.swift
@@ -44,7 +44,7 @@ public struct ScriptConfig: OptionSet, Sendable {
     public static let payToScriptHash = Self(rawValue: 1 << 7)
 
     /// BIP65: Evaluate `OP_CHECKLOCKTIMEVERIFY`.
-    public static let checkLockTimeVerify = Self(rawValue: 1 << 8)
+    public static let checkLocktimeVerify = Self(rawValue: 1 << 8)
 
     /// BIP112: Evaluate `OP_CHECKSEQUENCEVERIFY`.
     public static let checkSequenceVerify = Self(rawValue: 1 << 9)
@@ -88,7 +88,7 @@ public struct ScriptConfig: OptionSet, Sendable {
     public static let discourageUpgradablePubkeyType = Self(rawValue: 1 << 20)
 
     /// Standard script verification flags that standard transactions will comply with. However we do not ban/disconnect nodes that forward txs violating the additional (non-mandatory) rules here, to improve forwards and backwards compatability.
-    public static let standard: Self = [.strictDER, .pushOnly, .minimalData, .lowS, .cleanStack, .nullDummy, .strictEncoding, .payToScriptHash, .checkLockTimeVerify, .checkSequenceVerify, .discourageUpgradableNoOps, .constantScriptCode, .witness, .witnessCompressedPubkey, .minimalIf, .nullFail, .discourageUpgradableWitnessProgram, .taproot, .discourageUpgradableTaprootVersion, .discourageOpSuccess, .discourageUpgradablePubkeyType]
+    public static let standard: Self = [.strictDER, .pushOnly, .minimalData, .lowS, .cleanStack, .nullDummy, .strictEncoding, .payToScriptHash, .checkLocktimeVerify, .checkSequenceVerify, .discourageUpgradableNoOps, .constantScriptCode, .witness, .witnessCompressedPubkey, .minimalIf, .nullFail, .discourageUpgradableWitnessProgram, .taproot, .discourageUpgradableTaprootVersion, .discourageOpSuccess, .discourageUpgradablePubkeyType]
 
     /// Mandatory script verification flags that all new transactions must comply with for them to be valid under latest consensus rules. Failing one of these tests may trigger a DoS ban. See `CheckInputScripts()` on Bitcoin Core  for details.
     /// Note that this does not affect consensus validity. See `GetBlockScriptFlags()` for that.
@@ -96,7 +96,7 @@ public struct ScriptConfig: OptionSet, Sendable {
         .strictDER, // After DEPLOYMENT_DERSIG (BIP66) buried deployment block (1st)
         .nullDummy, // After DEPLOYMENT_SEGWIT (BIP147) buried deployment block (3rd)
         .payToScriptHash, // From chain start with 1 block excepted on mainnet
-        .checkLockTimeVerify, // After DEPLOYMENT_CLTV (BIP65) buried deployment block (2st)
+        .checkLocktimeVerify, // After DEPLOYMENT_CLTV (BIP65) buried deployment block (2st)
         .checkSequenceVerify, // After DEPLOYMENT_CSV (BIP112) buried deployment block (3rd)
         .witness, // From chain start with 0 blocks excepted
         .taproot // From chain start with 1 block excepted on mainnet

--- a/src/bitcoin-base/script/ScriptError.swift
+++ b/src/bitcoin-base/script/ScriptError.swift
@@ -24,10 +24,10 @@ enum ScriptError: Error {
          undefinedSighashType,
          missingDummyValue,
          dummyValueNotNull,
-         invalidLockTimeArgument,
+         invalidLocktimeArgument,
          lockTimeHeightEarly,
          lockTimeSecondsEarly,
-         invalidLockTime,
+         invalidLocktime,
          invalidSequenceArgument,
          sequenceHeightEarly,
          sequenceSecondsEarly,
@@ -66,5 +66,5 @@ enum ScriptError: Error {
          disallowedNoOp,
          invalidCheckSigAddArgument,
          minimumTxVersionRequired,
-         sequenceLockTimeDisabled
+         sequenceLocktimeDisabled
 }

--- a/src/bitcoin-base/script/ScriptRuntime.swift
+++ b/src/bitcoin-base/script/ScriptRuntime.swift
@@ -326,9 +326,9 @@ public struct ScriptRuntime {
             guard sigVersion == .base || sigVersion == .witnessV0 else { throw ScriptError.tapscriptCheckMultisigDisabled }
             try opCheckMultisigVerify()
         case .noOp1: if config.contains(.discourageUpgradableNoOps) { throw ScriptError.disallowedNoOp }
-        case .checkLockTimeVerify:
-            guard config.contains(.checkLockTimeVerify) else { break }
-            try opCheckLockTimeVerify()
+        case .checkLocktimeVerify:
+            guard config.contains(.checkLocktimeVerify) else { break }
+            try opCheckLocktimeVerify()
         case .checkSequenceVerify:
             guard config.contains(.checkSequenceVerify) else { break }
             try opCheckSequenceVerify()

--- a/src/bitcoin-base/scriptOperations/ScriptRuntime+LocktimeOps.swift
+++ b/src/bitcoin-base/scriptOperations/ScriptRuntime+LocktimeOps.swift
@@ -3,7 +3,7 @@ import Foundation
 extension ScriptRuntime {
 
     /// [BIP65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
-    mutating func opCheckLockTimeVerify() throws {
+    mutating func opCheckLocktimeVerify() throws {
         let first = try getUnaryParam(keep: true)
         let locktime64 = try ScriptNumber(first, extendedLength: true, minimal: config.contains(.minimalData)).value
 
@@ -11,7 +11,7 @@ extension ScriptRuntime {
             first.count < 6,
             locktime64 >= 0,
             locktime64 <= UInt32.max
-        else { throw ScriptError.invalidLockTimeArgument }
+        else { throw ScriptError.invalidLocktimeArgument }
 
         let locktime = Transaction.Locktime(locktime64)
 
@@ -24,7 +24,7 @@ extension ScriptRuntime {
                 throw ScriptError.lockTimeSecondsEarly
             }
         } else {
-            throw ScriptError.invalidLockTime
+            throw ScriptError.invalidLocktime
         }
 
         if tx.ins[input].sequence == .final { throw ScriptError.inputSequenceFinal }
@@ -47,7 +47,7 @@ extension ScriptRuntime {
         if tx.version == .v1 { throw ScriptError.minimumTxVersionRequired }
 
         let txSequence = tx.ins[input].sequence
-        if txSequence.isLocktimeDisabled { throw ScriptError.sequenceLockTimeDisabled }
+        if txSequence.isLocktimeDisabled { throw ScriptError.sequenceLocktimeDisabled }
 
         if let locktimeBlocks = sequence.locktimeBlocks, let txLocktimeBlocks = txSequence.locktimeBlocks {
             if locktimeBlocks > txLocktimeBlocks {

--- a/src/bitcoin-blockchain/Base+/Transaction+check.swift
+++ b/src/bitcoin-blockchain/Base+/Transaction+check.swift
@@ -116,8 +116,7 @@ extension Transaction {
     ///
     ///
     /// Analog to Bitcoin Core's `IsStandardTx()`.
-    func isStandard() throws(PolicyViolation) {
-        let permitBareMultisig = true // TODO: This is a startup option in Bitcoin Core.
+    func isStandard(maxDatacarrierBytes: Int, permitBareMultisig: Bool, dustRelayFeerate: Amount) throws(PolicyViolation) {
         // TODO: Implement analog to Bitcoin Core's `isStandardTx()`
         // bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason)
         guard version >= Transaction.Version.minStandard && version <= Transaction.Version.maxStandard else {
@@ -132,7 +131,7 @@ extension Transaction {
 
         for txIn in ins {
             // Biggest 'standard' txin involving only keys is a 15-of-15 P2SH multisig with compressed keys (remember the MAX_SCRIPT_ELEMENT_SIZE byte limit on redeemScript size). That works out to a (15*(33+1))+3=513 byte redeemScript, 513+1+15*(73+1)+3=1627 bytes of scriptSig, which we round off to 1650(MAX_STANDARD_SCRIPTSIG_SIZE) bytes for some minor future-proofing. That's also enough to spend a 20-of-20 CHECKMULTISIG scriptPubKey, though such a scriptPubKey is not considered standard.
-            guard txIn.script.dataSize <= Script.maxStandardSize else {
+            guard txIn.script.dataSize <= Script.maxStandardInputScriptSize else {
                 throw .inputScriptSize
             }
             guard txIn.script.isPushOnly else {
@@ -142,7 +141,6 @@ extension Transaction {
 
         var datacarrierBytesLeft = Script.maxOpReturnRelay
 
-        //var whichType = OutputType?.none
         for out in outs {
             guard let whichType = out.script.isStandard() else {
                 throw .outputScriptNotStandard
@@ -487,11 +485,60 @@ extension Transaction {
             sigops += txIn.script.sigopCount(accurate: true)
             sigops += prev.script.sigopCount(inputScript: txIn.script)
 
-            guard sigops <= Script.maxTransactionLegacySigops else {
+            guard sigops <= Transaction.maxLegacySigops else {
                 return false
             }
         }
         return true
+    }
+
+    func legacySigopCount() -> Int {
+        // unsigned int GetLegacySigOpCount(const CTransaction& tx)
+        var sigops = 0
+        for txIn in ins {
+            sigops += txIn.script.sigopCount(accurate: false)
+        }
+        for out in outs {
+            sigops += out.script.sigopCount(accurate: false)
+        }
+        return sigops
+    }
+
+    func p2shSigopCount(prevouts: [TransactionOutput]) -> Int {
+        //unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& inputs)
+        guard !isCoinbase else {
+            return 0
+        }
+
+        var sigops = 0
+        for (i, txIn) in ins.enumerated() {
+            // assert(!coin.IsSpent());
+            let prevout = prevouts[i]
+            if prevout.script.isPayToScriptHash {
+                sigops += prevout.script.sigopCount(inputScript: txIn.script)
+            }
+        }
+        return sigops
+    }
+
+    func sigopCost(prevouts: [TransactionOutput], options: ScriptConfig) -> Int {
+    // int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, script_verify_flags flags)
+        var sigops = legacySigopCount() * Self.witnessScaleFactor
+
+        guard !isCoinbase else {
+            return sigops
+        }
+
+        if options.contains(.payToScriptHash) {
+            sigops += p2shSigopCount(prevouts: prevouts) * Self.witnessScaleFactor
+        }
+
+        for (i, txIn) in ins.enumerated() {
+            // assert(!coin.IsSpent());
+            let prevout = prevouts[i]
+            sigops += countWitnessSigops(inputScript: txIn.script, outputScript: prevout.script, witnessStack: txIn.witness.stack /*tx.vin[i].scriptWitness*/, options: options)
+        }
+        return sigops
     }
 }
 
@@ -531,4 +578,42 @@ public enum PolicyViolation: Swift.Error {
     case prevoutMissingRedeemScript
     case prevoutInvalidRedeemScript
     case prevoutRedeemScriptSigopsExceeded
+}
+
+
+private func witnessSigops(witnessVersion: Int, witnessProgram: Data, witnessStack: [Data]) -> Int {
+    // size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& witprogram, const CScriptWitness& witness)
+    if witnessVersion == 0 {
+        if witnessProgram.count == SHA256.Digest.byteCount /* WITNESS_V0_KEYHASH_SIZE */ {
+            return 1
+        }
+        if witnessProgram.count == Hash160.Digest.byteCount /* WITNESS_V0_SCRIPTHASH_SIZE */, let lastStackElement = witnessStack.last, let subScript = try? Script(lastStackElement) {
+            return subScript.sigopCount(accurate: true)
+        }
+        return 0
+    }
+
+    // Future flags may be implemented here.
+    return 0
+}
+
+private func countWitnessSigops(inputScript: Script, outputScript: Script, witnessStack: [Data], options: ScriptConfig) -> Int {
+    // size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness& witness, script_verify_flags flags)
+    guard options.contains(.witness) else {
+        return 0
+    }
+    precondition(options.contains(.payToScriptHash))
+    if let (witnessVersion, witnessProgram) = outputScript.witnessVersionProgram {
+        return witnessSigops(witnessVersion: witnessVersion, witnessProgram: witnessProgram, witnessStack: witnessStack)
+    }
+
+    if outputScript.isPayToScriptHash,
+       inputScript.isPushOnly,
+       let lastOp = inputScript.ops.last,
+       let lastPush = lastOp.pushedData,
+       let subScript = try? Script(lastPush),
+       let (witnessVersion, witnessProgram) = subScript.witnessVersionProgram {
+        return witnessSigops(witnessVersion: witnessVersion, witnessProgram: witnessProgram, witnessStack: witnessStack)
+    }
+    return 0
 }

--- a/src/bitcoin-blockchain/BlockchainService+Error.swift
+++ b/src/bitcoin-blockchain/BlockchainService+Error.swift
@@ -16,7 +16,7 @@ extension BlockchainService {
         /// A transaction in the block could not be validated.
         case invalidTransactionInBlock(TransactionValidationError)
 
-        case unsupportedBlockVersion, orphanHeader, invalidDifficultyTarget, insuficientProofOfWork, headerTooOld, headerTooNew, headerPartOfInvalidChain, missingCoinbaseTransaction, coinbaseTransactionOverspends, wrongMerkleRoot, invalidBlockAlreadyExists, futureLockTime
+        case unsupportedBlockVersion, orphanHeader, invalidDifficultyTarget, insuficientProofOfWork, headerTooOld, headerTooNew, headerPartOfInvalidChain, missingCoinbaseTransaction, coinbaseTransactionOverspends, wrongMerkleRoot, invalidBlockAlreadyExists, futureLocktime
 
         case dataDirIssue, blockFileIssue
 

--- a/src/bitcoin-blockchain/BlockchainService.swift
+++ b/src/bitcoin-blockchain/BlockchainService.swift
@@ -365,9 +365,10 @@ public actor BlockchainService: Sendable {
 
         metrics.transactionsCounter.increment()
 
+        let requireStandard = true // Overrideable by parameter (for test/regtest networks only) in Bitcoin Core
         let prevouts: [TransactionOutput]
         do {
-            prevouts = try await mempoolAcceptPreChecks(tx)
+            prevouts = try await mempoolAcceptPreChecks(tx, requireStandard: requireStandard)
         } catch {
             logger.warning("Mempool precheck failed for tx \(tx.idHex)\n\(error)")
             throw error
@@ -614,7 +615,7 @@ public actor BlockchainService: Sendable {
         if params.preventBlockStorms {
             // Check timestamp for the first block of each difficulty adjustment interval, except the genesis block.
             if (headers + 1) % params.difficultyAdjustmentInterval == 0 {
-                guard header.time.timeIntervalSince1970 >= bestHeader.header.time.timeIntervalSince1970  - ConsensusParams.maxTimewarp else {
+                guard header.time.timeIntervalSince1970 >= bestHeader.header.time.timeIntervalSince1970  - Block.maxTimewarp else {
                     logger.error("Header \(header.idHex) - potential timewarp attack")
                     throw .timewarpAttack
                 }
@@ -1469,7 +1470,7 @@ public actor BlockchainService: Sendable {
         }
 
         // Enforce BIP68 (sequence locks)
-        let verifyLockTimeSequence = blockRef.height >= params.csvHeight
+        let verifyLocktimeSequence = blockRef.height >= params.csvHeight
 
         var fees = Amount(0)
         var tmpExclude = [Outpoint]()
@@ -1504,7 +1505,7 @@ public actor BlockchainService: Sendable {
                 // Check that transaction is BIP68 final
                 // BIP68 lock checks (as opposed to nLockTime checks) must be in ConnectBlock because they require the UTXO set
                 var previousHeights = await calculatePrevHeights(tx, tip: activeTip, excludeCoins: tmpExclude, auxCoins: tmpCoins)
-                try await sequenceLocks(tx, block: blockRef, previous: activeTip, verifyLockTimeSequence: verifyLockTimeSequence, previousHeights: &previousHeights)
+                try await sequenceLocks(tx, block: blockRef, previous: activeTip, verifyLocktimeSequence: verifyLocktimeSequence, previousHeights: &previousHeights)
             }
 
             // Remove coins
@@ -1816,7 +1817,7 @@ public actor BlockchainService: Sendable {
         // of the block *being* evaluated is what is used.
         // Thus if we want to know if a transaction can be part of the
         // *next* block, we need to use one more than active_chainstate.m_chain.Height()
-        let (minHeight, minTime) = await calculateSequenceLocks(tx, block: nextTip, verifyLockTimeSequence: true /* STANDARD_LOCKTIME_VERIFY_FLAGS */, previousHeights: &prevHeights)
+        let (minHeight, minTime) = await calculateSequenceLocks(tx, block: nextTip, verifyLocktimeSequence: Transaction.Input.standardLocktimeVerifyOption /* STANDARD_LOCKTIME_VERIFY_FLAGS */, previousHeights: &prevHeights)
 
         // Also store the hash of the block with the highest height of all the blocks which have sequence locked prevouts.
         // This hash needs to still be on the chain for these LockPoint calculations to be valid
@@ -1852,7 +1853,7 @@ public actor BlockchainService: Sendable {
 
     /// Run the policy checks on a given transaction, excluding any script checks.
     /// Looks up inputs, calculates feerate, considers replacement, evaluates package limits, etc. As this function can be invoked for "free" by a peer, only tests that are fast should be done here (to avoid CPU DoS).
-    private func mempoolAcceptPreChecks(_ tx: Transaction) async throws(TransactionValidationError) -> [TransactionOutput] {
+    private func mempoolAcceptPreChecks(_ tx: Transaction, requireStandard: Bool) async throws(TransactionValidationError) -> [TransactionOutput] {
 
         do {
             try tx.check()
@@ -1864,20 +1865,20 @@ public actor BlockchainService: Sendable {
         // Coinbase is only valid in a block, not as a loose transaction
         guard !tx.isCoinbase else {
             throw .coinbaseTransaction
-            // return state.Invalid(TxValidationResult::TX_CONSENSUS, "coinbase");
         }
 
         // Rather not work on nonstandard transactions (unless -testnet/-regtest)
-        /*
-        std::string reason;
-        if (m_pool.m_opts.require_standard && !IsStandardTx(tx, m_pool.m_opts.max_datacarrier_bytes, m_pool.m_opts.permit_bare_multisig, m_pool.m_opts.dust_relay_feerate, reason)) {
-            //return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
-         */
-        do {
-            try tx.isStandard()
-        } catch {
-            logger.warning("Non-standard transaction: \(error)")
-            throw .nonStandardTransaction(error)
+        if requireStandard {
+            // The following are overridable runtime options in Bitcoin Core
+            let maxDatacarrierBytes = Script.defaultAcceptDatacarrier ? Script.maxOpReturnRelay : 0
+            let permitBareMultisig = Script.defaultPermitBareMultisig
+            let dustRelayFeerate = Transaction.dustRelayFee
+            do {
+                try tx.isStandard(maxDatacarrierBytes: maxDatacarrierBytes, permitBareMultisig: permitBareMultisig, dustRelayFeerate: dustRelayFeerate)
+            } catch {
+                logger.warning("Non-standard transaction: \(error)")
+                throw .nonStandardTransaction(error)
+            }
         }
 
         // Transactions smaller than 65 non-witness bytes are not relayed to mitigate CVE-2017-12842.
@@ -1920,11 +1921,8 @@ public actor BlockchainService: Sendable {
         }
         let prevouts = coins.map(\.out) // To return
 
-        // Only accept BIP68 sequence locked transactions that can be mined in the next
-        // block; we don't want our mempool filled up with transactions that can't
-        // be mined yet.
-        // Pass in m_view which has all of the relevant inputs cached. Note that, since m_view's
-        // backend was removed, it no longer pulls coins from the mempool.
+        // Only accept BIP68 sequence locked transactions that can be mined in the next  block; we don't want our mempool filled up with transactions that can't be mined yet.
+        // Pass in m_view which has all of the relevant inputs cached. Note that, since m_view's backend was removed, it no longer pulls coins from the mempool.
         let lockPoints = await calculateLockPointsAtTip(tx, tip: activeTip)
         do {
             try await checkSequenceLocksAtTip(activeTip, lockPoints: lockPoints)
@@ -1934,36 +1932,50 @@ public actor BlockchainService: Sendable {
         }
 
         // The mempool holds txs for the next block, so pass height+1 to CheckTxInputs
-
-        /* if (!Consensus::CheckTxInputs(tx, state, m_view, m_active_chainstate.m_chain.Height() + 1, ws.m_base_fees)) { … } */
         do {
             try await tx.checkInputs(spendHeight: activeTip.height + 1, coinbaseMaturity: params.coinbaseMaturity, coins: coins)
+            // Consensus::CheckTxInputs(tx, state, m_view, m_active_chainstate.m_chain.Height() + 1, ws.m_base_fees))
         } catch {
             throw .transactionCheckError(error)
         }
 
-        /* if (m_pool.m_opts.require_standard) { … } */
-        do {
-            try tx.validateInputsStandardness(prevouts: prevouts)
-        } catch {
-            logger.warning("\(error)")
-            throw .nonStandardPrevouts(error)
+        if requireStandard {
+            do {
+                try tx.validateInputsStandardness(prevouts: prevouts)
+            } catch {
+                logger.warning("\(error)")
+                throw .nonStandardPrevouts(error)
+            }
         }
 
         // Check for non-standard witnesses.
-
-        /* if (tx.HasWitness() && m_pool.m_opts.require_standard && !IsWitnessStandard(tx, m_view)) { … } */
-        if tx.hasWitness {
+        if tx.hasWitness, requireStandard {
             do {
                 try tx.isWitnessStandard(prevouts: prevouts)
             } catch {
-                // state.Invalid(TxValidationResult::TX_WITNESS_MUTATED, "bad-witness-nonstandard")
                 logger.warning("\(error)")
                 throw .nonStandardWitness(error)
             }
         }
 
+        let sigopsCost = tx.sigopCost(prevouts: prevouts, options: .standard)
+
+        guard sigopsCost <= Transaction.maxStandardSigopsCost else {
+            throw .tooManySigops
+        }
+
+        // No individual transactions are allowed below the mempool min feerate except from disconnected blocks and transactions in a package. Package transactions will be checked using package feerate later.
+        /* if !bypass_limits { */
+        guard checkFeeRate(/*modifiedFees*/) else {
+            throw .feeTooLow
+        }
+
         return prevouts
+    }
+
+    private func checkFeeRate() -> Bool {
+        // TODO: Tie this to the node service state for minimum feeRate
+        return true
     }
 
     /// Checks if the transaction will be final in the next block to be created on top of the new chain.
@@ -1986,8 +1998,8 @@ public actor BlockchainService: Sendable {
     /// Called by `BlockchainService.connectBlock()`.
     ///
     /// BIP68
-    private func sequenceLocks(_ tx: Transaction, block: BlockRef, previous: BlockRef, verifyLockTimeSequence: Bool, previousHeights: inout [Int]) async throws(Error) {
-        try await evaluateSequenceLocks(block, previous: previous, lockPair: await calculateSequenceLocks(tx, block: block, verifyLockTimeSequence: verifyLockTimeSequence, previousHeights: &previousHeights))
+    private func sequenceLocks(_ tx: Transaction, block: BlockRef, previous: BlockRef, verifyLocktimeSequence: Bool, previousHeights: inout [Int]) async throws(Error) {
+        try await evaluateSequenceLocks(block, previous: previous, lockPair: await calculateSequenceLocks(tx, block: block, verifyLocktimeSequence: verifyLocktimeSequence, previousHeights: &previousHeights))
     }
 
     /// Calculates the block height and previous block's median time past at which the transaction will be considered final in the context of BIP 68.
@@ -1999,7 +2011,7 @@ public actor BlockchainService: Sendable {
     /// Called from `sequenceLocks()`.
     ///
     /// BIP68
-    private func calculateSequenceLocks(_ tx: Transaction, block: BlockRef, verifyLockTimeSequence: Bool, previousHeights: inout [Int]) async -> LockPair {
+    private func calculateSequenceLocks(_ tx: Transaction, block: BlockRef, verifyLocktimeSequence: Bool, previousHeights: inout [Int]) async -> LockPair {
 
         precondition(previousHeights.count == tx.ins.count);
 
@@ -2012,7 +2024,7 @@ public actor BlockchainService: Sendable {
         var minTime = -1;
 
         // tx.nVersion is signed integer so requires cast to unsigned otherwise we would be doing a signed comparison and half the range of nVersion wouldn't support BIP68.
-        let enforceBIP68 = tx.version >= .v2 && verifyLockTimeSequence
+        let enforceBIP68 = tx.version >= .v2 && verifyLocktimeSequence
 
         // Do not enforce sequence numbers as a relative lock time unless we have been instructed to
         guard enforceBIP68 else { return (minHeight, minTime) }
@@ -2053,7 +2065,7 @@ public actor BlockchainService: Sendable {
         let blockTime = Int(blockTimeDate.timeIntervalSince1970)
         if lockPair.height >= block.height || lockPair.time >= blockTime {
             logger.error("Non final transaction at block height \(block.height) (future lock time). BIP68 non-final transaction")
-            throw .futureLockTime
+            throw .futureLocktime
         }
     }
 

--- a/src/bitcoin-blockchain/ConsensusConstants.swift
+++ b/src/bitcoin-blockchain/ConsensusConstants.swift
@@ -1,26 +1,37 @@
 import BitcoinBase
+import Foundation
 
 // MARK: - Flags from `consensus.h` in Bitcoin Core.
-private enum ConsensusConstants {
+enum ConsensusConstants {
 
     // MARK: - Transaction
 
+    /// See ``BitcoinBase/Transaction/witnessScaleFactor``.
+    ///
+    /// `WITNESS_SCALE_FACTOR`
+    static let witnessScaleFactor = 4
 
     // MARK: - Block
 
     /// See ``BitcoinBase/Block/maxWeight``.
+    ///
+    /// `MAX_BLOCK_WEIGHT`
     static let maxBlockWeight = 4_000_000
 
     /// See ``BitcoinBase/Block/maxSerializedSize``.
+    ///
+    /// `MAX_BLOCK_SERIALIZED_SIZE`
     static let maxBlockSerializedSized = 4_000_000
 
-    /// See ``BitcoinBase/Block/coinbaseMaturity``.
-    static let coinbaseMaturity = 100
-
-    /// The maximum allowed number of signature check operations in a block (network rule)
+    /// See ``BitcoinBase/Block/maxSigopsCost``.
     ///
-    /// Unused as of May 18, 2026
+    /// `MAX_BLOCK_SIGOPS_COST`
     static let maxBlockSigopsCost = 80_000
+
+    /// See ``BitcoinBase/Block/coinbaseMaturity``.
+    ///
+    /// `COINBASE_MATURITY`
+    static let coinbaseMaturity = 100
 
     /// `MIN_TRANSACTION_WEIGHT` in Bitcoin Core.
     ///
@@ -31,8 +42,33 @@ private enum ConsensusConstants {
     ///
     /// Unused as of May 18, 2026
     static let minSerializableTransactionWeight = Transaction.witnessScaleFactor * 10 // 10 is the lower bound for the size of a serialized CTransaction
+
+    /// See ``BitcoinBase/Block/maxTimewarp``.
+    ///
+    /// `MAX_TIMEWARP`
+    static let maxTimewarp = TimeInterval(600)
+
+    /// See ``BitcoinBase/Transaction/Input/locktimeVerifySequence``.
+    ///
+    /// `LOCKTIME_VERIFY_SEQUENCE`
+    static let locktimeVerifySequence = true // 1 << 0
 }
 
+/// Consensus.
+public extension Transaction {
+
+    /// Witness scale factor.
+    static let witnessScaleFactor = ConsensusConstants.witnessScaleFactor
+}
+
+/// Consensus.
+public extension Transaction.Input {
+
+    /// Interpret sequence numbers as relative lock-time constraints.
+    static let locktimeVerifySequence = ConsensusConstants.locktimeVerifySequence
+}
+
+/// Consensus.
 public extension Block {
 
     /// The maximum allowed weight for a block, see BIP141 (network rule)
@@ -43,6 +79,12 @@ public extension Block {
     /// Used for storage only (not consensus) as of May 18, 2026
     static let maxSerializedSize = ConsensusConstants.maxBlockSerializedSized
 
+    /// The maximum allowed number of signature check operations in a block (network rule)
+    static let maxSigopsCost = ConsensusConstants.maxBlockSigopsCost
+
     /// Coinbase transaction outputs can only be spent after this number of new blocks (network rule)
     static let coinbaseMaturity = ConsensusConstants.coinbaseMaturity
+
+    /// Maximum number of seconds that the timestamp of the first block of a difficulty adjustment period is allowed to be earlier than the last block of the previous period (BIP94).
+    static let maxTimewarp = ConsensusConstants.maxTimewarp
 }

--- a/src/bitcoin-blockchain/ConsensusParams.swift
+++ b/src/bitcoin-blockchain/ConsensusParams.swift
@@ -220,12 +220,4 @@ public struct ConsensusParams: Sendable {
 
     // TODO: Define testnet params with magicBytes 0x0709110b
     // TODO: Define signet params with magicBytes 0x40cf030a
-
-    // MARK: - Flags for nSequence and nLockTime locks
-
-    /// Interpret sequence numbers as relative lock-time constraints.
-    private static let locktimeVerifySequence = 1 << 0
-
-    /// Maximum number of seconds that the timestamp of the first block of a difficulty adjustment period is allowed to be earlier than the last block of the previous period (BIP94).
-    package static let maxTimewarp = TimeInterval(600)
 }

--- a/src/bitcoin-blockchain/PolicyConstants.swift
+++ b/src/bitcoin-blockchain/PolicyConstants.swift
@@ -1,54 +1,92 @@
 import BitcoinBase
 
-private enum PolicyConstants {
+enum PolicyConstants {
 
-    /// See ``BitcoinBase/Transaction/witnessScaleFactor``.
-    static let witnessScaleFactor = 4
+    /// See ``BitcoinBase/Script/defaultPermitBareMultisig``.
+    ///
+    /// `DEFAULT_PERMIT_BAREMULTISIG`
+    static let defaultPermitBareMultisig = true
+
+    /// See ``BitcoinBase/Script/defaultAcceptDatacarrier``.
+    ///
+    /// `DEFAULT_ACCEPT_DATACARRIER`
+    static let defaultAcceptDatacarrier = true
 
     /// See ``BitcoinBase/Transaction/maxStandardWeight``.
+    ///
+    /// `MAX_STANDARD_TX_WEIGHT`
     static let maxStandardWeight = 400_000
 
     /// See ``BitcoinBase/Transaction/maxDustOutputs``.
+    ///
+    /// `MAX_DUST_OUTPUTS_PER_TX`
     static let maxDustOutputs = 1
 
     /// See ``BitcoinBase/Transaction/dustRelayFee``.
+    ///
+    /// `DUST_RELAY_TX_FEE`
     static let dustRelayFee = 3000
 
     /// See ``BitcoinBase/Transaction/minStandardNonWitnessSize``.
+    ///
+    /// `MIN_STANDARD_TX_NONWITNESS_SIZE`
     static let minStandardNonWitnessTransactionSize = 65
 
-    /// See ``BitcoinBase/Script/maxStandardSize``.
-    static let maxStandardSize = 1650
+    /// See ``BitcoinBase/Script/maxStandardInputScriptSize``.
+    ///
+    /// `MAX_STANDARD_SCRIPTSIG_SIZE`
+    static let maxStandardInputScriptSize = 1650
 
     /// See ``BitcoinBase/Script/maxOpReturnRelay``.
-    static let maxOpReturnRelay = maxStandardWeight / witnessScaleFactor
+    ///
+    /// `MAX_OP_RETURN_RELAY`
+    static let maxOpReturnRelay = maxStandardWeight / ConsensusConstants.witnessScaleFactor
 
     /// See ``BitcoinBase/Script/maxP2SHSigops``.
+    ///
+    /// `MAX_P2SH_SIGOPS`
     static let maxP2SHSigops = 15
 
-    /// See ``BitcoinBase/Script/maxTransactionLegacySigops``.
+    /// See ``BitcoinBase/Transaction/maxStandardSigopsCost``.
+    ///
+    /// `MAX_STANDARD_TX_SIGOPS_COST`
+    static let maxStandardTransactionSigopsCost = ConsensusConstants.maxBlockSigopsCost / 5
+
+    /// See ``BitcoinBase/Transaction/maxLegacySigops``.
+    ///
+    /// `MAX_TX_LEGACY_SIGOPS`
     static let maxTransactionLegacySigops = 2_500
 
     // MARK: - P2WSH limits (witness standardness)
 
     /// See ``BitcoinBase/Transaction/Witness/maxP2WSHScriptSize``.
+    ///
+    /// `MAX_STANDARD_P2WSH_SCRIPT_SIZE`
     static let maxP2WSHScriptSize = 3600 // bytes
 
     /// See ``BitcoinBase/Transaction/Witness/maxP2WSHStackItems``.
+    ///
+    /// `MAX_STANDARD_P2WSH_STACK_ITEMS`
     static let maxP2WSHStackItems = 100
 
     /// See ``BitcoinBase/Transaction/Witness/maxP2WSHStackItemSize``.
+    ///
+    /// `MAX_STANDARD_P2WSH_STACK_ITEM_SIZE`
     static let maxP2WSHStackItemSize = 80 // bytes
 
     /// See ``BitcoinBase/Transaction/Witness/maxTapscriptStackItemSize``.
+    ///
+    /// `MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE`
     static let maxTapscriptStackItemSize = 80 // bytes
+
+    /// See ``BitcoinBase/Transaction/Input/standardLocktimeVerifyOption``.
+    ///
+    /// `STANDARD_LOCKTIME_VERIFY_FLAGS`
+    static let standardLocktimeVerifyOption = ConsensusConstants.locktimeVerifySequence
 }
 
 /// Policy.
 public extension Transaction {
-
-    /// Witness scale factor.
-    static let witnessScaleFactor = PolicyConstants.witnessScaleFactor
 
     /// Maximum standard weight.
     static let maxStandardWeight = PolicyConstants.maxStandardWeight
@@ -64,21 +102,18 @@ public extension Transaction {
     /// The minimum non-witness size for transactions we're willing to relay/mine: one larger than 64 .
     static let minStandardNonWitnessSize = PolicyConstants.minStandardNonWitnessTransactionSize
 
-}
-
-/// Policy.
-public extension Script {
-    // The maximum size of a standard _ScriptSig_.
-    static let maxStandardSize = PolicyConstants.maxStandardSize
-
-    /// Default setting for max data carrier size in vbytes.
-    static let maxOpReturnRelay = PolicyConstants.maxOpReturnRelay
-
-    /// Maximum number of signature check operations in standard P2SH script.
-    static let maxP2SHSigops = PolicyConstants.maxP2SHSigops
+    /// The maximum number of sigops we're willing to relay/mine in a single transaction.
+    static let maxStandardSigopsCost = PolicyConstants.maxStandardTransactionSigopsCost
 
     /// The maximum number of potentially executed legacy signature operations in a single standard tx.
-    static let maxTransactionLegacySigops = PolicyConstants.maxTransactionLegacySigops
+    static let maxLegacySigops = PolicyConstants.maxTransactionLegacySigops
+}
+
+/// Consensus.
+public extension Transaction.Input {
+
+    /// Interpret sequence numbers as relative lock-time constraints.
+    static let standardLocktimeVerifyOption = PolicyConstants.standardLocktimeVerifyOption
 }
 
 /// Policy.
@@ -95,4 +130,23 @@ public extension Transaction.Witness {
 
     /// Maximum byte size for a single stack item in a Tapscript witness.
     static let maxTapscriptStackItemSize = PolicyConstants.maxTapscriptStackItemSize
+}
+
+/// Policy.
+public extension Script {
+
+    /// Default for -permitbaremultisig
+    static let defaultPermitBareMultisig = PolicyConstants.defaultPermitBareMultisig
+
+    /// Default for -datacarrier
+    static let defaultAcceptDatacarrier = PolicyConstants.defaultAcceptDatacarrier
+
+    // The maximum size of a standard _ScriptSig_.
+    static let maxStandardInputScriptSize = PolicyConstants.maxStandardInputScriptSize
+
+    /// Default setting for max data carrier size in vbytes.
+    static let maxOpReturnRelay = PolicyConstants.maxOpReturnRelay
+
+    /// Maximum number of signature check operations in standard P2SH script.
+    static let maxP2SHSigops = PolicyConstants.maxP2SHSigops
 }

--- a/src/bitcoin-blockchain/TransactionValidationError.swift
+++ b/src/bitcoin-blockchain/TransactionValidationError.swift
@@ -25,4 +25,7 @@ public enum TransactionValidationError: Error {
 
     /// Script verification error.
     case scriptError
+
+    case tooManySigops
+    case feeTooLow
 }

--- a/src/bitcoin-miniscript/dsl/Fragment.swift
+++ b/src/bitcoin-miniscript/dsl/Fragment.swift
@@ -99,7 +99,7 @@ public struct After: ExpB, ModZ {
     let n: Int
 
     public var compiled: [Script.Operation] {
-        [.encodeMinimally(n), .checkLockTimeVerify]
+        [.encodeMinimally(n), .checkLocktimeVerify]
     }
 
     public var description: String {

--- a/src/bitcoin-miniscript/parsing/ASTNode.swift
+++ b/src/bitcoin-miniscript/parsing/ASTNode.swift
@@ -406,7 +406,7 @@ indirect enum ASTNode {
                 guard case let .arg(val) = args[0], let n = Int(val) else {
                     throw .invalidArgumentValue
                 }
-                return [.encodeMinimally(n), .checkLockTimeVerify]
+                return [.encodeMinimally(n), .checkLocktimeVerify]
             case "sha256":
                 guard case let .arg(v) = args[0], let h = Data(hex: v), h.count == BitcoinCrypto.SHA256.Digest.byteCount else {
                     throw .invalidArgumentValue

--- a/test/bitcoin-base/BitcoinCoreTaprootTests.swift
+++ b/test/bitcoin-base/BitcoinCoreTaprootTests.swift
@@ -20,7 +20,7 @@ struct BitcoinCoreTaprootTests {
             if !includeFlags.contains("NULLDUMMY") { config.remove(.nullDummy) }
             if !includeFlags.contains("STRICTENC") { config.remove(.strictEncoding) }
             if !includeFlags.contains("P2SH") { config.remove(.payToScriptHash) }
-            if !includeFlags.contains("CHECKLOCKTIMEVERIFY") { config.remove(.checkLockTimeVerify) }
+            if !includeFlags.contains("CHECKLOCKTIMEVERIFY") { config.remove(.checkLocktimeVerify) }
             if !includeFlags.contains("CHECKSEQUENCEVERIFY") { config.remove(.checkSequenceVerify) }
             if !includeFlags.contains("CONST_SCRIPTCODE") { config.remove(.constantScriptCode) }
             if !includeFlags.contains("WITNESS") { config.remove(.witness) }

--- a/test/bitcoin-base/playground/ScriptNumberTests.swift
+++ b/test/bitcoin-base/playground/ScriptNumberTests.swift
@@ -6,6 +6,8 @@ struct ScriptNumberTests {
 
     let zeroData = Data()
     let oneData = Data([1])
+    let sixteenData = Data([16])
+    let seventeenData = Data([17])
     let minusOneData = Data([0b10000001])
     let oneByteMinData = Data([0xff]) // -127
     let oneByteMaxData = Data([127])
@@ -84,6 +86,75 @@ struct ScriptNumberTests {
         let fiveByteMinNum = try ScriptNumber(fiveByteMinData, extendedLength: true)
         let fiveByteMinDataBack = fiveByteMinNum.data
         #expect(fiveByteMinDataBack == fiveByteMinData)
+    }
+
+    @Test("Encode minimally and pushed data roundtrips")
+    func encodeMinimallyRoundtrips() throws {
+        // Zero (0)
+        var num = try ScriptNumber(zeroData)
+        #expect(num.value == 0)
+        var op = Script.Operation.encodeMinimally(num.value)
+        #expect(op.isPush)
+        var numData = num.data
+        var op2 = Script.Operation.encodeMinimally(numData)
+        #expect(op == op2)
+        #expect(op == .zero)
+        var pushedData = try #require(op.pushedData)
+        #expect(pushedData == zeroData)
+        #expect(pushedData == numData)
+
+        // One (1)
+        num = try ScriptNumber(oneData)
+        #expect(num.value == 1)
+        op = Script.Operation.encodeMinimally(num.value)
+        #expect(op.isPush)
+        numData = num.data
+        op2 = Script.Operation.encodeMinimally(numData)
+        #expect(op == op2)
+        #expect(op == .constant(1))
+        pushedData = try #require(op.pushedData)
+        #expect(pushedData == oneData)
+        #expect(pushedData == numData)
+
+        // Minus one (-1)
+        num = try ScriptNumber(minusOneData)
+        #expect(num.value == -1)
+        op = Script.Operation.encodeMinimally(num.value)
+        #expect(op.isPush)
+        numData = num.data
+        op2 = Script.Operation.encodeMinimally(numData)
+        #expect(op == op2)
+        #expect(op == .oneNegate)
+        pushedData = try #require(op.pushedData)
+        #expect(pushedData == minusOneData)
+        #expect(pushedData == numData)
+
+        // Sixteen (16)
+        num = try ScriptNumber(sixteenData)
+        #expect(num.value == 16)
+        op = Script.Operation.encodeMinimally(num.value)
+        #expect(op.isPush)
+        numData = num.data
+        op2 = Script.Operation.encodeMinimally(numData)
+        #expect(op == op2)
+        #expect(op == .constant(16))
+        pushedData = try #require(op.pushedData)
+        #expect(pushedData == sixteenData)
+        #expect(pushedData == numData)
+
+        // Seventeen (17)
+        num = try ScriptNumber(seventeenData)
+        #expect(num.value == 17)
+        op = Script.Operation.encodeMinimally(num.value)
+        #expect(op.isPush)
+        numData = num.data
+        op2 = Script.Operation.encodeMinimally(numData)
+        #expect(op == op2)
+        #expect(op == .pushBytes(seventeenData))
+        pushedData = try #require(op.pushedData)
+        #expect(pushedData == seventeenData)
+        #expect(pushedData == numData)
+
     }
 
     @Test("Adding")

--- a/test/bitcoin-blockchain/InvalidTxTests.swift
+++ b/test/bitcoin-blockchain/InvalidTxTests.swift
@@ -32,7 +32,7 @@ struct InvalidTxTests {
             if includeFlags.contains("NULLDUMMY") { config.insert(.nullDummy) }
             if includeFlags.contains("STRICTENC") { config.insert(.strictEncoding) }
             if includeFlags.contains("P2SH") { config.insert(.payToScriptHash) }
-            if includeFlags.contains("CHECKLOCKTIMEVERIFY") { config.insert(.checkLockTimeVerify) }
+            if includeFlags.contains("CHECKLOCKTIMEVERIFY") { config.insert(.checkLocktimeVerify) }
             if includeFlags.contains("CHECKSEQUENCEVERIFY") { config.insert(.checkSequenceVerify) }
             if includeFlags.contains("CONST_SCRIPTCODE") { config.insert(.constantScriptCode) }
             if includeFlags.contains("WITNESS") { config.insert(.witness) }
@@ -570,7 +570,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .constant(1),
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -586,7 +586,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x64, 0xff]).reversed())), // 499_999_999
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -603,7 +603,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x65, 0x01]).reversed())), // 500_000_001
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -619,7 +619,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x00, 0xff, 0xff, 0xff, 0xff]).reversed())), // 4_294_967_295
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -635,7 +635,7 @@ fileprivate let testVectors: [TestVector] = [
                 outIndex: 0,
                 amount: 0,
                 ops: [
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -668,7 +668,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .oneNegate,
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -685,7 +685,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .oneNegate,
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -717,7 +717,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -750,7 +750,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             ),
@@ -777,7 +777,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -809,7 +809,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x64, 0xff]).reversed())), // 499_999_999
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                 ]
             )
         ],
@@ -825,7 +825,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x65, 0x00]).reversed())), // 500_000_000
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -841,7 +841,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x65, 0x00]).reversed())), // 500_000_000
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -858,7 +858,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x10, 0x00, 0x00, 0x00, 0x00]).reversed())),
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -875,7 +875,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x00, 0x80, 0x00, 0x00, 0x00]).reversed())), // 2_147_483_648
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -892,7 +892,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )

--- a/test/bitcoin-blockchain/ValidTxTests.swift
+++ b/test/bitcoin-blockchain/ValidTxTests.swift
@@ -26,7 +26,7 @@ struct ValidTxTests {
             if excludeFlags.contains("NULLDUMMY") { config.remove(.nullDummy) }
             if excludeFlags.contains("STRICTENC") { config.remove(.strictEncoding) }
             if excludeFlags.contains("P2SH") { config.remove(.payToScriptHash) }
-            if excludeFlags.contains("CHECKLOCKTIMEVERIFY") { config.remove(.checkLockTimeVerify) }
+            if excludeFlags.contains("CHECKLOCKTIMEVERIFY") { config.remove(.checkLocktimeVerify) }
             if excludeFlags.contains("CHECKSEQUENCEVERIFY") { config.remove(.checkSequenceVerify) }
             if excludeFlags.contains("CONST_SCRIPTCODE") { config.remove(.constantScriptCode) }
             if excludeFlags.contains("WITNESS") { config.remove(.witness) }
@@ -973,7 +973,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -990,7 +990,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x64, 0xff]).reversed())), // 499_999_999
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -1006,7 +1006,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -1024,7 +1024,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x65, 0x00]).reversed())), // 500_000_000
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                 ]
             )
         ],
@@ -1040,7 +1040,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x00, 0xff, 0xff, 0xff, 0xff]).reversed())), // 4_294_967_295
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -1056,7 +1056,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x65, 0x00]).reversed())), // 500_000_000
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -1073,7 +1073,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .zero,
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )
@@ -1092,7 +1092,7 @@ fileprivate let testVectors: [TestVector] = [
                 ops: [
                     .pushBytes(.init(Data([0x1d, 0xcd, 0x64, 0xff]).reversed())), // 499_999_999
                     .oneAdd,
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -1111,7 +1111,7 @@ fileprivate let testVectors: [TestVector] = [
                     .pushBytes(.init(Data([0x7f, 0xff, 0xff, 0xff]).reversed())), // 2_147_483_647
                     .pushBytes(.init(Data([0x7f, 0xff, 0xff, 0xff]).reversed())), // 2_147_483_647
                     .add,
-                    .checkLockTimeVerify
+                    .checkLocktimeVerify
                 ]
             )
         ],
@@ -1128,7 +1128,7 @@ fileprivate let testVectors: [TestVector] = [
                 amount: 0,
                 ops: [
                     .pushBytes(.init([0x00, 0x00, 0x00, 0x00, 0x00])),
-                    .checkLockTimeVerify,
+                    .checkLocktimeVerify,
                     .constant(1)
                 ]
             )


### PR DESCRIPTION
Ported remaining policy constants.
Gating standardness cheks, bare multisig, data carrier outputs. Operation now supports obtaining the minimally encoded pushed data, unit tested. Renamed inconsistent TimeLock spelling in identifiers to Timelock Cleaned up Mempool PreChecks and other downstream functions. Some maintenance of ConsensusParams and ConsensusConstants as well.
