### PR TITLE
Integrate Swift Configuration for Bitcoin Node (bcnode)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,11 @@ let package = Package(
         .package(url: "https://github.com/swift-bitcoin/swift-lmdb", from: "6.2.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(
+            url: "https://github.com/apple/swift-configuration",
+            from: "1.0.0",
+            traits: [.defaults, "CommandLineArguments"]
+        ),
         .package(url: "https://github.com/apple/swift-binary-parsing", .upToNextMinor(from: "0.0.1")),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
@@ -155,6 +160,7 @@ let package = Package(
                 .product(name: "ProfileRecorderServer", package: "swift-profile-recorder"),
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Configuration", package: "swift-configuration"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),

--- a/plugin/copy-config-sources/CopyConfigSources.swift
+++ b/plugin/copy-config-sources/CopyConfigSources.swift
@@ -1,7 +1,7 @@
 import PackagePlugin
 import Foundation
 
-/// Copies the contents of `NodeConfig.swift` into a `NodeConfig.swift.txt` file in the plugin's output folder. The copied source code will be included in the resources bundle and prepended to configuration scripts.
+/// Copies the contents of `NodeConfig.swift` into a `NodeConfig.swift.txt` file in the plugin's output directory. The copied source code will be included in the resources bundle and prepended to configuration scripts.
 ///
 /// If stuck with an old version of the file, the copy can be manually removed before running/building again:
 ///

--- a/src/bitcoin-blockchain/block/index/HybridBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/HybridBlockIndex.swift
@@ -405,7 +405,7 @@ actor HybridBlockIndex: BlockIndex {
     private func clearPersistent() async {
         env = nil // closes env
 
-        // Removes folder
+        // Removes directory
         let fs = FileSystem.shared
         do {
             try await fs.removeItem(at: path)

--- a/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
+++ b/src/bitcoin-blockchain/block/index/PersistentBlockIndex.swift
@@ -392,7 +392,7 @@ actor PersistentBlockIndex: BlockIndex {
     func clear() async {
         env = nil // closes env
 
-        // Removes folder
+        // Removes directory
         let fs = FileSystem.shared
         do {
             try await fs.removeItem(at: path)

--- a/src/bitcoin-blockchain/coins/HybridCoinIndex.swift
+++ b/src/bitcoin-blockchain/coins/HybridCoinIndex.swift
@@ -107,7 +107,7 @@ actor HybridCoinIndex: CoinIndex {
     private func clearPersistent() async {
         env = nil // closes env
 
-        // Removes folder
+        // Removes directory
         let fs = FileSystem.shared
         do {
             try await fs.removeItem(at: path)

--- a/src/bitcoin-blockchain/coins/PersistentCoinIndex.swift
+++ b/src/bitcoin-blockchain/coins/PersistentCoinIndex.swift
@@ -119,7 +119,7 @@ actor PersistentCoinIndex: CoinIndex {
     func clear() async {
         env = nil // closes env
 
-        // Removes folder
+        // Removes directory
         let fs = FileSystem.shared
         do {
             try await fs.removeItem(at: path)

--- a/src/bitcoin-node/commands/CheckConfig.swift
+++ b/src/bitcoin-node/commands/CheckConfig.swift
@@ -1,7 +1,5 @@
-import ArgumentParser
 import Foundation
-import NIOCore
-import _NIOFileSystem
+import ArgumentParser
 
 struct CheckConfig: AsyncParsableCommand {
 
@@ -9,34 +7,14 @@ struct CheckConfig: AsyncParsableCommand {
         abstract: "Verifies the configuration file."
     )
 
-    @Argument(help: "The absolute path to either the folder containing Swift Bitcoin's configuration file or the configuration file itself, e.g. \"/some/folder/myConfig.json\".")
-    var location = NodeConfig.defaultLocation
+    @OptionGroup var configOptions: ConfigOptions
 
     mutating func run() async throws(ValidationError) {
-        let config: NodeConfig
-        do {
-            try config = await NodeConfig.parse(location, strict: true)
-        } catch {
-            throw ValidationError(error)
-        }
-        // Success, display the result of the check
-
-        // Additional round trip verification
+        let nodeConfig = try await NodeConfig.loadConfiguration(configOptions)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
-        guard let roundtrip = try? encoder.encode(config) else {
-            throw ValidationError("Issue verifying decoding-encoding round trip.")
-        }
-
-        print("Configuration file verification passed with following parameters:\n")
-        print(String(data: roundtrip, encoding: .utf8)!)
-    }
-}
-
-private func getInfo(_ path: FilePath) async -> FileInfo? {
-    do {
-        return try await FileSystem.shared.info(forFileAt: path)
-    } catch {
-        fatalError()
+        let data = try! encoder.encode(nodeConfig)
+        print(String(data: data, encoding: .utf8)!)
+        // debugPrint(nodeConfig)
     }
 }

--- a/src/bitcoin-node/commands/ConfigOptions.swift
+++ b/src/bitcoin-node/commands/ConfigOptions.swift
@@ -1,0 +1,59 @@
+import ArgumentParser
+
+struct ConfigOptions: ParsableArguments {
+
+    @Option(help: "The absolute path the directory containing Swift Bitcoin's configuration file(s).")
+    var configPath = NodeConfig.defaultLocation
+
+    @Option(help: "The P2P network to connect to. Defaults to what's specified in the configuration file. (default: \(NodeConfig.default.network))")
+    var network: NodeConfig.Network?
+
+    @Option(help: "The address to bind the RPC server to.")
+    var rpcHost: String?
+
+    @Option(help: "The TCP port number to bind the server instance to. Default's to network's default port (\(NodeConfig.Network.mainnet.defaultRPCPort) for mainnet)")
+    var rpcPort: Int?
+
+    @Option(help: "Use in-memory for ephemeral in-memory data. Use default-path for storing data in the default location (will be created if it does not yet exist) or use \"custom(path)\" to specify a custom path")
+    var dataLocation: String?
+
+    @Option(help: "Listen for incoming connections on the peer-to-peer network at the speficied \"address:port\".")
+    var bind: String?
+
+    /// Address on which to listen for incoming connections on the peer-to-peer network
+    @Option(help: .private)
+    var bindHost: String?
+
+    /// Port on which to listen for incoming connections on the peer-to-peer network
+    @Option(help: .private)
+    var bindPort: Int?
+
+    @Option(help: "Connect to specified remote peers automatically on startup.")
+    var connect: [String] = []
+
+    /// The list of peer hosts to connect to.
+    @Option(help: .private)
+    var connectHost: [String] = []
+
+    /// The list of peer ports corresponding to the specified peer hosts (--connect-host)
+    @Option(help: .private)
+    var connectPort: [Int] = []
+
+    @Option(help: "Connect to randomly selected public peers automatically on startup. (default: \(NodeConfig.default.autoConnect))")
+    var autoConnect: Bool?
+
+    @Option(help: "Log level.")
+    var logLevel: NodeConfig.LogLevel?
+
+    @Option(defaultAsFlag: true, help: "Enable metrics with default settings")
+    var metrics: Bool?
+
+    @Option(help: "Metrics conenction endpoint")
+    var metricsEndpoint: String?
+
+    @Option(defaultAsFlag: true, help: "Enable remote profiling")
+    var enableProfiling: Bool?
+
+    @Option(help: "Minimum fee rate to accept transactions")
+    var feeRate: Int?
+}

--- a/src/bitcoin-node/commands/LegacyCheckConfig.swift
+++ b/src/bitcoin-node/commands/LegacyCheckConfig.swift
@@ -1,0 +1,43 @@
+import ArgumentParser
+import Foundation
+import NIOCore
+import _NIOFileSystem
+
+/// Legacy check configuration command; uses old ``NodeConfig/parse(_:strict:)`` instead of `Configuration`.
+struct LegacyCheckConfig: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: "Verifies the configuration file."
+    )
+
+    @Argument(help: "The absolute path to either the directory containing Swift Bitcoin's configuration file or the configuration file itself, e.g. \"/some/directory/myConfig.json\".")
+    var location = NodeConfig.defaultLocation
+
+    mutating func run() async throws(ValidationError) {
+        let config: NodeConfig
+        do {
+            try config = await NodeConfig.parse(location, strict: true)
+        } catch {
+            throw ValidationError(error)
+        }
+        // Success, display the result of the check
+
+        // Additional round trip verification
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let roundtrip = try? encoder.encode(config) else {
+            throw ValidationError("Issue verifying decoding-encoding round trip.")
+        }
+
+        print("Configuration file verification passed with following parameters:\n")
+        print(String(data: roundtrip, encoding: .utf8)!)
+    }
+}
+
+private func getInfo(_ path: FilePath) async -> FileInfo? {
+    do {
+        return try await FileSystem.shared.info(forFileAt: path)
+    } catch {
+        fatalError()
+    }
+}

--- a/src/bitcoin-node/commands/LegacyStart.swift
+++ b/src/bitcoin-node/commands/LegacyStart.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import BitcoinTransport
+
+/// Legacy start node command; uses explicit command line options and the old ``NodeConfig/parse(_:strict:)`` instead of `Configuration`.
+struct LegacyStart: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        abstract: "Launch a Bitcoin node instance."
+    )
+
+    @Option(name: .shortAndLong, help: "The absolute path to either the directory containing Swift Bitcoin's configuration file or the configuration file itself, e.g. \"/some/directory/myConfig.json\".")
+    var configPath = NodeConfig.defaultLocation
+
+    @Option(name: .shortAndLong, help: "The P2P network to connect to. Defaults to what's specified in the configuration file. (default: \(NodeConfig.default.network))")
+    var network: NodeConfig.Network?
+
+    @Option(name: .shortAndLong, help: "Use in-memory for ephemeral in-memory data. Use default-path for storing data in the default location (will be created if it does not yet exist).")
+    var dataLocationType: DataLocationType?
+
+    @Option(name: [.customShort("q"), .long], help: "A custom absolute path to Swift Bitcoin's data directory (will be created if it does not yet exist).")
+    var dataLocationPath: String?
+
+    @Option(name: .long, help: "Listen for incoming connections on the peer-to-peer network at the speficied \"address:port\".")
+    var bind: String?
+
+    @Option(name: .long, help: "Connect to specified remote peers automatically on startup.")
+    var connect: [String] = []
+
+    @Option(name: .long, help: "Connect to randomly selected public peers automatically on startup. (default: \(NodeConfig.default.autoConnect))")
+    var autoConnect: Bool?
+
+    @Option(name: .shortAndLong, help: "The address to bind the RPC server to.")
+    var host = "0.0.0.0"
+
+    @Option(name: .shortAndLong, help: "The TCP port number to bind the server instance to. Default's to network's default port (\(NodeNetwork.mainnet.defaultRPCPort) for \(NodeNetwork.mainnet))")
+    var port: Int?
+
+    @Option(name: .shortAndLong, help: "Log level.")
+    var logLevel: NodeConfig.LogLevel?
+
+    mutating func run() async throws {
+
+        let dataLocation: NodeConfig.DataLocation? = if let dataLocationType, dataLocationPath == nil {
+            switch dataLocationType {
+            case .inMemory: .inMemory
+            case .defaultPath: .defaultPath
+            }
+        } else if let dataLocationPath, dataLocationType == nil {
+            .custom(path: dataLocationPath)
+        } else if dataLocationType == nil, dataLocationPath == nil {
+            nil
+        } else {
+            throw ValidationError("Either specify data-location-type or data-location-path.")
+        }
+
+        let config: NodeConfig
+        do {
+            try config = await NodeConfig.parse(configPath)
+        } catch {
+            throw ValidationError(error)
+        }
+
+        let bind: NodeConfig.BindSettings? = if let bind {
+            if let (host, port) = IPv4Address.parse(bind) {
+                .init(host: host, port: port)
+            } else if let (host, port) = IPv6Address.parse(bind) {
+                .init(host: host, port: port)
+            } else {
+                throw ValidationError("Invalid bind address format")
+            }
+        } else { config.bind }
+
+        let connect: [NodeConfig.RemotePeer] = try connect.map { address in
+            if let (host, port) = IPv4Address.parse(address) {
+                .init(host: host, port: port)
+            } else if let (host, port) = IPv6Address.parse(address) {
+                .init(host: host, port: port)
+            } else {
+                throw ValidationError("Invalid bind address format")
+            }
+        }
+
+        // WARNING: New configuration options need to be added here regardless of whether there is a command line parameter override!
+        let resolvedConfig = NodeConfig(
+            network: network ?? config.network,
+            rpc: .init(host: host, port: port ?? NodeConfig.default.rpc.port),
+            dataLocation: dataLocation ?? config.dataLocation,
+            bind: bind,
+            connect: connect + config.connect,
+            autoConnect: autoConnect ?? config.autoConnect,
+            logLevel: logLevel ?? config.logLevel,
+            metrics: config.metrics,
+            enableProfiling: config.enableProfiling,
+            feeRate: config.feeRate
+        )
+
+        _ = try await ServerApp(resolvedConfig)
+    }
+}
+
+enum DataLocationType: String, ExpressibleByArgument {
+    case inMemory = "in-memory", defaultPath = "default-path"
+}

--- a/src/bitcoin-node/commands/Start.swift
+++ b/src/bitcoin-node/commands/Start.swift
@@ -1,7 +1,4 @@
 import ArgumentParser
-import BitcoinTransport
-
-extension NodeNetwork: Decodable, ExpressibleByArgument { }
 
 struct Start: AsyncParsableCommand {
 
@@ -9,95 +6,15 @@ struct Start: AsyncParsableCommand {
         abstract: "Launch a Bitcoin node instance."
     )
 
-    @Option(name: .shortAndLong, help: "The absolute path to either the folder containing Swift Bitcoin's configuration file or the configuration file itself, e.g. \"/some/folder/myConfig.json\".")
-    var configPath = NodeConfig.defaultLocation
+    @OptionGroup var configOptions: ConfigOptions
 
-    @Option(name: .shortAndLong, help: "The P2P network to connect to. Defaults to what's specified in the configuration file. (default: \(NodeConfig.default.network))")
-    var network: NodeConfig.Network?
-
-    @Option(name: .shortAndLong, help: "Use in-memory for ephemeral in-memory data. Use default-path for storing data in the default location (will be created if it does not yet exist).")
-    var dataLocationType: DataLocationType?
-
-    @Option(name: [.customShort("q"), .long], help: "A custom absolute path to Swift Bitcoin's data directory (will be created if it does not yet exist).")
-    var dataLocationPath: String?
-
-    @Option(name: .long, help: "Listen for incoming connections on the peer-to-peer network at the speficied \"address:port\".")
-    var bind: String?
-
-    @Option(name: .long, help: "Connect to specified remote peers automatically on startup.")
-    var connect: [String] = []
-
-    @Option(name: .long, help: "Connect to randomly selected public peers automatically on startup. (default: \(NodeConfig.default.autoConnect))")
-    var autoConnect: Bool?
-
-    @Option(name: .shortAndLong, help: "The address to bind the RPC server to.")
-    var host = "0.0.0.0"
-
-    @Option(name: .shortAndLong, help: "The TCP port number to bind the server instance to. Default's to network's default port (\(NodeNetwork.mainnet.defaultRPCPort) for \(NodeNetwork.mainnet))")
-    var port: Int?
-
-    @Option(name: .shortAndLong, help: "Log level.")
-    var logLevel: NodeConfig.LogLevel?
-
-    mutating func run() async throws {
-
-        let dataLocation: NodeConfig.DataLocation? = if let dataLocationType, dataLocationPath == nil {
-            switch dataLocationType {
-            case .inMemory: .inMemory
-            case .defaultPath: .defaultPath
-            }
-        } else if let dataLocationPath, dataLocationType == nil {
-            .custom(path: dataLocationPath)
-        } else if dataLocationType == nil, dataLocationPath == nil {
-            nil
-        } else {
-            throw ValidationError("Either specify data-location-type or data-location-path.")
-        }
-
-        let config: NodeConfig
+    mutating func run() async throws(ValidationError) {
+        let nodeConfig = try await NodeConfig.loadConfiguration(configOptions)
         do {
-            try config = await NodeConfig.parse(configPath)
+            _ = try await ServerApp(nodeConfig)
         } catch {
-            throw ValidationError(error)
+            throw ValidationError("Error starting server: \(error)")
         }
-
-        let bind: NodeConfig.BindSettings? = if let bind {
-            if let (host, port) = IPv4Address.parse(bind) {
-                .init(host: host, port: port)
-            } else if let (host, port) = IPv6Address.parse(bind) {
-                .init(host: host, port: port)
-            } else {
-                throw ValidationError("Invalid bind address format")
-            }
-        } else { config.bind }
-
-        let connect: [NodeConfig.RemotePeer] = try connect.map { address in
-            if let (host, port) = IPv4Address.parse(address) {
-                .init(host: host, port: port)
-            } else if let (host, port) = IPv6Address.parse(address) {
-                .init(host: host, port: port)
-            } else {
-                throw ValidationError("Invalid bind address format")
-            }
-        }
-
-        // WARNING: New configuration options need to be added here regardless of whether there is a command line parameter override!
-        let resolvedConfig = NodeConfig(
-            dataLocation: dataLocation ?? config.dataLocation,
-            network: network ?? config.network,
-            bind: bind,
-            connect: connect + config.connect,
-            autoConnect: autoConnect ?? config.autoConnect,
-            logLevel: logLevel ?? config.logLevel,
-            feeRate: config.feeRate,
-            metrics: config.metrics,
-            enableProfiling: config.enableProfiling
-        )
-
-        _ = try await ServerApp(resolvedConfig, host: host, port: port)
     }
 }
 
-enum DataLocationType: String, ExpressibleByArgument {
-    case inMemory = "in-memory", defaultPath = "default-path"
-}

--- a/src/bitcoin-node/config/NodeConfig+ConfigError.swift
+++ b/src/bitcoin-node/config/NodeConfig+ConfigError.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+
+extension NodeConfig {
+
+    enum ConfigError: Error {
+        case conflictingArguments(String, String)
+    }
+}
+
+extension ValidationError {
+    init(_ error: NodeConfig.ConfigError) {
+        self = switch error {
+        case let .conflictingArguments(arg1, arg2):
+            ValidationError("Conflicting arguments \"\(arg1)\" vs \"\(arg2)\"")
+        }
+    }
+}

--- a/src/bitcoin-node/config/NodeConfig+Decodable.swift
+++ b/src/bitcoin-node/config/NodeConfig+Decodable.swift
@@ -1,0 +1,94 @@
+extension NodeConfig: Decodable {
+    // This extension does not need to be in NodeConfig when used from a Swift script
+
+    init(from decoder: any Decoder) throws {
+        let defaults = Self.default
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.network = try container.decodeIfPresent(NodeConfig.Network.self, forKey: .network) ?? defaults.network
+
+        self.rpc = try container.decodeIfPresent(NodeConfig.RPCSettings.self, forKey: .rpc) ?? defaults.rpc
+
+        self.dataLocation = try container.decodeIfPresent(NodeConfig.DataLocation.self, forKey: .dataLocation) ?? defaults.dataLocation
+
+        self.bind = if let b = try container.decodeIfPresent(BindSettings.self, forKey: .bind) {
+            b
+        } else if let bindString = try container.decodeIfPresent(String.self, forKey: .bind), let b = BindSettings(bindString) {
+            b
+        } else {
+            defaults.bind
+        }
+
+        self.connect = if let c = try container.decodeIfPresent([RemotePeer].self, forKey: .connect) {
+            c
+        } else if let connectStrings = try container.decodeIfPresent([String].self, forKey: .connect) {
+            connectStrings.compactMap(RemotePeer.init)
+        } else {
+            defaults.connect
+        }
+
+        self.autoConnect = try container.decodeIfPresent(Bool.self, forKey: .autoConnect) ?? defaults.autoConnect
+        self.logLevel = try container.decodeIfPresent(LogLevel.self, forKey: .logLevel) ?? defaults.logLevel
+        self.metrics = try container.decodeIfPresent(NodeConfig.OTelMetrics.self, forKey: .metrics) ?? defaults.metrics
+        self.enableProfiling = try container.decodeIfPresent(Bool.self, forKey: .enableProfiling) ?? defaults.enableProfiling
+        self.feeRate = try container.decodeIfPresent(Int.self, forKey: .feeRate) ?? defaults.feeRate
+    }
+}
+
+extension NodeConfig.DataLocation: Decodable {
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        guard let other = Self(value) else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: decoder.codingPath, debugDescription: "Invalid Location format: \(value)")
+            )
+        }
+        self = other
+    }
+
+    init?(_ value: String) {
+        switch value {
+        case "in-memory":
+            self = .inMemory
+        case "default-path":
+            self = .defaultPath
+        default:
+            let regex = #/custom\((.+)\)/# // Because this file is run as a Swift script we cannot use bare regex `/custom\((.+)\)/`
+            guard let match = try? regex.wholeMatch(in: value) else {
+                return nil
+            }
+            let customPathSubstring = match.1  // Substring
+            let customPath = String(customPathSubstring)
+            self = .custom(path: customPath)
+        }
+    }
+}
+
+import BitcoinTransport
+
+extension NodeConfig.BindSettings {
+
+    init?(_ bind: String) {
+        if let (host, port) = IPv4Address.parse(bind) {
+            self.init(host: host, port: port)
+        } else if let (host, port) = IPv6Address.parse(bind) {
+            self.init(host: host, port: port)
+        } else {
+            return nil
+        }
+    }
+}
+
+extension NodeConfig.RemotePeer {
+
+    init?(_ bind: String) {
+        if let (host, port) = IPv4Address.parse(bind) {
+            self.init(host: host, port: port)
+        } else if let (host, port) = IPv6Address.parse(bind) {
+            self.init(host: host, port: port)
+        } else {
+            return nil
+        }
+    }
+}

--- a/src/bitcoin-node/config/NodeConfig+ParseError.swift
+++ b/src/bitcoin-node/config/NodeConfig+ParseError.swift
@@ -3,11 +3,12 @@ import ArgumentParser
 extension NodeConfig {
 
     enum ParseError: Error {
-        case locateFolder(String)
-        case readFolder(String)
+        case locateDirectory(String)
+        case readDirectory(String)
         case missingFile(String)
         case invalidExtension
-        case notFileOrFolder(String)
+        case notDirectory(String)
+        case notFileOrDirectory(String)
         case maximumSizeExceeded(size: Int, max: Int)
         case unknownOpenReadIssue
         case decodingError
@@ -15,23 +16,25 @@ extension NodeConfig {
         case missingInternalResource
         case internalResourceUnavailable
         case swiftScriptFailure
-        case unableToCreateFolder
+        case unableToCreateDirectory
     }
 }
 
 extension ValidationError {
     init(_ error: NodeConfig.ParseError) {
         self = switch error {
-        case .locateFolder(let location):
-            ValidationError("Could not locate folder/file at \"\(location)\"")
-        case .readFolder(let location):
-            ValidationError("Issue retrieving folder/file information at \"\(location)\"")
+        case .locateDirectory(let location):
+            ValidationError("Could not locate directory/file at \"\(location)\"")
+        case .readDirectory(let location):
+            ValidationError("Issue retrieving directory/file information at \"\(location)\"")
         case .missingFile(let location):
             ValidationError("Could not find either config.swift or config.json in \"\(location)\".")
         case .invalidExtension:
             ValidationError("Only \".swift\" or \".json\" file extensions are accepted.")
-        case .notFileOrFolder(let location):
-            ValidationError("Could not find folder or regular file at \"\(location)\".")
+        case .notDirectory(let location):
+            ValidationError("Found regular file instead of directory at \"\(location)\".")
+        case .notFileOrDirectory(let location):
+            ValidationError("Could not find directory or regular file at \"\(location)\".")
         case let .maximumSizeExceeded(size, max):
             ValidationError("Maximum file size allowes is \(max) bytes (current file is \(size) bytes.")
         case .unknownOpenReadIssue:
@@ -46,8 +49,8 @@ extension ValidationError {
             ValidationError("Unable to read internal resource file contents.")
         case .swiftScriptFailure:
             ValidationError("Issue while converting Swift configuration.")
-        case .unableToCreateFolder:
-            ValidationError("Unable to create default folder.")
+        case .unableToCreateDirectory:
+            ValidationError("Unable to create default directory.")
         }
     }
 }

--- a/src/bitcoin-node/config/NodeConfig+SwiftConfiguration.swift
+++ b/src/bitcoin-node/config/NodeConfig+SwiftConfiguration.swift
@@ -1,0 +1,116 @@
+import Configuration
+
+extension NodeConfig {
+
+    init(_ config: ConfigReader) throws(ConfigError) {
+        let network = if let networkString = config.string(forKey: "network"), let n = Network(rawValue: networkString) {
+            n
+        } else {
+            NodeConfig.default.network
+        }
+
+        let rpcHost = config.string(forKey: "rpc.host", default: NodeConfig.default.rpc.host)
+        let rpcPort = config.int(forKey: "rpc.port", default: NodeConfig.default.rpc.port)
+        let rpc = NodeConfig.RPCSettings(host: rpcHost, port: rpcPort)
+
+        let dataLocation = if let dataLocationString = config.string(forKey: "dataLocation"), let dl = DataLocation(dataLocationString) {
+            dl
+        } else {
+            NodeConfig.default.dataLocation
+        }
+
+        guard config.string(forKey: "bind") == nil || (config.string(forKey: "bind.host") == nil && config.string(forKey: "bind.port") == nil) else {
+            throw .conflictingArguments("bind", "bind.host/port")
+        }
+
+        let bind = if let bindString = config.string(forKey: "bind"), let b = BindSettings(bindString) {
+            b
+        } else if let bindHost = config.string(forKey: "bind.host") {
+            BindSettings(host: bindHost, port: config.int(forKey: "bind.port"))
+        } else {
+            NodeConfig.default.bind
+        }
+
+        let connectPartA = config.stringArray(forKey: "connect")?.compactMap(RemotePeer.init)
+        let connectPartB: [RemotePeer]? = if let connectHosts = config.stringArray(forKey: "connect.host"), let connectPorts = config.intArray(forKey: "connect.port") {
+            zip(connectHosts, connectPorts).map { RemotePeer(host: $0.0, port: $0.1)}
+        } else {
+            nil
+        }
+        let connect = if connectPartA == nil, connectPartB == nil {
+            NodeConfig.default.connect
+        } else {
+            (connectPartA ?? []) + (connectPartB ?? [])
+        }
+
+        let autoConnect = config.bool(forKey: "autoConnect", default: NodeConfig.default.autoConnect)
+
+        let logLevel = if let logLevelString = config.string(forKey: "logLevel"), let ll = LogLevel(rawValue: logLevelString) {
+            ll
+        } else {
+            NodeConfig.default.logLevel
+        }
+
+        let metrics = if let metricsEndpoint = config.string(forKey: "metrics.endpoint") {
+            OTelMetrics(endpoint: metricsEndpoint)
+        } else if config.bool(forKey: "metrics", default: false) {
+            OTelMetrics()
+        } else {
+            NodeConfig.default.metrics
+        }
+
+        let enableProfiling = config.bool(forKey: "enableProfiling", default: NodeConfig.default.enableProfiling)
+
+        let feeRate = config.int(forKey: "feeRate") ?? NodeConfig.default.feeRate
+
+        self.init(network: network, rpc: rpc, dataLocation: dataLocation, bind: bind, connect: connect, autoConnect: autoConnect, logLevel: logLevel, metrics: metrics, enableProfiling: enableProfiling, feeRate: feeRate)
+    }
+}
+
+import _NIOFileSystem
+import ArgumentParser
+
+extension NodeConfig {
+    static func loadConfiguration(_ configOptions: ConfigOptions) async throws(ValidationError) -> NodeConfig {
+        let configPath: FilePath
+        do {
+            configPath = try await NodeConfig.checkLocation(configOptions.configPath)
+        } catch {
+            throw ValidationError(error)
+        }
+
+        let filePathJSON = configPath.appending("config.json")
+        let fileProviderJSON: FileProvider<JSONSnapshot>
+        do {
+            fileProviderJSON = try await FileProvider<JSONSnapshot>(filePath: filePathJSON, allowMissing: true)
+        } catch {
+            throw ValidationError("Error opening/reading \(filePathJSON) file.\n\n\(error)")
+        }
+
+        let filePathSwift = configPath.appending("config.swift")
+        let fileProviderSwift: FileProvider<SwiftSnapshot>
+        do {
+            fileProviderSwift = try await FileProvider<SwiftSnapshot>(filePath: filePathSwift, allowMissing: true)
+        } catch {
+            throw ValidationError("Error opening/reading \(filePathSwift) file.\n\n\(error)")
+        }
+
+        let config = ConfigReader(providers: [
+            // First check command line arguments and environment variables.
+            CommandLineArgumentsProvider(),
+            EnvironmentVariablesProvider(),
+            // Then check the config files for JSON and Swift.
+            fileProviderJSON,
+            fileProviderSwift,
+            // Finally, use hardcoded defaults.
+            InMemoryProvider(values: [:] /* No need for hardcoded values as NodeConfig handles defaults */)
+        ])
+        let nodeConfig: NodeConfig
+        do {
+            nodeConfig = try NodeConfig(config)
+        } catch {
+            throw ValidationError(error)
+        }
+        return nodeConfig
+    }
+}

--- a/src/bitcoin-node/config/NodeConfig+checkLocation.swift
+++ b/src/bitcoin-node/config/NodeConfig+checkLocation.swift
@@ -1,0 +1,43 @@
+import Foundation
+import _NIOFileSystem
+
+extension NodeConfig {
+
+    static func checkLocation(_ location: String) async throws(ParseError) -> FilePath {
+        // Check whether we are accessing the default location
+        let isDefault = location == Self.defaultLocation
+
+        // Find the actual configuration file
+        let fs = FileSystem.shared
+        let directoryPath = FilePath(location)
+        let directoryInfo: FileInfo?
+        do {
+            directoryInfo = try await fs.info(forFileAt: directoryPath)
+        } catch {
+            throw .locateDirectory(location)
+        }
+        guard let directoryInfo else {
+            guard isDefault else {
+                throw .readDirectory(location)
+            }
+            do {
+                try await fs.createDirectory(at: directoryPath, withIntermediateDirectories: true)
+            } catch {
+                throw .internalResourceUnavailable
+            }
+            return directoryPath
+        }
+        guard directoryInfo.type == .directory else {
+            throw .notDirectory(directoryPath.string)
+        }
+        return directoryPath
+    }
+}
+
+private func getInfo(_ path: FilePath) async -> FileInfo? {
+    do {
+        return try await FileSystem.shared.info(forFileAt: path)
+    } catch {
+        fatalError()
+    }
+}

--- a/src/bitcoin-node/config/NodeConfig+parse.swift
+++ b/src/bitcoin-node/config/NodeConfig+parse.swift
@@ -28,11 +28,11 @@ extension NodeConfig {
         let filePath: FilePath
         let fileInfo: FileInfo
 
-        // Do we already have a path to the configuration file or just its containing folder?
+        // Do we already have a path to the configuration file or just its containing directory?
         do {
             directoryOrFileInfo = try await fs.info(forFileAt: directoryOrFilePath)
         } catch {
-            throw .locateFolder(location)
+            throw .locateDirectory(location)
         }
         guard let directoryOrFileInfo else {
             if isDefault && !strict {
@@ -45,7 +45,7 @@ extension NodeConfig {
                 }
                 return .default
             }
-            throw .readFolder(location)
+            throw .readDirectory(location)
         }
         if directoryOrFileInfo.type == .directory {
             // We have a directory, let's find out if it contains a valid configuration file
@@ -77,9 +77,9 @@ extension NodeConfig {
             filePath = directoryOrFilePath
             fileInfo = directoryOrFileInfo
         } else {
-            // We only support folders or regular files
+            // We only support directories or regular files
             // TODO: Allow symlinks
-            throw .notFileOrFolder(directoryOrFilePath.string)
+            throw .notFileOrDirectory(directoryOrFilePath.string)
         }
 
         // Limit the file's size

--- a/src/bitcoin-node/config/NodeConfig.swift
+++ b/src/bitcoin-node/config/NodeConfig.swift
@@ -1,86 +1,117 @@
 // Note: This file is required by the plugin `CopyConfigSources`.
 
-struct NodeConfig: Codable {
+struct NodeConfig: Encodable {
 
     init(
-        dataLocation: DataLocation = .defaultPath,
         network: Network = .mainnet,
+        rpc: RPCSettings? = nil,
+        dataLocation: DataLocation = .defaultPath,
         bind: BindSettings? = nil,
         connect: [RemotePeer] = [],
         autoConnect: Bool = true,
         logLevel: LogLevel = .info,
-        feeRate: Int = 100,
         metrics: OTelMetrics? = nil,
-        enableProfiling: Bool = false
+        enableProfiling: Bool = false,
+        feeRate: Int = 100
     ) {
-        self.dataLocation = dataLocation
         self.network = network
+        self.rpc = rpc ?? RPCSettings(host: "0.0.0.0", port: network.defaultRPCPort)
+        self.dataLocation = dataLocation
         self.bind = bind
         self.connect = connect
         self.autoConnect = autoConnect
         self.logLevel = logLevel
-        self.feeRate = feeRate
         self.metrics = metrics
         self.enableProfiling = enableProfiling
+        self.feeRate = feeRate
     }
 
-    let dataLocation: DataLocation
     let network: Network
+    let rpc: RPCSettings
+    let dataLocation: DataLocation
     let bind: BindSettings?
     let connect: [RemotePeer]
     let autoConnect: Bool
     let logLevel: LogLevel
-    let feeRate: Int
 
     /// Whether to report OpenTelemetry metrics, including system metrics.
     let metrics: OTelMetrics?
     let enableProfiling: Bool
+    let feeRate: Int
 
     static let `default` = Self()
 
-    init(from decoder: any Decoder) throws {
-        let defaults = Self.default
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.dataLocation = try container.decodeIfPresent(NodeConfig.DataLocation.self, forKey: .dataLocation) ?? defaults.dataLocation
-        self.network = try container.decodeIfPresent(NodeConfig.Network.self, forKey: .network) ?? defaults.network
-        self.bind = try container.decodeIfPresent(BindSettings.self, forKey: .bind) ?? defaults.bind
-        self.connect = try container.decodeIfPresent([RemotePeer].self, forKey: .connect) ?? defaults.connect
-        self.autoConnect = try container.decodeIfPresent(Bool.self, forKey: .autoConnect) ?? defaults.autoConnect
-        self.logLevel = try container.decodeIfPresent(LogLevel.self, forKey: .logLevel) ?? defaults.logLevel
-        self.feeRate = try container.decodeIfPresent(Int.self, forKey: .feeRate) ?? defaults.feeRate
-        self.metrics = try container.decodeIfPresent(NodeConfig.OTelMetrics.self, forKey: .metrics) ?? defaults.metrics
-        self.enableProfiling = try container.decodeIfPresent(Bool.self, forKey: .enableProfiling) ?? defaults.enableProfiling
+    enum CodingKeys: CodingKey {
+        case network
+        case rpc
+        case dataLocation
+        case bind
+        case connect
+        case autoConnect
+        case logLevel
+        case metrics
+        case enableProfiling
+        case feeRate
     }
-}
 
-extension NodeConfig {
-    enum DataLocation: Codable {
-        case inMemory, defaultPath, custom(path: String)
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.network, forKey: .network)
+        try container.encode(self.rpc, forKey: .rpc)
+        try container.encode(self.dataLocation, forKey: .dataLocation)
+        try container.encodeIfPresent(self.bind, forKey: .bind)
+        try container.encode(self.connect.map(\.description), forKey: .connect)
+        try container.encode(self.autoConnect, forKey: .autoConnect)
+        try container.encode(self.logLevel, forKey: .logLevel)
+        try container.encodeIfPresent(self.metrics, forKey: .metrics)
+        try container.encode(self.enableProfiling, forKey: .enableProfiling)
+        try container.encode(self.feeRate, forKey: .feeRate)
     }
 }
 
 extension NodeConfig {
     enum Network: String, Codable {
         case mainnet, testnet, regtest
+
+        var defaultRPCPort: Int {
+            switch self {
+            case .mainnet: 8332
+            //case .testnet3: 18332
+            case .testnet: 48332
+            case .regtest: 18443
+            // case .signet: 38332
+            }
+        }
     }
 }
 
 extension NodeConfig {
-    enum LogLevel: String, Codable {
-        case trace, debug, info, notice, warning, error, critical
-    }
-}
-
-extension NodeConfig {
-
-    /// OpenTelemetry metrics settings.
-    struct OTelMetrics: Codable {
-        init(endpoint: String = "http://localhost:4317") {
-            self.endpoint = endpoint
+    struct RPCSettings: Codable {
+        init(host: String, port: Int) {
+            self.host = host
+            self.port = port
         }
 
-        /// The gRPC endpoint, e.g. `http://localhost:4317`.
-        let endpoint: String
+        let host: String
+        let port: Int
+    }
+}
+
+extension NodeConfig {
+    enum DataLocation: Encodable {
+        case inMemory, defaultPath, custom(path: String)
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .inMemory:
+                try container.encode("in-memory")
+            case .defaultPath:
+                try container.encode("default-path")
+            case let .custom(path: path):
+                try container.encode("custom(\(path))")
+            }
+        }
     }
 }
 
@@ -102,7 +133,8 @@ extension NodeConfig {
 
 extension NodeConfig {
 
-    struct RemotePeer: Codable {
+    struct RemotePeer: Codable, CustomStringConvertible {
+
         init(host: String, port: Int?) {
             self.host = host
             self.port = port
@@ -113,5 +145,28 @@ extension NodeConfig {
 
         /// IP port of the remote peer. If `nil` it will use the current network's default
         let port: Int?
+
+        var description: String {
+            "\(host):\(port?.description ?? "")"
+        }
+    }
+}
+
+extension NodeConfig {
+    enum LogLevel: String, Codable {
+        case trace, debug, info, notice, warning, error, critical
+    }
+}
+
+extension NodeConfig {
+
+    /// OpenTelemetry metrics settings.
+    struct OTelMetrics: Codable {
+        init(endpoint: String = "http://localhost:4317") {
+            self.endpoint = endpoint
+        }
+
+        /// The gRPC endpoint, e.g. `http://localhost:4317`.
+        let endpoint: String
     }
 }

--- a/src/bitcoin-node/config/SwiftSnapshot.swift
+++ b/src/bitcoin-node/config/SwiftSnapshot.swift
@@ -1,0 +1,127 @@
+import Configuration
+import Foundation
+
+struct SwiftSnapshot {
+    let jsonSnapshot: JSONSnapshot
+
+    enum SwiftSnapshotError: Error {
+        case maximumSizeExceeded(size: Int, max: Int), swiftConfigError, missingInternalResource, internalResourceUnavailable, swiftScriptFailure, decodingError
+    }
+}
+
+#if canImport(Foundation.NSTask)
+import class Foundation.NSTask.Process
+#endif
+
+extension SwiftSnapshot: FileConfigSnapshot {
+    public init(data: RawSpan, providerName: String, parsingOptions: JSONSnapshot.ParsingOptions) throws {
+
+#if !canImport(Foundation.NSTask)
+    fatalError("Foundation.NSTask.Process class not available")
+#endif
+
+    // Limit the file's size
+    let maxSize = 1024 * 1024 // 1MB
+    guard data.byteCount <= maxSize else {
+        throw SwiftSnapshotError.maximumSizeExceeded(size: Int(data.byteCount), max: maxSize)
+    }
+
+    // For Swift we need to put together a Swift source to pass via stdin to the interpreter…
+
+    // First we need the unmodified contents of the actual configuration file
+    guard let contentsAsString = String(data: Data(data), encoding: .utf8) else {
+        throw SwiftSnapshotError.swiftConfigError
+    }
+
+    // We'll also need a copy of the NodeConfig struct and dependencies. This resource is produced by the CopyConfigSources package plugin
+    guard let resource = Bundle.module.path(forResource: "NodeConfig", ofType: "swift.txt") else {
+        throw SwiftSnapshotError.missingInternalResource
+    }
+
+    let resourceContents = try Data(contentsOf: URL(filePath: resource))
+
+    // Can't use NIO here because this initializer is not async
+    // let resourceContents: Data
+    // do {
+    //     resourceContents =  Data(try await ByteBuffer(
+    //         contentsOf: FilePath(resource),
+    //         maximumSizeAllowed: .bytes(Int64(maxSize))
+    //     ).readableBytesView)
+    // } catch {
+    //     throw SwiftSnapshotError.internalResourceUnavailable
+    // }
+
+    let resourceText = String(data: resourceContents, encoding: .utf8)!
+
+    // We will now build the Swift source code to pass to the Swift interpreter
+    let configGenerationScript = """
+    import Foundation
+    \(resourceText)
+    let encoder = JSONEncoder()
+    \(contentsAsString)
+    let data = try encoder.encode(config)
+    print(String(data: data, encoding: .utf8)!)
+    """
+
+    // Create a process and pipes to pass the script to the interpreter
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["swift", "-"]
+    let pipeIn = Pipe()
+    process.standardInput = pipeIn
+    let pipeOut = Pipe()
+    process.standardOutput = pipeOut
+    process.standardError = pipeOut
+
+    // Set up the input pipe (stdin) to write the script
+    let fileHandle = pipeIn.fileHandleForWriting
+    fileHandle.write(configGenerationScript.data(using: .utf8)!)
+    fileHandle.closeFile()
+
+    // Run the process to obtain the configuration in JSON format
+    let output: Data
+    do {
+        try process.run()
+        // Read raw JSON data from the output pipe (stdout)
+        output = pipeOut.fileHandleForReading.readDataToEndOfFile()
+    } catch {
+        throw SwiftSnapshotError.swiftScriptFailure
+    }
+        jsonSnapshot = try .init(data: output.bytes, providerName: providerName, parsingOptions: parsingOptions)
+    }
+}
+
+extension SwiftSnapshot: ConfigSnapshot {
+    var providerName: String {
+        jsonSnapshot.providerName
+    }
+
+    public func value(forKey key: AbsoluteConfigKey, type: ConfigType) throws -> LookupResult {
+        try jsonSnapshot.value(forKey: key, type: type)
+    }
+}
+
+extension SwiftSnapshot: CustomStringConvertible {
+    public var description: String {
+        jsonSnapshot.description
+    }
+}
+
+extension SwiftSnapshot: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        jsonSnapshot.debugDescription
+    }
+}
+
+extension Data {
+    /// Creates data from a raw span.
+    /// - Parameter span: The raw span whose bytes to copy into a new Data.
+    internal init(_ span: RawSpan) {
+        self = span.withUnsafeBytes { pointer in
+            guard let base = pointer.baseAddress else {
+                return Data()
+            }
+            return Data(bytes: base, count: pointer.count)
+        }
+    }
+}

--- a/src/bitcoin-node/services/ServerApp.swift
+++ b/src/bitcoin-node/services/ServerApp.swift
@@ -61,10 +61,10 @@ import NIOPosix
 ///   - StatusRPC, ConnectRPC, StartP2PRPC for RPC command interfaces
 actor ServerApp {
 
-    init(_ config: NodeConfig, host: String, port: Int?) async throws {
+    init(_ config: NodeConfig) async throws {
         let network = NodeNetwork(config.network)
         let dataLocation = BlockchainService.Config.DataLocation(config.dataLocation)
-        let port = port ?? network.defaultRPCPort
+        let port = config.rpc.port // ?? network.defaultRPCPort
 
         var logger = Logger(label: "bcnode")
         logger.logLevel = .init(config.logLevel)
@@ -116,7 +116,7 @@ actor ServerApp {
 
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
-        rpcService = RPCService(host: host, port: port, eventLoopGroup: eventLoopGroup, node: node, blockchain: blockchain, logger: logger)
+        rpcService = RPCService(host: config.rpc.host, port: port, eventLoopGroup: eventLoopGroup, node: node, blockchain: blockchain, logger: logger)
 
         var services: [ServiceGroupConfiguration.ServiceConfiguration] = []
 

--- a/src/bitcoin-transport/support/IPv6Address.swift
+++ b/src/bitcoin-transport/support/IPv6Address.swift
@@ -129,7 +129,7 @@ public struct IPv6Address: Equatable, Sendable, CustomStringConvertible, CustomD
 
 extension IPv6Address {
     public static func parse(_ address: String) -> (host: String, port: Int?)? {
-        let regex = /\[([\d\:A-Fa-f]+)\](\:(\d{1,5}))?/
+        let regex = /(\[[\d\:A-Fa-f]+\])(\:(\d{1,5}))?/
         guard let _ = address.wholeMatch(of: regex) else {
             return nil
         }


### PR DESCRIPTION
Shared options for related commands start and check-config Command line options override
Environment variables override
Swift-format custom file snapshot for file configuration provider Swift and JSON configuration (with JSON taking priority) Configuration validation and default value resolution Keep old manual configuration logic as disabled commands as we evaluate the new solution which does not yet support JSON5 RPC host/port now part of the unified configuration set Round trip serialization of NodeConfig with Swift Configuration-compatible JSON generation
