### PR TITLE
Temporarily conditioning use of span on C interop wrappers until 6.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ab1abedd58c6b1c4123f903d91cb1127b5900c5fa6e44a9e54bc8ffae5d373af",
+  "originHash" : "56661df12352699859659460a561646df6cf06804038c3aaa00af19687749767",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
-        "version" : "1.13.1"
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2.4
+// swift-tools-version: 6.3.2
 import PackageDescription
 
 let package = Package(

--- a/src/bitcoin-crypto/ecc/ECDSASignature.swift
+++ b/src/bitcoin-crypto/ecc/ECDSASignature.swift
@@ -323,10 +323,17 @@ private func verifyECDSA(sigData: Data, hash: Data, pubkey: PublicKey) -> Bool {
 
     var sig = secp256k1_ecdsa_signature()
 
-
+// Swift Static Linux SDK crashes with `sigData.span`. See #552
+#if canImport(Musl)
+    let sigBytes = [UInt8](sigData)
+    guard ECCHelper.ecdsa_signature_parse_der_lax(&sig, sigBytes, sigBytes.count) != 0 else {
+        preconditionFailure()
+    }
+#else
     guard unsafe ecdsa_signature_parse_der_lax(&sig, sigData.span) != 0 else {
         preconditionFailure()
     }
+#endif
 
     var sigNormalized = secp256k1_ecdsa_signature()
     secp256k1_ecdsa_signature_normalize(secp256k1_context_static, &sigNormalized, &sig)
@@ -364,9 +371,17 @@ private func internalIsLowS(compactSignatureData: Data) -> Bool {
 private func internalIsLowS(laxSignatureData: Data) -> Bool {
     var sig = secp256k1_ecdsa_signature()
 
+#if canImport(Musl)
+    let sigBytes = [UInt8](laxSignatureData)
+    guard ecdsa_signature_parse_der_lax(&sig, sigBytes, sigBytes.count) != 0 else {
+        preconditionFailure()
+    }
+#else
     guard unsafe ecdsa_signature_parse_der_lax(&sig, laxSignatureData.span) != 0 else {
         preconditionFailure()
     }
+#endif
+
     let normalizationOccurred = secp256k1_ecdsa_signature_normalize(secp256k1_context_static, nil, &sig)
     return normalizationOccurred == 0
 }


### PR DESCRIPTION
Temporarily conditioning use of span on C interop wrappers until 6.4 which fixes crash.
